### PR TITLE
feat: optimize routing and add google distance provider

### DIFF
--- a/internal/database/paths.go
+++ b/internal/database/paths.go
@@ -49,7 +49,8 @@ func GetConfigFilePath() (string, error) {
 
 // AppConfig stores application configuration
 type AppConfig struct {
-	DatabasePath string `json:"database_path"`
+	DatabasePath     string `json:"database_path"`
+	GoogleMapsAPIKey string `json:"google_maps_api_key,omitempty"`
 }
 
 // LoadConfig loads the application config, returning defaults if not found
@@ -107,6 +108,6 @@ func SaveConfig(config *AppConfig) error {
 		return fmt.Errorf("failed to rename config file: %w", err)
 	}
 
-	log.Printf("Config saved: database_path=%s", config.DatabasePath)
+	log.Printf("Config saved: database_path=%s google_maps_api_key_configured=%t", config.DatabasePath, config.GoogleMapsAPIKey != "")
 	return nil
 }

--- a/internal/database/paths_test.go
+++ b/internal/database/paths_test.go
@@ -1,0 +1,46 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAppConfig_PreservesGoogleMapsAPIKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	config := &AppConfig{
+		DatabasePath:     filepath.Join(home, "custom.db"),
+		GoogleMapsAPIKey: "test-key",
+	}
+	if err := SaveConfig(config); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if loaded.DatabasePath != config.DatabasePath {
+		t.Fatalf("DatabasePath = %q, want %q", loaded.DatabasePath, config.DatabasePath)
+	}
+	if loaded.GoogleMapsAPIKey != config.GoogleMapsAPIKey {
+		t.Fatalf("GoogleMapsAPIKey = %q, want preserved key", loaded.GoogleMapsAPIKey)
+	}
+}
+
+func TestAppConfig_DefaultKeepsGoogleMapsAPIKeyEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if loaded.GoogleMapsAPIKey != "" {
+		t.Fatalf("GoogleMapsAPIKey = %q, want empty", loaded.GoogleMapsAPIKey)
+	}
+	if loaded.DatabasePath != filepath.Join(home, AppDirName, SQLiteDBFileName) {
+		t.Fatalf("DatabasePath = %q, want default under temp HOME", loaded.DatabasePath)
+	}
+}

--- a/internal/distance/google.go
+++ b/internal/distance/google.go
@@ -1,0 +1,424 @@
+package distance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"ride-home-router/internal/database"
+	"ride-home-router/internal/models"
+)
+
+const (
+	googleRouteMatrixURL         = "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix"
+	googleRouteMatrixFieldMask   = "originIndex,destinationIndex,status,condition,distanceMeters,duration"
+	googleRouteMatrixMaxElements = 625
+	googleHTTPTimeout            = 60 * time.Second
+)
+
+var ErrProviderNotConfigured = errors.New("distance provider is not configured")
+
+type APIKeyProvider func() (string, error)
+
+type googleCalculator struct {
+	httpClient *http.Client
+	cache      database.DistanceCacheRepository
+	apiKey     APIKeyProvider
+	endpoint   string
+}
+
+func NewGoogleCalculator(cache database.DistanceCacheRepository, apiKey APIKeyProvider) DistanceCalculator {
+	return &googleCalculator{
+		httpClient: &http.Client{Timeout: googleHTTPTimeout},
+		cache:      cache,
+		apiKey:     apiKey,
+		endpoint:   googleRouteMatrixURL,
+	}
+}
+
+func (c *googleCalculator) GetDistance(ctx context.Context, origin, dest models.Coordinates) (*DistanceResult, error) {
+	if sameRoundedPoint(origin, dest) {
+		return &DistanceResult{DistanceMeters: 0, DurationSecs: 0}, nil
+	}
+
+	cached, err := c.cache.Get(ctx, origin, dest)
+	if err != nil {
+		return nil, err
+	}
+	if cached != nil {
+		return &DistanceResult{
+			DistanceMeters: cached.DistanceMeters,
+			DurationSecs:   cached.DurationSecs,
+		}, nil
+	}
+
+	results, err := c.GetDistancesFromPoint(ctx, origin, []models.Coordinates{dest})
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, &ErrDistanceCalculationFailed{Origin: origin, Dest: dest, Reason: "no results returned"}
+	}
+	return &results[0], nil
+}
+
+func (c *googleCalculator) GetDistanceMatrix(ctx context.Context, points []models.Coordinates) ([][]DistanceResult, error) {
+	n := len(points)
+	if n == 0 {
+		return [][]DistanceResult{}, nil
+	}
+
+	matrix := make([][]DistanceResult, n)
+	for i := range matrix {
+		matrix[i] = make([]DistanceResult, n)
+	}
+
+	for originIndex, origin := range points {
+		var missingDestinations []models.Coordinates
+		var missingIndexes []int
+		for destIndex, dest := range points {
+			if originIndex == destIndex || sameRoundedPoint(origin, dest) {
+				continue
+			}
+
+			cached, err := c.cache.Get(ctx, origin, dest)
+			if err != nil {
+				return nil, err
+			}
+			if cached != nil {
+				matrix[originIndex][destIndex] = DistanceResult{
+					DistanceMeters: cached.DistanceMeters,
+					DurationSecs:   cached.DurationSecs,
+				}
+				continue
+			}
+
+			missingDestinations = append(missingDestinations, dest)
+			missingIndexes = append(missingIndexes, destIndex)
+		}
+
+		for start := 0; start < len(missingDestinations); start += googleRouteMatrixMaxElements {
+			end := min(start+googleRouteMatrixMaxElements, len(missingDestinations))
+			chunkDestinations := missingDestinations[start:end]
+			chunkIndexes := missingIndexes[start:end]
+
+			results, err := c.fetchMatrix(ctx, []models.Coordinates{origin}, chunkDestinations)
+			if err != nil {
+				return nil, err
+			}
+
+			cacheEntries := make([]models.DistanceCacheEntry, 0, len(chunkDestinations))
+			for localDestIndex, destIndex := range chunkIndexes {
+				result, ok := results[matrixIndex{origin: 0, destination: localDestIndex}]
+				if !ok {
+					return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response missing element"}
+				}
+				matrix[originIndex][destIndex] = result
+				cacheEntries = append(cacheEntries, models.DistanceCacheEntry{
+					Origin:         origin,
+					Destination:    points[destIndex],
+					DistanceMeters: result.DistanceMeters,
+					DurationSecs:   result.DurationSecs,
+				})
+			}
+			if err := c.cache.SetBatch(ctx, cacheEntries); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return matrix, nil
+}
+
+func (c *googleCalculator) GetDistancesFromPoint(ctx context.Context, origin models.Coordinates, destinations []models.Coordinates) ([]DistanceResult, error) {
+	if len(destinations) == 0 {
+		return []DistanceResult{}, nil
+	}
+
+	results := make([]DistanceResult, len(destinations))
+	var missingDestinations []models.Coordinates
+	var missingIndexes []int
+	for i, dest := range destinations {
+		if sameRoundedPoint(origin, dest) {
+			continue
+		}
+
+		cached, err := c.cache.Get(ctx, origin, dest)
+		if err != nil {
+			return nil, err
+		}
+		if cached != nil {
+			results[i] = DistanceResult{
+				DistanceMeters: cached.DistanceMeters,
+				DurationSecs:   cached.DurationSecs,
+			}
+			continue
+		}
+		missingDestinations = append(missingDestinations, dest)
+		missingIndexes = append(missingIndexes, i)
+	}
+
+	for start := 0; start < len(missingDestinations); start += googleRouteMatrixMaxElements {
+		end := min(start+googleRouteMatrixMaxElements, len(missingDestinations))
+		chunkDestinations := missingDestinations[start:end]
+		chunkIndexes := missingIndexes[start:end]
+
+		matrixResults, err := c.fetchMatrix(ctx, []models.Coordinates{origin}, chunkDestinations)
+		if err != nil {
+			return nil, err
+		}
+
+		cacheEntries := make([]models.DistanceCacheEntry, 0, len(chunkDestinations))
+		for localDestIndex, resultIndex := range chunkIndexes {
+			result, ok := matrixResults[matrixIndex{origin: 0, destination: localDestIndex}]
+			if !ok {
+				return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response missing element"}
+			}
+			results[resultIndex] = result
+			cacheEntries = append(cacheEntries, models.DistanceCacheEntry{
+				Origin:         origin,
+				Destination:    destinations[resultIndex],
+				DistanceMeters: result.DistanceMeters,
+				DurationSecs:   result.DurationSecs,
+			})
+		}
+		if err := c.cache.SetBatch(ctx, cacheEntries); err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+func (c *googleCalculator) PrewarmCache(ctx context.Context, points []models.Coordinates) error {
+	_, err := c.GetDistanceMatrix(ctx, points)
+	return err
+}
+
+type matrixIndex struct {
+	origin      int
+	destination int
+}
+
+func (c *googleCalculator) fetchMatrix(ctx context.Context, origins, destinations []models.Coordinates) (map[matrixIndex]DistanceResult, error) {
+	if len(origins) == 0 || len(destinations) == 0 {
+		return map[matrixIndex]DistanceResult{}, nil
+	}
+	if len(origins)*len(destinations) > googleRouteMatrixMaxElements {
+		return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix batch exceeds 625 elements"}
+	}
+
+	apiKey, err := c.currentAPIKey()
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(googleMatrixRequest{
+		Origins:           makeGoogleOrigins(origins),
+		Destinations:      makeGoogleDestinations(destinations),
+		TravelMode:        "DRIVE",
+		RoutingPreference: "TRAFFIC_UNAWARE",
+	})
+	if err != nil {
+		return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Goog-Api-Key", apiKey)
+	req.Header.Set("X-Goog-FieldMask", googleRouteMatrixFieldMask)
+
+	log.Printf("[GOOGLE] Route matrix request: origins=%d destinations=%d elements=%d", len(origins), len(destinations), len(origins)*len(destinations))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, &ErrDistanceCalculationFailed{Reason: fmt.Sprintf("Google route matrix HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))}
+	}
+
+	elements, err := parseGoogleMatrixElements(responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[matrixIndex]DistanceResult, len(elements))
+	for _, element := range elements {
+		if element.OriginIndex < 0 || element.OriginIndex >= len(origins) || element.DestinationIndex < 0 || element.DestinationIndex >= len(destinations) {
+			return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response contained out-of-range index"}
+		}
+		if element.Status.Code != 0 {
+			reason := element.Status.Message
+			if reason == "" {
+				reason = fmt.Sprintf("Google route matrix element status code %d", element.Status.Code)
+			}
+			return nil, &ErrDistanceCalculationFailed{Reason: reason}
+		}
+		if element.Condition != "" && element.Condition != "ROUTE_EXISTS" {
+			return nil, &ErrDistanceCalculationFailed{Reason: fmt.Sprintf("Google route matrix element condition: %s", element.Condition)}
+		}
+
+		durationSecs, err := parseGoogleDurationSeconds(element.Duration)
+		if err != nil {
+			return nil, err
+		}
+		results[matrixIndex{origin: element.OriginIndex, destination: element.DestinationIndex}] = DistanceResult{
+			DistanceMeters: float64(element.DistanceMeters),
+			DurationSecs:   durationSecs,
+		}
+	}
+
+	return results, nil
+}
+
+func (c *googleCalculator) currentAPIKey() (string, error) {
+	if c.apiKey == nil {
+		return "", fmt.Errorf("%w: Google Maps API key is missing", ErrProviderNotConfigured)
+	}
+	apiKey, err := c.apiKey()
+	if err != nil {
+		return "", err
+	}
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", fmt.Errorf("%w: Google Maps API key is missing. Add it in Settings.", ErrProviderNotConfigured)
+	}
+	return apiKey, nil
+}
+
+func sameRoundedPoint(a, b models.Coordinates) bool {
+	return models.RoundCoordinate(a.Lat) == models.RoundCoordinate(b.Lat) &&
+		models.RoundCoordinate(a.Lng) == models.RoundCoordinate(b.Lng)
+}
+
+type googleMatrixRequest struct {
+	Origins           []googleRouteMatrixOrigin      `json:"origins"`
+	Destinations      []googleRouteMatrixDestination `json:"destinations"`
+	TravelMode        string                         `json:"travelMode"`
+	RoutingPreference string                         `json:"routingPreference"`
+}
+
+type googleRouteMatrixOrigin struct {
+	Waypoint googleWaypoint `json:"waypoint"`
+}
+
+type googleRouteMatrixDestination struct {
+	Waypoint googleWaypoint `json:"waypoint"`
+}
+
+type googleWaypoint struct {
+	Location googleLocation `json:"location"`
+}
+
+type googleLocation struct {
+	LatLng googleLatLng `json:"latLng"`
+}
+
+type googleLatLng struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+func makeGoogleOrigins(points []models.Coordinates) []googleRouteMatrixOrigin {
+	origins := make([]googleRouteMatrixOrigin, len(points))
+	for i, point := range points {
+		origins[i] = googleRouteMatrixOrigin{Waypoint: makeGoogleWaypoint(point)}
+	}
+	return origins
+}
+
+func makeGoogleDestinations(points []models.Coordinates) []googleRouteMatrixDestination {
+	destinations := make([]googleRouteMatrixDestination, len(points))
+	for i, point := range points {
+		destinations[i] = googleRouteMatrixDestination{Waypoint: makeGoogleWaypoint(point)}
+	}
+	return destinations
+}
+
+func makeGoogleWaypoint(point models.Coordinates) googleWaypoint {
+	return googleWaypoint{
+		Location: googleLocation{
+			LatLng: googleLatLng{
+				Latitude:  point.Lat,
+				Longitude: point.Lng,
+			},
+		},
+	}
+}
+
+type googleMatrixElement struct {
+	OriginIndex      int          `json:"originIndex"`
+	DestinationIndex int          `json:"destinationIndex"`
+	Status           googleStatus `json:"status"`
+	Condition        string       `json:"condition"`
+	DistanceMeters   int64        `json:"distanceMeters"`
+	Duration         string       `json:"duration"`
+}
+
+type googleStatus struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func parseGoogleMatrixElements(body []byte) ([]googleMatrixElement, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response was empty"}
+	}
+
+	if trimmed[0] == '[' {
+		var elements []googleMatrixElement
+		if err := json.Unmarshal(trimmed, &elements); err != nil {
+			return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+		}
+		return elements, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	var elements []googleMatrixElement
+	for {
+		var element googleMatrixElement
+		if err := decoder.Decode(&element); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+		}
+		elements = append(elements, element)
+	}
+	return elements, nil
+}
+
+func parseGoogleDurationSeconds(value string) (float64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, &ErrDistanceCalculationFailed{Reason: "Google route matrix response missing duration"}
+	}
+	if !strings.HasSuffix(value, "s") {
+		return 0, &ErrDistanceCalculationFailed{Reason: fmt.Sprintf("invalid Google duration %q", value)}
+	}
+	seconds, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, &ErrDistanceCalculationFailed{Reason: err.Error()}
+	}
+	return math.Round(seconds.Seconds()*1000) / 1000, nil
+}

--- a/internal/distance/google.go
+++ b/internal/distance/google.go
@@ -1,6 +1,7 @@
 package distance
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -48,6 +49,9 @@ func (c *googleCalculator) GetDistance(ctx context.Context, origin, dest models.
 	if sameRoundedPoint(origin, dest) {
 		return &DistanceResult{DistanceMeters: 0, DurationSecs: 0}, nil
 	}
+	if _, err := c.currentAPIKey(); err != nil {
+		return nil, err
+	}
 
 	cached, err := c.cache.Get(ctx, origin, dest)
 	if err != nil {
@@ -74,6 +78,11 @@ func (c *googleCalculator) GetDistanceMatrix(ctx context.Context, points []model
 	n := len(points)
 	if n == 0 {
 		return [][]DistanceResult{}, nil
+	}
+	if matrixNeedsProvider(points) {
+		if _, err := c.currentAPIKey(); err != nil {
+			return nil, err
+		}
 	}
 
 	matrix := make([][]DistanceResult, n)
@@ -141,6 +150,11 @@ func (c *googleCalculator) GetDistanceMatrix(ctx context.Context, points []model
 func (c *googleCalculator) GetDistancesFromPoint(ctx context.Context, origin models.Coordinates, destinations []models.Coordinates) ([]DistanceResult, error) {
 	if len(destinations) == 0 {
 		return []DistanceResult{}, nil
+	}
+	if destinationsNeedProvider(origin, destinations) {
+		if _, err := c.currentAPIKey(); err != nil {
+			return nil, err
+		}
 	}
 
 	results := make([]DistanceResult, len(destinations))
@@ -248,15 +262,15 @@ func (c *googleCalculator) fetchMatrix(ctx context.Context, origins, destination
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
-	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		responseBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
+		}
 		return nil, &ErrDistanceCalculationFailed{Reason: fmt.Sprintf("Google route matrix HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))}
 	}
 
-	elements, err := parseGoogleMatrixElements(responseBody)
+	elements, err := parseGoogleMatrixElements(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -308,6 +322,26 @@ func (c *googleCalculator) currentAPIKey() (string, error) {
 func sameRoundedPoint(a, b models.Coordinates) bool {
 	return models.RoundCoordinate(a.Lat) == models.RoundCoordinate(b.Lat) &&
 		models.RoundCoordinate(a.Lng) == models.RoundCoordinate(b.Lng)
+}
+
+func matrixNeedsProvider(points []models.Coordinates) bool {
+	for i, origin := range points {
+		for j, dest := range points {
+			if i != j && !sameRoundedPoint(origin, dest) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func destinationsNeedProvider(origin models.Coordinates, destinations []models.Coordinates) bool {
+	for _, dest := range destinations {
+		if !sameRoundedPoint(origin, dest) {
+			return true
+		}
+	}
+	return false
 }
 
 type googleMatrixRequest struct {
@@ -379,21 +413,25 @@ type googleStatus struct {
 	Message string `json:"message"`
 }
 
-func parseGoogleMatrixElements(body []byte) ([]googleMatrixElement, error) {
-	trimmed := bytes.TrimSpace(body)
-	if len(trimmed) == 0 {
-		return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response was empty"}
+func parseGoogleMatrixElements(body io.Reader) ([]googleMatrixElement, error) {
+	reader := bufio.NewReader(body)
+	first, err := peekFirstNonSpace(reader)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response was empty"}
+		}
+		return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
 	}
 
-	if trimmed[0] == '[' {
+	decoder := json.NewDecoder(reader)
+	if first == '[' {
 		var elements []googleMatrixElement
-		if err := json.Unmarshal(trimmed, &elements); err != nil {
+		if err := decoder.Decode(&elements); err != nil {
 			return nil, &ErrDistanceCalculationFailed{Reason: err.Error()}
 		}
 		return elements, nil
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(trimmed))
 	var elements []googleMatrixElement
 	for {
 		var element googleMatrixElement
@@ -406,6 +444,22 @@ func parseGoogleMatrixElements(body []byte) ([]googleMatrixElement, error) {
 		elements = append(elements, element)
 	}
 	return elements, nil
+}
+
+func peekFirstNonSpace(reader *bufio.Reader) (byte, error) {
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		if b == ' ' || b == '\n' || b == '\r' || b == '\t' {
+			continue
+		}
+		if err := reader.UnreadByte(); err != nil {
+			return 0, err
+		}
+		return b, nil
+	}
 }
 
 func parseGoogleDurationSeconds(value string) (float64, error) {

--- a/internal/distance/google.go
+++ b/internal/distance/google.go
@@ -90,58 +90,58 @@ func (c *googleCalculator) GetDistanceMatrix(ctx context.Context, points []model
 		matrix[i] = make([]DistanceResult, n)
 	}
 
-	for originIndex, origin := range points {
-		var missingDestinations []models.Coordinates
-		var missingIndexes []int
-		for destIndex, dest := range points {
-			if originIndex == destIndex || sameRoundedPoint(origin, dest) {
+	missingPairs, err := c.hydrateMatrixFromCache(ctx, points, matrix)
+	if err != nil {
+		return nil, err
+	}
+	if len(missingPairs) == 0 {
+		return matrix, nil
+	}
+
+	var cacheEntries []models.DistanceCacheEntry
+	for destStart := 0; destStart < n; {
+		destEnd := min(destStart+googleRouteMatrixMaxElements, n)
+		destCount := destEnd - destStart
+		maxOrigins := max(1, googleRouteMatrixMaxElements/destCount)
+
+		for originStart := 0; originStart < n; originStart += maxOrigins {
+			originEnd := min(originStart+maxOrigins, n)
+			sourceIndexes, destIndexes := collectGoogleMatrixBlock(originStart, originEnd, destStart, destEnd, missingPairs)
+			if len(sourceIndexes) == 0 || len(destIndexes) == 0 {
 				continue
 			}
 
-			cached, err := c.cache.Get(ctx, origin, dest)
-			if err != nil {
-				return nil, err
-			}
-			if cached != nil {
-				matrix[originIndex][destIndex] = DistanceResult{
-					DistanceMeters: cached.DistanceMeters,
-					DurationSecs:   cached.DurationSecs,
-				}
-				continue
-			}
-
-			missingDestinations = append(missingDestinations, dest)
-			missingIndexes = append(missingIndexes, destIndex)
-		}
-
-		for start := 0; start < len(missingDestinations); start += googleRouteMatrixMaxElements {
-			end := min(start+googleRouteMatrixMaxElements, len(missingDestinations))
-			chunkDestinations := missingDestinations[start:end]
-			chunkIndexes := missingIndexes[start:end]
-
-			results, err := c.fetchMatrix(ctx, []models.Coordinates{origin}, chunkDestinations)
+			results, err := c.fetchMatrix(ctx, coordinatesForIndexes(points, sourceIndexes), coordinatesForIndexes(points, destIndexes))
 			if err != nil {
 				return nil, err
 			}
 
-			cacheEntries := make([]models.DistanceCacheEntry, 0, len(chunkDestinations))
-			for localDestIndex, destIndex := range chunkIndexes {
-				result, ok := results[matrixIndex{origin: 0, destination: localDestIndex}]
-				if !ok {
-					return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response missing element"}
+			for localSourceIndex, sourceIndex := range sourceIndexes {
+				for localDestIndex, destIndex := range destIndexes {
+					pair := matrixIndex{origin: sourceIndex, destination: destIndex}
+					if _, ok := missingPairs[pair]; !ok {
+						continue
+					}
+
+					result, ok := results[matrixIndex{origin: localSourceIndex, destination: localDestIndex}]
+					if !ok {
+						return nil, &ErrDistanceCalculationFailed{Reason: "Google route matrix response missing element"}
+					}
+					matrix[sourceIndex][destIndex] = result
+					cacheEntries = append(cacheEntries, models.DistanceCacheEntry{
+						Origin:         points[sourceIndex],
+						Destination:    points[destIndex],
+						DistanceMeters: result.DistanceMeters,
+						DurationSecs:   result.DurationSecs,
+					})
 				}
-				matrix[originIndex][destIndex] = result
-				cacheEntries = append(cacheEntries, models.DistanceCacheEntry{
-					Origin:         origin,
-					Destination:    points[destIndex],
-					DistanceMeters: result.DistanceMeters,
-					DurationSecs:   result.DurationSecs,
-				})
-			}
-			if err := c.cache.SetBatch(ctx, cacheEntries); err != nil {
-				return nil, err
 			}
 		}
+		destStart = destEnd
+	}
+
+	if err := c.cache.SetBatch(ctx, cacheEntries); err != nil {
+		return nil, err
 	}
 
 	return matrix, nil
@@ -220,6 +220,82 @@ func (c *googleCalculator) PrewarmCache(ctx context.Context, points []models.Coo
 type matrixIndex struct {
 	origin      int
 	destination int
+}
+
+func (c *googleCalculator) hydrateMatrixFromCache(ctx context.Context, points []models.Coordinates, matrix [][]DistanceResult) (map[matrixIndex]struct{}, error) {
+	var cachePairs []struct{ Origin, Dest models.Coordinates }
+	var indexes []matrixIndex
+	for originIndex, origin := range points {
+		for destIndex, dest := range points {
+			if originIndex == destIndex || sameRoundedPoint(origin, dest) {
+				continue
+			}
+			cachePairs = append(cachePairs, struct{ Origin, Dest models.Coordinates }{Origin: origin, Dest: dest})
+			indexes = append(indexes, matrixIndex{origin: originIndex, destination: destIndex})
+		}
+	}
+
+	cached, err := c.cache.GetBatch(ctx, cachePairs)
+	if err != nil {
+		return nil, err
+	}
+
+	missing := make(map[matrixIndex]struct{})
+	for i, pair := range cachePairs {
+		index := indexes[i]
+		entry := cached[googleCacheKey(pair.Origin, pair.Dest)]
+		if entry == nil {
+			missing[index] = struct{}{}
+			continue
+		}
+		matrix[index.origin][index.destination] = DistanceResult{
+			DistanceMeters: entry.DistanceMeters,
+			DurationSecs:   entry.DurationSecs,
+		}
+	}
+	return missing, nil
+}
+
+func collectGoogleMatrixBlock(originStart, originEnd, destStart, destEnd int, missingPairs map[matrixIndex]struct{}) ([]int, []int) {
+	sourceSeen := make(map[int]struct{}, originEnd-originStart)
+	destSeen := make(map[int]struct{}, destEnd-destStart)
+	var sourceIndexes []int
+	var destIndexes []int
+
+	for originIndex := originStart; originIndex < originEnd; originIndex++ {
+		for destIndex := destStart; destIndex < destEnd; destIndex++ {
+			if _, ok := missingPairs[matrixIndex{origin: originIndex, destination: destIndex}]; !ok {
+				continue
+			}
+			if _, ok := sourceSeen[originIndex]; !ok {
+				sourceSeen[originIndex] = struct{}{}
+				sourceIndexes = append(sourceIndexes, originIndex)
+			}
+			if _, ok := destSeen[destIndex]; !ok {
+				destSeen[destIndex] = struct{}{}
+				destIndexes = append(destIndexes, destIndex)
+			}
+		}
+	}
+
+	return sourceIndexes, destIndexes
+}
+
+func coordinatesForIndexes(points []models.Coordinates, indexes []int) []models.Coordinates {
+	coordinates := make([]models.Coordinates, len(indexes))
+	for i, index := range indexes {
+		coordinates[i] = points[index]
+	}
+	return coordinates
+}
+
+func googleCacheKey(origin, dest models.Coordinates) string {
+	return fmt.Sprintf("%.5f,%.5f->%.5f,%.5f",
+		models.RoundCoordinate(origin.Lat),
+		models.RoundCoordinate(origin.Lng),
+		models.RoundCoordinate(dest.Lat),
+		models.RoundCoordinate(dest.Lng),
+	)
 }
 
 func (c *googleCalculator) fetchMatrix(ctx context.Context, origins, destinations []models.Coordinates) (map[matrixIndex]DistanceResult, error) {

--- a/internal/distance/google_test.go
+++ b/internal/distance/google_test.go
@@ -109,6 +109,37 @@ func TestGoogleCalculator_BatchesDestinationsUnderElementLimit(t *testing.T) {
 	}
 }
 
+func TestGoogleCalculator_GetDistanceMatrixBatchesOriginDestinationBlocks(t *testing.T) {
+	requests := 0
+	calc, _ := newTestGoogleCalculator(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var captured googleMatrixRequest
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		elements := len(captured.Origins) * len(captured.Destinations)
+		if elements > googleRouteMatrixMaxElements {
+			t.Fatalf("request elements = %d, exceeds %d", elements, googleRouteMatrixMaxElements)
+		}
+		for originIndex := range captured.Origins {
+			for destIndex := range captured.Destinations {
+				w.Write([]byte(`{"originIndex":` + strconv.Itoa(originIndex) + `,"destinationIndex":` + strconv.Itoa(destIndex) + `,"status":{},"condition":"ROUTE_EXISTS","distanceMeters":100,"duration":"10s"}` + "\n"))
+			}
+		}
+	})
+
+	points := make([]models.Coordinates, 30)
+	for i := range points {
+		points[i] = models.Coordinates{Lat: 35 + float64(i)*0.001, Lng: -79}
+	}
+	if _, err := calc.GetDistanceMatrix(context.Background(), points); err != nil {
+		t.Fatalf("GetDistanceMatrix() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2 matrix block requests", requests)
+	}
+}
+
 func TestGoogleCalculator_ReturnsElementFailure(t *testing.T) {
 	calc, _ := newTestGoogleCalculator(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"originIndex":0,"destinationIndex":0,"status":{"code":5,"message":"route not found"},"condition":"ROUTE_NOT_FOUND"}` + "\n"))

--- a/internal/distance/google_test.go
+++ b/internal/distance/google_test.go
@@ -1,0 +1,141 @@
+package distance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"ride-home-router/internal/models"
+	"ride-home-router/internal/sqlite"
+)
+
+func newTestGoogleCalculator(t *testing.T, handler http.HandlerFunc) (*googleCalculator, *sqlite.Store) {
+	t.Helper()
+
+	store, err := sqlite.New(filepath.Join(t.TempDir(), "google-distance-test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		server.Close()
+		if err := store.Close(); err != nil {
+			t.Fatalf("close sqlite store: %v", err)
+		}
+	})
+
+	calc := NewGoogleCalculator(store.DistanceCache(), func() (string, error) {
+		return "test-api-key", nil
+	}).(*googleCalculator)
+	calc.endpoint = server.URL
+	return calc, store
+}
+
+func TestGoogleCalculator_GetDistancesFromPointSendsRequiredHeadersAndParsesStream(t *testing.T) {
+	var captured googleMatrixRequest
+	calc, _ := newTestGoogleCalculator(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("X-Goog-Api-Key"); got != "test-api-key" {
+			t.Fatalf("X-Goog-Api-Key = %q", got)
+		}
+		if got := r.Header.Get("X-Goog-FieldMask"); got != googleRouteMatrixFieldMask {
+			t.Fatalf("X-Goog-FieldMask = %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"originIndex":0,"destinationIndex":0,"status":{},"condition":"ROUTE_EXISTS","distanceMeters":1200,"duration":"300s"}` + "\n"))
+		w.Write([]byte(`{"originIndex":0,"destinationIndex":1,"status":{},"condition":"ROUTE_EXISTS","distanceMeters":2400,"duration":"600.5s"}` + "\n"))
+	})
+
+	results, err := calc.GetDistancesFromPoint(context.Background(), models.Coordinates{Lat: 35, Lng: -79}, []models.Coordinates{
+		{Lat: 35.1, Lng: -79.1},
+		{Lat: 35.2, Lng: -79.2},
+	})
+	if err != nil {
+		t.Fatalf("GetDistancesFromPoint() error = %v", err)
+	}
+	if len(captured.Origins) != 1 || len(captured.Destinations) != 2 {
+		t.Fatalf("origins/destinations = %d/%d, want 1/2", len(captured.Origins), len(captured.Destinations))
+	}
+	if captured.TravelMode != "DRIVE" {
+		t.Fatalf("TravelMode = %q, want DRIVE", captured.TravelMode)
+	}
+	if captured.RoutingPreference != "TRAFFIC_UNAWARE" {
+		t.Fatalf("RoutingPreference = %q, want TRAFFIC_UNAWARE", captured.RoutingPreference)
+	}
+	if results[0].DistanceMeters != 1200 || results[0].DurationSecs != 300 {
+		t.Fatalf("result[0] = %+v, want 1200m/300s", results[0])
+	}
+	if results[1].DistanceMeters != 2400 || results[1].DurationSecs != 600.5 {
+		t.Fatalf("result[1] = %+v, want 2400m/600.5s", results[1])
+	}
+}
+
+func TestGoogleCalculator_BatchesDestinationsUnderElementLimit(t *testing.T) {
+	requests := 0
+	calc, _ := newTestGoogleCalculator(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var captured googleMatrixRequest
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(captured.Origins)*len(captured.Destinations) > googleRouteMatrixMaxElements {
+			t.Fatalf("request elements = %d, exceeds %d", len(captured.Origins)*len(captured.Destinations), googleRouteMatrixMaxElements)
+		}
+		for i := range captured.Destinations {
+			w.Write([]byte(`{"originIndex":0,"destinationIndex":` + intToString(i) + `,"status":{},"condition":"ROUTE_EXISTS","distanceMeters":100,"duration":"10s"}` + "\n"))
+		}
+	})
+
+	destinations := make([]models.Coordinates, 700)
+	for i := range destinations {
+		destinations[i] = models.Coordinates{Lat: 36 + float64(i)*0.001, Lng: -79}
+	}
+	if _, err := calc.GetDistancesFromPoint(context.Background(), models.Coordinates{Lat: 35, Lng: -79}, destinations); err != nil {
+		t.Fatalf("GetDistancesFromPoint() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestGoogleCalculator_ReturnsElementFailure(t *testing.T) {
+	calc, _ := newTestGoogleCalculator(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"originIndex":0,"destinationIndex":0,"status":{"code":5,"message":"route not found"},"condition":"ROUTE_NOT_FOUND"}` + "\n"))
+	})
+
+	_, err := calc.GetDistancesFromPoint(context.Background(), models.Coordinates{Lat: 35, Lng: -79}, []models.Coordinates{{Lat: 36, Lng: -79}})
+	if err == nil || !strings.Contains(err.Error(), "route not found") {
+		t.Fatalf("error = %v, want route not found", err)
+	}
+}
+
+func TestGoogleCalculator_MissingAPIKeyReturnsTypedError(t *testing.T) {
+	store, err := sqlite.New(filepath.Join(t.TempDir(), "missing-key-test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	calc := NewGoogleCalculator(store.DistanceCache(), func() (string, error) {
+		return "", nil
+	})
+	_, err = calc.GetDistancesFromPoint(context.Background(), models.Coordinates{Lat: 35, Lng: -79}, []models.Coordinates{{Lat: 36, Lng: -79}})
+	if !errors.Is(err, ErrProviderNotConfigured) {
+		t.Fatalf("error = %v, want ErrProviderNotConfigured", err)
+	}
+}
+
+func intToString(v int) string {
+	return strconv.Itoa(v)
+}

--- a/internal/distance/google_test.go
+++ b/internal/distance/google_test.go
@@ -136,6 +136,39 @@ func TestGoogleCalculator_MissingAPIKeyReturnsTypedError(t *testing.T) {
 	}
 }
 
+func TestGoogleCalculator_MissingAPIKeyFailsBeforeUsingCache(t *testing.T) {
+	store, err := sqlite.New(filepath.Join(t.TempDir(), "cached-missing-key-test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	origin := models.Coordinates{Lat: 35, Lng: -79}
+	dest := models.Coordinates{Lat: 36, Lng: -79}
+	if err := store.DistanceCache().Set(context.Background(), &models.DistanceCacheEntry{
+		Origin:         origin,
+		Destination:    dest,
+		DistanceMeters: 1000,
+		DurationSecs:   300,
+	}); err != nil {
+		t.Fatalf("seed distance cache: %v", err)
+	}
+
+	calc := NewGoogleCalculator(store.DistanceCache(), func() (string, error) {
+		return "", nil
+	})
+
+	if _, err := calc.GetDistance(context.Background(), origin, dest); !errors.Is(err, ErrProviderNotConfigured) {
+		t.Fatalf("GetDistance() error = %v, want ErrProviderNotConfigured", err)
+	}
+	if _, err := calc.GetDistancesFromPoint(context.Background(), origin, []models.Coordinates{dest}); !errors.Is(err, ErrProviderNotConfigured) {
+		t.Fatalf("GetDistancesFromPoint() error = %v, want ErrProviderNotConfigured", err)
+	}
+	if _, err := calc.GetDistanceMatrix(context.Background(), []models.Coordinates{origin, dest}); !errors.Is(err, ErrProviderNotConfigured) {
+		t.Fatalf("GetDistanceMatrix() error = %v, want ErrProviderNotConfigured", err)
+	}
+}
+
 func intToString(v int) string {
 	return strconv.Itoa(v)
 }

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -30,6 +30,7 @@ const (
 	messageOrganizationVehicleNotFound                   = "Organization vehicle not found"
 	messageParticipantNotFound                           = "Participant not found"
 	messagePreferencesSaved                              = "Preferences saved!"
+	messageRoutingProviderConfigUnchanged                = "Google Maps API key unchanged."
 	messageRoutingProviderConfigUpdated                  = "Google Maps API key saved. Distance cache cleared."
 	messageRoutesRequired                                = "Routes are required"
 	messageSessionNotFound                               = "Session not found"

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -30,6 +30,7 @@ const (
 	messageOrganizationVehicleNotFound                   = "Organization vehicle not found"
 	messageParticipantNotFound                           = "Participant not found"
 	messagePreferencesSaved                              = "Preferences saved!"
+	messageRoutingProviderConfigUpdated                  = "Google Maps API key saved. Distance cache cleared."
 	messageRoutesRequired                                = "Routes are required"
 	messageSessionNotFound                               = "Session not found"
 	messageSelectedActivityLocationNotFound              = "Selected activity location not found"

--- a/internal/handlers/pages.go
+++ b/internal/handlers/pages.go
@@ -139,6 +139,9 @@ func (h *Handler) HandleSettingsPage(w http.ResponseWriter, r *http.Request) {
 			DefaultPath:  defaultDBPath,
 			IsDefault:    dbConfig.DatabasePath == defaultDBPath,
 		},
+		RoutingProviderConfig: RoutingProviderConfigView{
+			GoogleMapsAPIKeyConfigured: dbConfig.GoogleMapsAPIKey != "",
+		},
 	})
 }
 

--- a/internal/handlers/pages_test.go
+++ b/internal/handlers/pages_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"ride-home-router/internal/database"
 	"ride-home-router/internal/models"
 	"ride-home-router/internal/sqlite"
 )
@@ -61,6 +63,145 @@ func TestHandleSettingsPage_DoesNotRenderVanManagement(t *testing.T) {
 	}
 	if !strings.Contains(body, `href="/vans"`) {
 		t.Fatalf("expected Settings page to link to Vans page, body=%q", body)
+	}
+}
+
+func TestHandleSettingsPage_ShowsGoogleKeyStatusWithoutRenderingKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := database.SaveConfig(&database.AppConfig{
+		DatabasePath:     filepath.Join(home, "settings.db"),
+		GoogleMapsAPIKey: "secret-google-key",
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	handler, _ := newTestPageHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleSettingsPage(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	body := rr.Body.String()
+	if strings.Contains(body, "secret-google-key") {
+		t.Fatalf("settings page leaked API key: body=%q", body)
+	}
+	if !strings.Contains(body, "Configured") {
+		t.Fatalf("expected configured status, body=%q", body)
+	}
+}
+
+func TestHandleUpdateRoutingProviderConfig_SavesKeyAndClearsDistanceCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	handler, store := newTestPageHandler(t)
+
+	if err := store.DistanceCache().Set(context.Background(), &models.DistanceCacheEntry{
+		Origin:         models.Coordinates{Lat: 35, Lng: -79},
+		Destination:    models.Coordinates{Lat: 36, Lng: -79},
+		DistanceMeters: 1000,
+		DurationSecs:   300,
+	}); err != nil {
+		t.Fatalf("seed distance cache: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("google_maps_api_key", "new-google-key")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/config/routing-provider", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateRoutingProviderConfig(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	config, err := database.LoadConfig()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if config.GoogleMapsAPIKey != "new-google-key" {
+		t.Fatalf("GoogleMapsAPIKey = %q, want saved key", config.GoogleMapsAPIKey)
+	}
+	cached, err := store.DistanceCache().Get(context.Background(), models.Coordinates{Lat: 35, Lng: -79}, models.Coordinates{Lat: 36, Lng: -79})
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	if cached != nil {
+		t.Fatalf("distance cache entry still present after key save")
+	}
+}
+
+func TestHandleUpdateRoutingProviderConfig_EmptyKeyDoesNotOverwriteExistingKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := database.SaveConfig(&database.AppConfig{
+		DatabasePath:     filepath.Join(home, "settings.db"),
+		GoogleMapsAPIKey: "existing-key",
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	handler, _ := newTestPageHandler(t)
+
+	form := url.Values{}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/config/routing-provider", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateRoutingProviderConfig(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	config, err := database.LoadConfig()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if config.GoogleMapsAPIKey != "existing-key" {
+		t.Fatalf("GoogleMapsAPIKey = %q, want existing key preserved", config.GoogleMapsAPIKey)
+	}
+}
+
+func TestHandleUpdateDatabaseConfig_PreservesGoogleKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := database.SaveConfig(&database.AppConfig{
+		DatabasePath:     filepath.Join(home, "old.db"),
+		GoogleMapsAPIKey: "existing-key",
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	handler, _ := newTestPageHandler(t)
+
+	newDBPath := filepath.Join(home, "new.db")
+	form := url.Values{}
+	form.Set("database_path", newDBPath)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/config/database", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateDatabaseConfig(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	config, err := database.LoadConfig()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if config.DatabasePath != newDBPath {
+		t.Fatalf("DatabasePath = %q, want %q", config.DatabasePath, newDBPath)
+	}
+	if config.GoogleMapsAPIKey != "existing-key" {
+		t.Fatalf("GoogleMapsAPIKey = %q, want existing key preserved", config.GoogleMapsAPIKey)
 	}
 }
 

--- a/internal/handlers/pages_test.go
+++ b/internal/handlers/pages_test.go
@@ -94,6 +94,9 @@ func TestHandleSettingsPage_ShowsGoogleKeyStatusWithoutRenderingKey(t *testing.T
 	if !strings.Contains(body, "Configured") {
 		t.Fatalf("expected configured status, body=%q", body)
 	}
+	if !strings.Contains(body, "hx-on::after-request") {
+		t.Fatalf("expected routing provider form to update configured status after save, body=%q", body)
+	}
 }
 
 func TestHandleUpdateRoutingProviderConfig_SavesKeyAndClearsDistanceCache(t *testing.T) {
@@ -159,6 +162,9 @@ func TestHandleUpdateRoutingProviderConfig_EmptyKeyDoesNotOverwriteExistingKey(t
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	if strings.Contains(rr.Header().Get("HX-Trigger"), messageRoutingProviderConfigUpdated) {
+		t.Fatalf("empty key update reported saved/cleared: HX-Trigger=%q", rr.Header().Get("HX-Trigger"))
 	}
 	config, err := database.LoadConfig()
 	if err != nil {

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -284,6 +284,13 @@ func (h *Handler) recalculateRoute(ctx context.Context, activityLocation *models
 	return routing.PopulateRouteMetrics(ctx, h.DistanceCalc, activityLocation.GetCoords(), mode, route)
 }
 
+func (h *Handler) optimizeRouteOrder(ctx context.Context, activityLocation *models.ActivityLocation, mode models.RouteMode, route *models.CalculatedRoute) error {
+	if activityLocation == nil {
+		return fmt.Errorf("activity location is required")
+	}
+	return routing.OptimizeRouteOrder(ctx, h.DistanceCalc, activityLocation.GetCoords(), mode, route)
+}
+
 // HandleMoveParticipant handles POST /api/v1/routes/edit/move-participant
 func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) {
 	var req struct {
@@ -361,13 +368,13 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 			append([]models.RouteStop{newStop}, toRoute.Stops[req.InsertAtPosition:]...)...)
 	}
 
-	// Recalculate distances for both routes
+	// Recalculate the source route, then optimize the destination car's route after the move.
 	if err := h.recalculateRoute(r.Context(), session.ActivityLocation, session.Mode, fromRoute); err != nil {
 		session.CurrentRoutes = backupRoutes
 		h.handleInternalError(w, err)
 		return
 	}
-	if err := h.recalculateRoute(r.Context(), session.ActivityLocation, session.Mode, toRoute); err != nil {
+	if err := h.optimizeRouteOrder(r.Context(), session.ActivityLocation, session.Mode, toRoute); err != nil {
 		session.CurrentRoutes = backupRoutes
 		h.handleInternalError(w, err)
 		return

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -1,8 +1,12 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"testing"
 
@@ -258,5 +262,67 @@ func TestRecalculateRoutePickupUsesModeAwareMetrics(t *testing.T) {
 	}
 	if route.Stops[1].DistanceFromPrevMeters != 5000 {
 		t.Fatalf("second stop distance = %.0f, want 5000", route.Stops[1].DistanceFromPrevMeters)
+	}
+}
+
+func TestHandleMoveParticipantOptimizesDestinationRoute(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	session := store.Create([]models.CalculatedRoute{
+		{
+			Driver: &models.Driver{ID: 1, Name: "From", Lat: 10, Lng: 0, VehicleCapacity: 2},
+			Stops: []models.RouteStop{
+				{Participant: &models.Participant{ID: 2, Name: "Origin Detour", Lat: 1, Lng: 100}},
+			},
+		},
+		{
+			Driver: &models.Driver{ID: 2, Name: "To", Lat: 10, Lng: 0, VehicleCapacity: 3},
+			Stops: []models.RouteStop{
+				{Participant: &models.Participant{ID: 1, Name: "Destination Side", Lat: 9, Lng: 0}},
+			},
+		},
+	}, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+
+	body, err := json.Marshal(map[string]any{
+		"session_id":         session.ID,
+		"participant_id":     int64(2),
+		"from_route_index":   0,
+		"to_route_index":     1,
+		"insert_at_position": -1,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleMoveParticipant(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	updated := store.Get(session.ID)
+	if updated == nil {
+		t.Fatal("expected route session to remain available")
+	}
+	toRoute := updated.CurrentRoutes[1]
+	if len(toRoute.Stops) != 2 {
+		t.Fatalf("destination stops = %d, want 2", len(toRoute.Stops))
+	}
+	if toRoute.Stops[0].Participant.Name != "Origin Detour" {
+		t.Fatalf("first destination stop = %q, want Origin Detour", toRoute.Stops[0].Participant.Name)
+	}
+	if toRoute.Stops[0].Order != 0 || toRoute.Stops[1].Order != 1 {
+		t.Fatalf("destination orders = [%d %d], want [0 1]", toRoute.Stops[0].Order, toRoute.Stops[1].Order)
+	}
+	if toRoute.RouteDurationSecs == 0 {
+		t.Fatal("destination route metrics were not refreshed")
 	}
 }

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -3,12 +3,14 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"html"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"ride-home-router/internal/distance"
 	"ride-home-router/internal/httpx"
 	"ride-home-router/internal/routing"
 )
@@ -214,7 +216,7 @@ func (h *Handler) HandleCalculateRoutes(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		log.Printf("[ERROR] Route calculation failed: err=%v", err)
-		h.handleInternalError(w, err)
+		h.handleRouteCalculationError(w, r, err)
 		return
 	}
 
@@ -382,7 +384,7 @@ func (h *Handler) HandleCalculateRoutesWithOrgVehicles(w http.ResponseWriter, r 
 			))
 			return
 		}
-		h.handleInternalError(w, err)
+		h.handleRouteCalculationError(w, r, err)
 		return
 	}
 
@@ -399,4 +401,26 @@ func (h *Handler) HandleCalculateRoutesWithOrgVehicles(w http.ResponseWriter, r 
 
 	h.setHTMXToast(w, messageRoutesCalculated(result.Summary.TotalDriversUsed), toastTypeSuccess)
 	h.renderTemplate(w, "route_results", buildRouteResultsView(result.Routes, result.Summary, activityLocation, settings.UseMiles, routeTime, session.ID, false, getUnusedDrivers(session), mode))
+}
+
+func (h *Handler) handleRouteCalculationError(w http.ResponseWriter, r *http.Request, err error) {
+	message := err.Error()
+	status := http.StatusServiceUnavailable
+	code := "DISTANCE_PROVIDER_FAILED"
+
+	if errors.Is(err, distance.ErrProviderNotConfigured) {
+		message = "Google Maps API key is not configured. Add it in Settings."
+		status = http.StatusBadRequest
+		code = "DISTANCE_PROVIDER_NOT_CONFIGURED"
+	}
+
+	if h.isHTMX(r) {
+		h.setHTMXToast(w, message, toastTypeError)
+		w.Header().Set(httpx.HeaderContentType, httpx.MediaTypeHTML)
+		w.WriteHeader(status)
+		w.Write([]byte(`<div class="alert alert-warning">` + html.EscapeString(message) + `</div>`))
+		return
+	}
+
+	h.writeError(w, status, code, message, nil)
 }

--- a/internal/handlers/routes_test.go
+++ b/internal/handlers/routes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"ride-home-router/internal/database"
+	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
 	"ride-home-router/internal/routing"
 	"ride-home-router/internal/sqlite"
@@ -243,6 +245,61 @@ func TestHandleCalculateRoutes_InvalidModeReturnsValidationError(t *testing.T) {
 	}
 	if router.lastRequest != nil {
 		t.Fatalf("expected router to not receive a request, got %#v", router.lastRequest)
+	}
+}
+
+func TestHandleCalculateRoutes_DistanceProviderFailureReturnsVisibleError(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Rd",
+		Lat:     40.10,
+		Lng:     -73.90,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "2 Driver Rd",
+		Lat:             40.20,
+		Lng:             -73.80,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(context.Background(), &models.ActivityLocation{
+		Name:    "Event",
+		Address: "3 Event Ave",
+		Lat:     42.00,
+		Lng:     -75.00,
+	})
+	if err != nil {
+		t.Fatalf("create location: %v", err)
+	}
+
+	handler.Router = &captureRouter{err: fmt.Errorf("%w: missing key", distance.ErrProviderNotConfigured)}
+
+	form := url.Values{}
+	form.Add("participant_ids", int64ToString(participant.ID))
+	form.Add("driver_ids", int64ToString(driver.ID))
+	form.Set("activity_location_id", int64ToString(location.ID))
+	form.Set("route_time", "18:30")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/routes/calculate", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCalculateRoutes(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Google Maps API key is not configured") {
+		t.Fatalf("body = %q, want provider setup message", rr.Body.String())
 	}
 }
 

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"ride-home-router/internal/database"
 	"ride-home-router/internal/models"
@@ -23,6 +24,78 @@ func (h *Handler) HandleGetSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeJSON(w, http.StatusOK, settings)
+}
+
+// HandleGetRoutingProviderConfig handles GET /api/v1/config/routing-provider
+func (h *Handler) HandleGetRoutingProviderConfig(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[HTTP] GET /api/v1/config/routing-provider")
+
+	config, err := database.LoadConfig()
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, RoutingProviderConfigResponse{
+		GoogleMapsAPIKeyConfigured: config.GoogleMapsAPIKey != "",
+	})
+}
+
+// HandleUpdateRoutingProviderConfig handles PUT /api/v1/config/routing-provider
+func (h *Handler) HandleUpdateRoutingProviderConfig(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		GoogleMapsAPIKey string `json:"google_maps_api_key"`
+	}
+
+	if h.isHTMX(r) {
+		if err := r.ParseForm(); err != nil {
+			h.setHTMXToast(w, err.Error(), toastTypeError)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		req.GoogleMapsAPIKey = r.FormValue("google_maps_api_key")
+	} else if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.handleValidationError(w, messageInvalidRequestBody)
+		return
+	}
+
+	config, err := database.LoadConfig()
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+
+	trimmedKey := strings.TrimSpace(req.GoogleMapsAPIKey)
+	if trimmedKey != "" {
+		config.GoogleMapsAPIKey = trimmedKey
+		if err := h.DB.DistanceCache().Clear(r.Context()); err != nil {
+			h.handleInternalError(w, err)
+			return
+		}
+	}
+
+	if err := database.SaveConfig(config); err != nil {
+		if h.isHTMX(r) {
+			h.setHTMXToast(w, err.Error(), toastTypeError)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
+
+	log.Printf("[HTTP] Updated routing provider config: google_maps_api_key_configured=%t cache_cleared=%t", config.GoogleMapsAPIKey != "", trimmedKey != "")
+
+	if h.isHTMX(r) {
+		h.setHTMXToast(w, messageRoutingProviderConfigUpdated, toastTypeSuccess)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, RoutingProviderConfigResponse{
+		GoogleMapsAPIKeyConfigured: config.GoogleMapsAPIKey != "",
+		Message:                    messageRoutingProviderConfigUpdated,
+	})
 }
 
 // HandleUpdateSettings handles PUT /api/v1/settings
@@ -221,10 +294,13 @@ func (h *Handler) HandleUpdateDatabaseConfig(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Save config
-	config := &database.AppConfig{
-		DatabasePath: req.DatabasePath,
+	config, err := database.LoadConfig()
+	if err != nil {
+		log.Printf("[ERROR] Failed to load config before database update: err=%v", err)
+		h.handleInternalError(w, err)
+		return
 	}
+	config.DatabasePath = req.DatabasePath
 
 	if err := database.SaveConfig(config); err != nil {
 		log.Printf("[ERROR] Failed to save config: err=%v", err)

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -66,14 +66,20 @@ func (h *Handler) HandleUpdateRoutingProviderConfig(w http.ResponseWriter, r *ht
 	}
 
 	trimmedKey := strings.TrimSpace(req.GoogleMapsAPIKey)
-	if trimmedKey != "" {
-		config.GoogleMapsAPIKey = trimmedKey
-		if err := h.DB.DistanceCache().Clear(r.Context()); err != nil {
-			h.handleInternalError(w, err)
+	if trimmedKey == "" {
+		if h.isHTMX(r) {
+			h.setHTMXToast(w, messageRoutingProviderConfigUnchanged, toastTypeWarning)
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		h.writeJSON(w, http.StatusOK, RoutingProviderConfigResponse{
+			GoogleMapsAPIKeyConfigured: config.GoogleMapsAPIKey != "",
+			Message:                    messageRoutingProviderConfigUnchanged,
+		})
+		return
 	}
 
+	config.GoogleMapsAPIKey = trimmedKey
 	if err := database.SaveConfig(config); err != nil {
 		if h.isHTMX(r) {
 			h.setHTMXToast(w, err.Error(), toastTypeError)
@@ -84,7 +90,17 @@ func (h *Handler) HandleUpdateRoutingProviderConfig(w http.ResponseWriter, r *ht
 		return
 	}
 
-	log.Printf("[HTTP] Updated routing provider config: google_maps_api_key_configured=%t cache_cleared=%t", config.GoogleMapsAPIKey != "", trimmedKey != "")
+	if err := h.DB.DistanceCache().Clear(r.Context()); err != nil {
+		if h.isHTMX(r) {
+			h.setHTMXToast(w, err.Error(), toastTypeError)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
+
+	log.Printf("[HTTP] Updated routing provider config: google_maps_api_key_configured=%t cache_cleared=true", config.GoogleMapsAPIKey != "")
 
 	if h.isHTMX(r) {
 		h.setHTMXToast(w, messageRoutingProviderConfigUpdated, toastTypeSuccess)

--- a/internal/handlers/view_models.go
+++ b/internal/handlers/view_models.go
@@ -53,10 +53,15 @@ type DatabaseConfigView struct {
 	IsDefault    bool
 }
 
+type RoutingProviderConfigView struct {
+	GoogleMapsAPIKeyConfigured bool
+}
+
 type SettingsPageView struct {
 	BasePageView
-	Settings       *models.Settings
-	DatabaseConfig DatabaseConfigView
+	Settings              *models.Settings
+	DatabaseConfig        DatabaseConfigView
+	RoutingProviderConfig RoutingProviderConfigView
 }
 
 type HistoryPageView struct {
@@ -146,4 +151,9 @@ type RouteCalculationResponse struct {
 type DatabasePathUpdateResponse struct {
 	DatabasePath string `json:"database_path"`
 	Message      string `json:"message"`
+}
+
+type RoutingProviderConfigResponse struct {
+	GoogleMapsAPIKeyConfigured bool   `json:"google_maps_api_key_configured"`
+	Message                    string `json:"message,omitempty"`
 }

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -115,6 +115,8 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 	if err != nil {
 		return nil, err
 	}
+	// Rider score drives construction and local ordering. Min-max remains a
+	// duration guardrail and only runs when a route is clearly excessive.
 	if shouldRunMinMaxOptimize(durations) {
 		iterations = r.minMaxOptimize(ctx, rc, routes, driverIDs)
 	}
@@ -206,6 +208,10 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 		currentDriverID := driverIDs[driverIndex]
 		route := routes[currentDriverID]
 		remainingCapacity := route.driver.VehicleCapacity - len(route.stops)
+		routeScore, err := rc.riderScore(ctx, route.driver, route.stops)
+		if err != nil {
+			return nil, err
+		}
 
 		// Find best group and position for this driver (minimize insertion cost)
 		bestCost := math.Inf(1)
@@ -224,7 +230,7 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 
 			// Try all insertion positions for this group
 			for _, pos := range householdBoundaryPositions(route.stops) {
-				cost, err := rc.groupInsertionDeltaRiderScore(ctx, route.driver, route.stops, group, pos)
+				cost, err := rc.groupInsertionDeltaRiderScoreFrom(ctx, route.driver, route.stops, group, pos, routeScore)
 				if err != nil {
 					return nil, err
 				}
@@ -258,7 +264,7 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 						lat:     group.lat,
 						lng:     group.lng,
 					}
-					cost, err := rc.groupInsertionDeltaRiderScore(ctx, route.driver, route.stops, singleGroup, pos)
+					cost, err := rc.groupInsertionDeltaRiderScoreFrom(ctx, route.driver, route.stops, singleGroup, pos, routeScore)
 					if err != nil {
 						return nil, err
 					}
@@ -275,6 +281,9 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 
 		if bestGroup == nil {
 			driverIndex = (driverIndex + 1) % len(driverIDs)
+			if driverIndex == startIndex {
+				break
+			}
 			continue
 		}
 
@@ -347,6 +356,7 @@ func (r *BalancedRouter) optimizeAllRoutes(ctx context.Context, rc routeContext,
 }
 
 // twoOpt applies 2-opt-style block reversals to reduce the rider score.
+// Routes with fewer than two household blocks are returned unchanged.
 func (r *BalancedRouter) twoOpt(ctx context.Context, rc routeContext, route *balancedRoute, stops []*models.Participant) ([]*models.Participant, error) {
 	return rc.twoOptRiderScore(ctx, route.driver, stops)
 }
@@ -801,9 +811,6 @@ func coalesceHouseholdStops(stops []*models.Participant) []*models.Participant {
 func maxRouteVehicleCapacity(routes map[int64]*balancedRoute) int {
 	maxCapacity := 0
 	for _, route := range routes {
-		if route == nil || route.driver == nil {
-			continue
-		}
 		if route.driver.VehicleCapacity > maxCapacity {
 			maxCapacity = route.driver.VehicleCapacity
 		}

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -15,10 +15,16 @@ import (
 
 // BalancedRouter implements fair distribution routing that:
 // 1. Uses all available drivers
-// 2. Minimizes the maximum route duration (load balancing)
+// 2. Prioritizes earlier rider dropoffs/pickups before guarded load balancing
 type BalancedRouter struct {
 	distanceCalc distance.DistanceCalculator
 }
+
+const (
+	minMaxRelativeThreshold     = 1.6
+	minMaxAbsoluteThresholdSecs = 3600.0
+	scoreImprovementEpsilon     = 0.001
+)
 
 // NewBalancedRouter creates a router that balances load across all drivers.
 func NewBalancedRouter(distanceCalc distance.DistanceCalculator) Router {
@@ -104,7 +110,14 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 
 	// Phase 3: Min-max inter-route optimization
 	phase3Start := time.Now()
-	iterations := r.minMaxOptimize(ctx, rc, routes, driverIDs)
+	iterations := 0
+	durations, err := r.calculateRouteDurations(ctx, rc, routes, driverIDs)
+	if err != nil {
+		return nil, err
+	}
+	if shouldRunMinMaxOptimize(durations) {
+		iterations = r.minMaxOptimize(ctx, rc, routes, driverIDs)
+	}
 	log.Printf("[TIMING] Phase 3 (min-max): %v (iterations=%d)", time.Since(phase3Start), iterations)
 
 	// Check for unassigned participants
@@ -149,6 +162,13 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 
 	// Group participants by address
 	groups := groupParticipantsByAddress(unassigned)
+	maxVehicleCapacity := maxRouteVehicleCapacity(routes)
+	splittableHouseholds := make(map[string]struct{})
+	for _, group := range groups {
+		if len(group.members) > maxVehicleCapacity {
+			splittableHouseholds[participantGroupKey(group)] = struct{}{}
+		}
+	}
 
 	totalParticipants := len(unassigned)
 	log.Printf("[BALANCED] Distributing %d participants (%d household groups) across %d drivers",
@@ -204,7 +224,7 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 
 			// Try all insertion positions for this group
 			for _, pos := range householdBoundaryPositions(route.stops) {
-				cost, err := rc.groupInsertionDeltaDuration(ctx, route.driver, route.stops, group, pos)
+				cost, err := rc.groupInsertionDeltaRiderScore(ctx, route.driver, route.stops, group, pos)
 				if err != nil {
 					return nil, err
 				}
@@ -218,31 +238,34 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 			}
 		}
 
-		// If no group fits, try to assign single participants from groups
+		// If no whole group fits this vehicle, split only households that cannot
+		// fit in any selected vehicle.
 		if bestGroup == nil {
-			// Find smallest participant we can fit
 			for groupIdx, group := range groups {
 				if len(group.members) == 0 {
+					continue
+				}
+				if _, ok := splittableHouseholds[participantGroupKey(group)]; !ok {
 					continue
 				}
 
 				// Try just the first member of the group, but still only at
 				// household boundaries so existing same-address riders stay adjacent.
 				for _, pos := range householdBoundaryPositions(route.stops) {
-					cost, err := rc.insertionDeltaDuration(ctx, route.driver, route.stops, group.members[0], pos)
+					singleGroup := &participantGroup{
+						members: []*models.Participant{group.members[0]},
+						address: group.address,
+						lat:     group.lat,
+						lng:     group.lng,
+					}
+					cost, err := rc.groupInsertionDeltaRiderScore(ctx, route.driver, route.stops, singleGroup, pos)
 					if err != nil {
 						return nil, err
 					}
 
 					if cost < bestCost {
 						bestCost = cost
-						// Create a temporary single-person group
-						bestGroup = &participantGroup{
-							members: []*models.Participant{group.members[0]},
-							address: group.address,
-							lat:     group.lat,
-							lng:     group.lng,
-						}
+						bestGroup = singleGroup
 						bestGroupIndex = groupIdx
 						bestPosition = pos
 					}
@@ -251,7 +274,8 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 		}
 
 		if bestGroup == nil {
-			break // No group can be assigned
+			driverIndex = (driverIndex + 1) % len(driverIDs)
+			continue
 		}
 
 		// Insert the group
@@ -266,10 +290,10 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 		}
 
 		if len(bestGroup.members) == 1 {
-			log.Printf("[BALANCED] Assigned %s to %s (pos=%d, cost=%.0fs)",
+			log.Printf("[BALANCED] Assigned %s to %s (pos=%d, rider_score_delta=%.0f)",
 				memberNames[0], route.driver.Name, bestPosition, bestCost)
 		} else {
-			log.Printf("[BALANCED] Assigned household group [%v] to %s (pos=%d, cost=%.0fs, size=%d)",
+			log.Printf("[BALANCED] Assigned household group [%v] to %s (pos=%d, rider_score_delta=%.0f, size=%d)",
 				memberNames, route.driver.Name, bestPosition, bestCost, len(bestGroup.members))
 		}
 
@@ -304,10 +328,10 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 	return unassignedResult, nil
 }
 
-// optimizeAllRoutes runs 2-opt on each route and updates durations
+// optimizeAllRoutes runs local route optimization and updates durations.
 func (r *BalancedRouter) optimizeAllRoutes(ctx context.Context, rc routeContext, routes map[int64]*balancedRoute) error {
 	for _, route := range routes {
-		if len(route.stops) >= 3 {
+		if len(route.stops) >= 2 {
 			optimized, err := r.twoOpt(ctx, rc, route, route.stops)
 			if err != nil {
 				return err
@@ -322,9 +346,9 @@ func (r *BalancedRouter) optimizeAllRoutes(ctx context.Context, rc routeContext,
 	return nil
 }
 
-// twoOpt applies 2-opt optimization to reduce the routing objective duration.
+// twoOpt applies 2-opt-style block reversals to reduce the rider score.
 func (r *BalancedRouter) twoOpt(ctx context.Context, rc routeContext, route *balancedRoute, stops []*models.Participant) ([]*models.Participant, error) {
-	return rc.twoOptDuration(ctx, route.driver, stops)
+	return rc.twoOptRiderScore(ctx, route.driver, stops)
 }
 
 // minMaxOptimize moves participants between routes to minimize the maximum route duration
@@ -515,6 +539,46 @@ func (r *BalancedRouter) calculateRouteDuration(ctx context.Context, rc routeCon
 	return rc.routeDuration(ctx, route.driver, route.stops)
 }
 
+func (r *BalancedRouter) calculateRouteDurations(ctx context.Context, rc routeContext, routes map[int64]*balancedRoute, driverIDs []int64) ([]float64, error) {
+	durations := make([]float64, 0, len(driverIDs))
+	for _, id := range driverIDs {
+		duration, err := r.calculateRouteDuration(ctx, rc, routes[id])
+		if err != nil {
+			return nil, err
+		}
+		durations = append(durations, duration)
+	}
+	return durations, nil
+}
+
+func shouldRunMinMaxOptimize(durations []float64) bool {
+	nonZero := make([]float64, 0, len(durations))
+	for _, duration := range durations {
+		if duration > 0 {
+			nonZero = append(nonZero, duration)
+		}
+	}
+	if len(nonZero) < 2 {
+		return false
+	}
+
+	sort.Float64s(nonZero)
+	maxDuration := nonZero[len(nonZero)-1]
+	if maxDuration > minMaxAbsoluteThresholdSecs {
+		return true
+	}
+
+	median := nonZero[len(nonZero)/2]
+	if len(nonZero)%2 == 0 {
+		median = (nonZero[len(nonZero)/2-1] + nonZero[len(nonZero)/2]) / 2
+	}
+	if median <= 0 {
+		return false
+	}
+
+	return maxDuration > median*minMaxRelativeThreshold
+}
+
 // updateRouteDuration recalculates and caches the total duration for a route
 func (r *BalancedRouter) updateRouteDuration(ctx context.Context, rc routeContext, route *balancedRoute) error {
 	if len(route.stops) == 0 {
@@ -634,7 +698,10 @@ func groupParticipantsByAddress(participants []*models.Participant) []*participa
 
 	// Sort groups by size (larger groups first) for better initial assignment
 	sort.Slice(groups, func(i, j int) bool {
-		return len(groups[i].members) > len(groups[j].members)
+		if len(groups[i].members) != len(groups[j].members) {
+			return len(groups[i].members) > len(groups[j].members)
+		}
+		return participantGroupKey(groups[i]) < participantGroupKey(groups[j])
 	})
 
 	return groups
@@ -650,6 +717,13 @@ func householdKey(participant *models.Participant) string {
 		return ""
 	}
 	return coordinateKey(models.RoundCoordinate(participant.Lat), models.RoundCoordinate(participant.Lng))
+}
+
+func participantGroupKey(group *participantGroup) string {
+	if group == nil {
+		return ""
+	}
+	return coordinateKey(group.lat, group.lng)
 }
 
 func newParticipantGroup(participant *models.Participant) *participantGroup {
@@ -722,6 +796,19 @@ func coalesceHouseholdStops(stops []*models.Participant) []*models.Participant {
 	}
 
 	return result
+}
+
+func maxRouteVehicleCapacity(routes map[int64]*balancedRoute) int {
+	maxCapacity := 0
+	for _, route := range routes {
+		if route == nil || route.driver == nil {
+			continue
+		}
+		if route.driver.VehicleCapacity > maxCapacity {
+			maxCapacity = route.driver.VehicleCapacity
+		}
+	}
+	return maxCapacity
 }
 
 // insertGroupAt inserts all members of a group consecutively at the specified position

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -227,6 +227,9 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 				// Group too large - skip; we'll try splitting individuals below
 				continue
 			}
+			if !assignmentPreservesCapacityFeasibility(routes, currentDriverID, groups, groupIdx, groupSize, splittableHouseholds) {
+				continue
+			}
 
 			// Try all insertion positions for this group
 			for _, pos := range householdBoundaryPositions(route.stops) {
@@ -252,6 +255,9 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 					continue
 				}
 				if _, ok := splittableHouseholds[participantGroupKey(group)]; !ok {
+					continue
+				}
+				if !assignmentPreservesCapacityFeasibility(routes, currentDriverID, groups, groupIdx, 1, splittableHouseholds) {
 					continue
 				}
 
@@ -568,7 +574,7 @@ func shouldRunMinMaxOptimize(durations []float64) bool {
 			nonZero = append(nonZero, duration)
 		}
 	}
-	if len(nonZero) < 2 {
+	if len(nonZero) == 0 {
 		return false
 	}
 
@@ -576,6 +582,9 @@ func shouldRunMinMaxOptimize(durations []float64) bool {
 	maxDuration := nonZero[len(nonZero)-1]
 	if maxDuration > minMaxAbsoluteThresholdSecs {
 		return true
+	}
+	if len(nonZero) < 2 {
+		return false
 	}
 
 	median := nonZero[len(nonZero)/2]
@@ -816,6 +825,81 @@ func maxRouteVehicleCapacity(routes map[int64]*balancedRoute) int {
 		}
 	}
 	return maxCapacity
+}
+
+func assignmentPreservesCapacityFeasibility(routes map[int64]*balancedRoute, currentDriverID int64, groups []*participantGroup, assignedGroupIndex, assignedCount int, splittableHouseholds map[string]struct{}) bool {
+	capacities := make([]int, 0, len(routes))
+	totalCapacity := 0
+	for driverID, route := range routes {
+		capacity := route.driver.VehicleCapacity - len(route.stops)
+		if driverID == currentDriverID {
+			capacity -= assignedCount
+		}
+		if capacity < 0 {
+			return false
+		}
+		capacities = append(capacities, capacity)
+		totalCapacity += capacity
+	}
+
+	remainingParticipants := 0
+	atomicSizes := make([]int, 0, len(groups))
+	for groupIdx, group := range groups {
+		size := len(group.members)
+		if groupIdx == assignedGroupIndex {
+			size -= assignedCount
+		}
+		if size <= 0 {
+			continue
+		}
+
+		remainingParticipants += size
+		if _, splittable := splittableHouseholds[participantGroupKey(group)]; !splittable {
+			atomicSizes = append(atomicSizes, size)
+		}
+	}
+	if remainingParticipants > totalCapacity {
+		return false
+	}
+
+	return canPackAtomicGroupSizes(atomicSizes, capacities)
+}
+
+func canPackAtomicGroupSizes(groupSizes []int, capacities []int) bool {
+	if len(groupSizes) == 0 {
+		return true
+	}
+
+	groupSizes = slices.Clone(groupSizes)
+	capacities = slices.Clone(capacities)
+	sort.Sort(sort.Reverse(sort.IntSlice(groupSizes)))
+	sort.Sort(sort.Reverse(sort.IntSlice(capacities)))
+
+	var pack func(int) bool
+	pack = func(groupIndex int) bool {
+		if groupIndex == len(groupSizes) {
+			return true
+		}
+
+		size := groupSizes[groupIndex]
+		lastTriedCapacity := -1
+		for i, capacity := range capacities {
+			if capacity < size || capacity == lastTriedCapacity {
+				continue
+			}
+
+			capacities[i] -= size
+			if pack(groupIndex + 1) {
+				return true
+			}
+			capacities[i] += size
+			lastTriedCapacity = capacity
+		}
+
+		return false
+	}
+
+	return pack(0)
 }
 
 // insertGroupAt inserts all members of a group consecutively at the specified position

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -15,7 +15,8 @@ import (
 
 // BalancedRouter implements fair distribution routing that:
 // 1. Uses all available drivers
-// 2. Prioritizes earlier rider dropoffs/pickups before guarded load balancing
+// 2. Assigns riders with rider-experience scoring
+// 3. Finishes by minimizing driven time inside each fixed route
 type BalancedRouter struct {
 	distanceCalc distance.DistanceCalculator
 }
@@ -101,26 +102,26 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 	}
 	log.Printf("[TIMING] Phase 1 (round-robin): %v", time.Since(phase1Start))
 
-	// Phase 2: 2-opt on each route
+	// Phase 2: Min-max inter-route optimization
 	phase2Start := time.Now()
-	if err := r.optimizeAllRoutes(ctx, rc, routes); err != nil {
-		return nil, err
-	}
-	log.Printf("[TIMING] Phase 2 (2-opt): %v", time.Since(phase2Start))
-
-	// Phase 3: Min-max inter-route optimization
-	phase3Start := time.Now()
 	iterations := 0
 	durations, err := r.calculateRouteDurations(ctx, rc, routes, driverIDs)
 	if err != nil {
 		return nil, err
 	}
-	// Rider score drives construction and local ordering. Min-max remains a
-	// duration guardrail and only runs when a route is clearly excessive.
+	// Rider score drives construction. Min-max remains a duration guardrail and
+	// only runs before final in-car ordering when a route is clearly excessive.
 	if shouldRunMinMaxOptimize(durations) {
 		iterations = r.minMaxOptimize(ctx, rc, routes, driverIDs)
 	}
-	log.Printf("[TIMING] Phase 3 (min-max): %v (iterations=%d)", time.Since(phase3Start), iterations)
+	log.Printf("[TIMING] Phase 2 (min-max): %v (iterations=%d)", time.Since(phase2Start), iterations)
+
+	// Phase 3: Final 2-opt on each fixed route
+	phase3Start := time.Now()
+	if err := r.optimizeAllRoutes(ctx, rc, routes); err != nil {
+		return nil, err
+	}
+	log.Printf("[TIMING] Phase 3 (2-opt): %v", time.Since(phase3Start))
 
 	// Check for unassigned participants
 	if len(unassigned) > 0 {
@@ -343,7 +344,7 @@ func (r *BalancedRouter) roundRobinInsertion(ctx context.Context, rc routeContex
 	return unassignedResult, nil
 }
 
-// optimizeAllRoutes runs local route optimization and updates durations.
+// optimizeAllRoutes runs final local route optimization and updates durations.
 func (r *BalancedRouter) optimizeAllRoutes(ctx context.Context, rc routeContext, routes map[int64]*balancedRoute) error {
 	for _, route := range routes {
 		if len(route.stops) >= 2 {
@@ -361,10 +362,10 @@ func (r *BalancedRouter) optimizeAllRoutes(ctx context.Context, rc routeContext,
 	return nil
 }
 
-// twoOpt applies 2-opt-style block reversals to reduce the rider score.
+// twoOpt applies 2-opt-style block reversals to reduce total driven time.
 // Routes with fewer than two household blocks are returned unchanged.
 func (r *BalancedRouter) twoOpt(ctx context.Context, rc routeContext, route *balancedRoute, stops []*models.Participant) ([]*models.Participant, error) {
-	return rc.twoOptRiderScore(ctx, route.driver, stops)
+	return rc.twoOptRouteDuration(ctx, route.driver, stops)
 }
 
 // minMaxOptimize moves participants between routes to minimize the maximum route duration

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -269,6 +269,42 @@ func TestBalancedRouter_LargeHouseholdStaysTogetherWhenAnyVehicleFits(t *testing
 	}
 }
 
+func TestRoundRobinInsertion_ReservesOnlyFittingVehicleForHousehold(t *testing.T) {
+	distances := stableDistanceCalculator{}
+	router := &BalancedRouter{distanceCalc: distances}
+	institute := models.Coordinates{Lat: 0, Lng: 0}
+	household := models.Coordinates{Lat: 10, Lng: 0}
+	solo := models.Coordinates{Lat: 0.1, Lng: 0}
+
+	largeDriver := &models.Driver{ID: 1, Name: "LargeCar", Lat: 0, Lng: 0, VehicleCapacity: 4}
+	smallDriver := &models.Driver{ID: 2, Name: "SmallCar", Lat: 0, Lng: 0, VehicleCapacity: 2}
+	routes := map[int64]*balancedRoute{
+		largeDriver.ID: {driver: largeDriver, stops: []*models.Participant{}},
+		smallDriver.ID: {driver: smallDriver, stops: []*models.Participant{}},
+	}
+	participants := []*models.Participant{
+		{ID: 1, Name: "Household 1", Lat: household.Lat, Lng: household.Lng},
+		{ID: 2, Name: "Household 2", Lat: household.Lat, Lng: household.Lng},
+		{ID: 3, Name: "Household 3", Lat: household.Lat, Lng: household.Lng},
+		{ID: 4, Name: "Household 4", Lat: household.Lat, Lng: household.Lng},
+		{ID: 5, Name: "Solo", Lat: solo.Lat, Lng: solo.Lng},
+	}
+
+	remaining, err := router.roundRobinInsertion(context.Background(), newRouteContext(distances, institute, RouteModeDropoff), routes, []int64{largeDriver.ID, smallDriver.ID}, participants)
+	if err != nil {
+		t.Fatalf("roundRobinInsertion() error = %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("roundRobinInsertion() left %d unassigned participants", len(remaining))
+	}
+	if got := len(routes[largeDriver.ID].stops); got != 4 {
+		t.Fatalf("large driver stop count = %d, want reserved 4-person household", got)
+	}
+	if got := len(routes[smallDriver.ID].stops); got != 1 {
+		t.Fatalf("small driver stop count = %d, want solo rider", got)
+	}
+}
+
 func TestBalancedRouter_OversizedHouseholdMaySplitOnlyWhenNoVehicleFits(t *testing.T) {
 	mock := newMockDistanceAdapter()
 	router := NewBalancedRouter(mock)
@@ -622,6 +658,9 @@ func TestShouldRunMinMaxOptimizeUsesGuardrailThresholds(t *testing.T) {
 	}
 	if !shouldRunMinMaxOptimize([]float64{100, 3700}) {
 		t.Fatal("should run min-max above absolute threshold")
+	}
+	if !shouldRunMinMaxOptimize([]float64{3700, 0}) {
+		t.Fatal("should run min-max above absolute threshold with a single non-empty route")
 	}
 }
 

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -528,7 +528,7 @@ func TestRoundRobinInsertion_SingleParticipantFallbackPreservesExistingHousehold
 		t.Fatalf("roundRobinInsertion() error = %v", err)
 	}
 	if len(remaining) != 2 {
-		t.Fatalf("roundRobinInsertion() remaining = %d, want 2 because the full household fits this vehicle capacity", len(remaining))
+		t.Fatalf("roundRobinInsertion() remaining = %d, want 2 because the household fits the max selected vehicle capacity", len(remaining))
 	}
 
 	stops := routes[driver.ID].stops

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -236,6 +236,76 @@ func TestBalancedRouter_LargeHouseholdSplit(t *testing.T) {
 	}
 }
 
+func TestBalancedRouter_LargeHouseholdStaysTogetherWhenAnyVehicleFits(t *testing.T) {
+	mock := newMockDistanceAdapter()
+	router := NewBalancedRouter(mock)
+
+	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 1, Name: "Household 1", Lat: 0.01, Lng: 0.01},
+			{ID: 2, Name: "Household 2", Lat: 0.01, Lng: 0.01},
+			{ID: 3, Name: "Household 3", Lat: 0.01, Lng: 0.01},
+			{ID: 4, Name: "Household 4", Lat: 0.01, Lng: 0.01},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "Small", Lat: 0.05, Lng: 0.05, VehicleCapacity: 3},
+			{ID: 2, Name: "Large", Lat: 0.06, Lng: 0.06, VehicleCapacity: 4},
+		},
+		Mode: RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+
+	if len(result.Routes) != 1 {
+		t.Fatalf("route count = %d, want 1 household route", len(result.Routes))
+	}
+	if got := len(result.Routes[0].Stops); got != 4 {
+		t.Fatalf("household route stop count = %d, want 4", got)
+	}
+	if result.Routes[0].Driver.ID != 2 {
+		t.Fatalf("household assigned to driver %d, want large-capacity driver 2", result.Routes[0].Driver.ID)
+	}
+}
+
+func TestBalancedRouter_OversizedHouseholdMaySplitOnlyWhenNoVehicleFits(t *testing.T) {
+	mock := newMockDistanceAdapter()
+	router := NewBalancedRouter(mock)
+
+	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 1, Name: "Household 1", Lat: 0.01, Lng: 0.01},
+			{ID: 2, Name: "Household 2", Lat: 0.01, Lng: 0.01},
+			{ID: 3, Name: "Household 3", Lat: 0.01, Lng: 0.01},
+			{ID: 4, Name: "Household 4", Lat: 0.01, Lng: 0.01},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "Driver1", Lat: 0.05, Lng: 0.05, VehicleCapacity: 3},
+			{ID: 2, Name: "Driver2", Lat: 0.06, Lng: 0.06, VehicleCapacity: 3},
+		},
+		Mode: RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+
+	if len(result.Routes) != 2 {
+		t.Fatalf("route count = %d, want split across 2 routes", len(result.Routes))
+	}
+	totalAssigned := 0
+	for _, route := range result.Routes {
+		if len(route.Stops) > route.Driver.VehicleCapacity {
+			t.Fatalf("route for %s has %d stops over capacity %d", route.Driver.Name, len(route.Stops), route.Driver.VehicleCapacity)
+		}
+		totalAssigned += len(route.Stops)
+	}
+	if totalAssigned != 4 {
+		t.Fatalf("assigned stops = %d, want 4", totalAssigned)
+	}
+}
+
 func TestInsertGroupAt(t *testing.T) {
 	existing := []*models.Participant{
 		{ID: 1, Name: "Alice"},
@@ -457,13 +527,13 @@ func TestRoundRobinInsertion_SingleParticipantFallbackPreservesExistingHousehold
 	if err != nil {
 		t.Fatalf("roundRobinInsertion() error = %v", err)
 	}
-	if len(remaining) != 1 {
-		t.Fatalf("roundRobinInsertion() remaining = %d, want 1 after capacity-driven split", len(remaining))
+	if len(remaining) != 2 {
+		t.Fatalf("roundRobinInsertion() remaining = %d, want 2 because the full household fits this vehicle capacity", len(remaining))
 	}
 
 	stops := routes[driver.ID].stops
-	if len(stops) != 4 {
-		t.Fatalf("route stop count = %d, want 4", len(stops))
+	if len(stops) != 3 {
+		t.Fatalf("route stop count = %d, want unchanged 3", len(stops))
 	}
 	for i := 0; i < len(stops)-1; i++ {
 		if stops[i].Name == "Sister 1" && stops[i+1].Name == "Sister 2" {
@@ -471,7 +541,7 @@ func TestRoundRobinInsertion_SingleParticipantFallbackPreservesExistingHousehold
 		}
 	}
 
-	t.Fatalf("single-participant fallback split existing household: got order %q, %q, %q, %q", stops[0].Name, stops[1].Name, stops[2].Name, stops[3].Name)
+	t.Fatalf("single-participant fallback split existing household: got order %q, %q, %q", stops[0].Name, stops[1].Name, stops[2].Name)
 }
 
 func TestOptimizeAllRoutes_CoalescesHouseholdsForBothModes(t *testing.T) {
@@ -505,6 +575,53 @@ func TestOptimizeAllRoutes_CoalescesHouseholdsForBothModes(t *testing.T) {
 				t.Fatalf("%s optimization left household split: got order %q, %q, %q", mode, stops[0].Name, stops[1].Name, stops[2].Name)
 			}
 		})
+	}
+}
+
+func TestOptimizeAllRoutes_ImprovesRiderScoreWithExactRecompute(t *testing.T) {
+	distances := stableDistanceCalculator{}
+	router := &BalancedRouter{distanceCalc: distances}
+	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 20, Lng: 0, VehicleCapacity: 2}
+	rc := newRouteContext(distances, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
+	routes := map[int64]*balancedRoute{
+		driver.ID: {
+			driver: driver,
+			stops: []*models.Participant{
+				{ID: 1, Name: "Far", Lat: 10, Lng: 0},
+				{ID: 2, Name: "Near", Lat: 1, Lng: 0},
+			},
+		},
+	}
+
+	before, err := rc.riderScore(context.Background(), driver, routes[driver.ID].stops)
+	if err != nil {
+		t.Fatalf("before score error = %v", err)
+	}
+	if err := router.optimizeAllRoutes(context.Background(), rc, routes); err != nil {
+		t.Fatalf("optimizeAllRoutes() error = %v", err)
+	}
+	after, err := rc.riderScore(context.Background(), driver, routes[driver.ID].stops)
+	if err != nil {
+		t.Fatalf("after score error = %v", err)
+	}
+
+	if after >= before {
+		t.Fatalf("rider score after optimize = %.0f, want less than before %.0f", after, before)
+	}
+	if routes[driver.ID].stops[0].Name != "Near" {
+		t.Fatalf("first stop = %q, want Near", routes[driver.ID].stops[0].Name)
+	}
+}
+
+func TestShouldRunMinMaxOptimizeUsesGuardrailThresholds(t *testing.T) {
+	if shouldRunMinMaxOptimize([]float64{600, 600, 900}) {
+		t.Fatal("should not run min-max below relative and absolute thresholds")
+	}
+	if !shouldRunMinMaxOptimize([]float64{600, 600, 1000}) {
+		t.Fatal("should run min-max above relative threshold")
+	}
+	if !shouldRunMinMaxOptimize([]float64{100, 3700}) {
+		t.Fatal("should run min-max above absolute threshold")
 	}
 }
 

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -614,38 +614,38 @@ func TestOptimizeAllRoutes_CoalescesHouseholdsForBothModes(t *testing.T) {
 	}
 }
 
-func TestOptimizeAllRoutes_ImprovesRiderScoreWithExactRecompute(t *testing.T) {
+func TestOptimizeAllRoutes_FinalOrderingMinimizesTotalDriveTime(t *testing.T) {
 	distances := stableDistanceCalculator{}
 	router := &BalancedRouter{distanceCalc: distances}
-	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 20, Lng: 0, VehicleCapacity: 2}
+	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0, VehicleCapacity: 2}
 	rc := newRouteContext(distances, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
 	routes := map[int64]*balancedRoute{
 		driver.ID: {
 			driver: driver,
 			stops: []*models.Participant{
-				{ID: 1, Name: "Far", Lat: 10, Lng: 0},
-				{ID: 2, Name: "Near", Lat: 1, Lng: 0},
+				{ID: 1, Name: "Destination Side", Lat: 9, Lng: 0},
+				{ID: 2, Name: "Origin Detour", Lat: 1, Lng: 100},
 			},
 		},
 	}
 
-	before, err := rc.riderScore(context.Background(), driver, routes[driver.ID].stops)
+	before, err := rc.totalDriveDuration(context.Background(), driver, routes[driver.ID].stops)
 	if err != nil {
-		t.Fatalf("before score error = %v", err)
+		t.Fatalf("before duration error = %v", err)
 	}
 	if err := router.optimizeAllRoutes(context.Background(), rc, routes); err != nil {
 		t.Fatalf("optimizeAllRoutes() error = %v", err)
 	}
-	after, err := rc.riderScore(context.Background(), driver, routes[driver.ID].stops)
+	after, err := rc.totalDriveDuration(context.Background(), driver, routes[driver.ID].stops)
 	if err != nil {
-		t.Fatalf("after score error = %v", err)
+		t.Fatalf("after duration error = %v", err)
 	}
 
 	if after >= before {
-		t.Fatalf("rider score after optimize = %.0f, want less than before %.0f", after, before)
+		t.Fatalf("duration after optimize = %.0f, want less than before %.0f", after, before)
 	}
-	if routes[driver.ID].stops[0].Name != "Near" {
-		t.Fatalf("first stop = %q, want Near", routes[driver.ID].stops[0].Name)
+	if routes[driver.ID].stops[0].Name != "Origin Detour" {
+		t.Fatalf("first stop = %q, want Origin Detour", routes[driver.ID].stops[0].Name)
 	}
 }
 

--- a/internal/routing/helpers.go
+++ b/internal/routing/helpers.go
@@ -16,3 +16,24 @@ func reverse(stops []*models.Participant, i, j int) {
 		j--
 	}
 }
+
+func reverseGroups(groups []*participantGroup, i, j int) {
+	for i < j {
+		groups[i], groups[j] = groups[j], groups[i]
+		i++
+		j--
+	}
+}
+
+func flattenParticipantGroups(groups []*participantGroup) []*models.Participant {
+	total := 0
+	for _, group := range groups {
+		total += len(group.members)
+	}
+
+	stops := make([]*models.Participant, 0, total)
+	for _, group := range groups {
+		stops = append(stops, group.members...)
+	}
+	return stops
+}

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -60,9 +60,7 @@ func (rc routeContext) destination(driver *models.Driver) models.Coordinates {
 }
 
 func (rc routeContext) routeDuration(ctx context.Context, driver *models.Driver, stops []*models.Participant) (float64, error) {
-	return rc.objectiveCost(ctx, driver, stops, func(result *distance.DistanceResult) float64 {
-		return result.DurationSecs
-	})
+	return rc.totalDriveDuration(ctx, driver, stops)
 }
 
 func (rc routeContext) riderScore(ctx context.Context, driver *models.Driver, stops []*models.Participant) (float64, error) {
@@ -91,6 +89,14 @@ func (rc routeContext) riderScore(ctx context.Context, driver *models.Driver, st
 	}
 
 	return total, nil
+}
+
+func (rc routeContext) totalDriveDuration(ctx context.Context, driver *models.Driver, stops []*models.Participant) (float64, error) {
+	metrics, err := rc.evaluateParticipants(ctx, driver, stops)
+	if err != nil {
+		return 0, err
+	}
+	return metrics.RouteDurationSecs, nil
 }
 
 func (rc routeContext) evaluateParticipants(ctx context.Context, driver *models.Driver, stops []*models.Participant) (*routeMetrics, error) {
@@ -335,6 +341,44 @@ func (rc routeContext) twoOptRiderScore(ctx context.Context, driver *models.Driv
 				reverseGroups(candidateBlocks, i, j-1)
 				candidateStops := flattenParticipantGroups(candidateBlocks)
 				candidateScore, err := rc.riderScore(ctx, driver, candidateStops)
+				if err != nil {
+					return nil, err
+				}
+				if candidateScore < currentScore-scoreImprovementEpsilon {
+					currentBlocks = candidateBlocks
+					currentStops = candidateStops
+					currentScore = candidateScore
+					improved = true
+				}
+			}
+		}
+	}
+
+	return currentStops, nil
+}
+
+func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
+	blocks := routeHouseholdBlocks(stops)
+	if len(blocks) < 2 {
+		return stops, nil
+	}
+
+	currentBlocks := append([]*participantGroup(nil), blocks...)
+	currentStops := flattenParticipantGroups(currentBlocks)
+	currentScore, err := rc.totalDriveDuration(ctx, driver, currentStops)
+	if err != nil {
+		return nil, err
+	}
+
+	improved := true
+	for improved {
+		improved = false
+		for i := 0; i < len(currentBlocks)-1; i++ {
+			for j := i + 2; j <= len(currentBlocks); j++ {
+				candidateBlocks := append([]*participantGroup(nil), currentBlocks...)
+				reverseGroups(candidateBlocks, i, j-1)
+				candidateStops := flattenParticipantGroups(candidateBlocks)
+				candidateScore, err := rc.totalDriveDuration(ctx, driver, candidateStops)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -277,6 +277,31 @@ func PopulateRouteMetrics(ctx context.Context, distanceCalc distance.DistanceCal
 	return nil
 }
 
+// OptimizeRouteOrder reorders one calculated route by total driven time, then refreshes metrics.
+func OptimizeRouteOrder(ctx context.Context, distanceCalc distance.DistanceCalculator, instituteCoords models.Coordinates, mode RouteMode, route *models.CalculatedRoute) error {
+	if route == nil {
+		return fmt.Errorf("route is required")
+	}
+
+	rc := newRouteContext(distanceCalc, instituteCoords, mode)
+	participants := make([]*models.Participant, len(route.Stops))
+	for i := range route.Stops {
+		participants[i] = route.Stops[i].Participant
+	}
+
+	optimized, err := rc.twoOptRouteDuration(ctx, route.Driver, participants)
+	if err != nil {
+		return err
+	}
+
+	route.Stops = make([]models.RouteStop, len(optimized))
+	for i, participant := range optimized {
+		route.Stops[i].Participant = participant
+	}
+
+	return PopulateRouteMetrics(ctx, distanceCalc, instituteCoords, mode, route)
+}
+
 func (rc routeContext) twoOptDistance(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
 	return twoOptByDelta(stops, func(candidate []*models.Participant, i, j int) (float64, error) {
 		return rc.twoOptDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -243,6 +243,14 @@ func (rc routeContext) insertionDelta(ctx context.Context, driver *models.Driver
 }
 
 func (rc routeContext) groupInsertionDeltaRiderScore(ctx context.Context, driver *models.Driver, stops []*models.Participant, group *participantGroup, pos int) (float64, error) {
+	before, err := rc.riderScore(ctx, driver, stops)
+	if err != nil {
+		return 0, err
+	}
+	return rc.groupInsertionDeltaRiderScoreFrom(ctx, driver, stops, group, pos, before)
+}
+
+func (rc routeContext) groupInsertionDeltaRiderScoreFrom(ctx context.Context, driver *models.Driver, stops []*models.Participant, group *participantGroup, pos int, before float64) (float64, error) {
 	if driver == nil {
 		return 0, fmt.Errorf("route driver is required")
 	}
@@ -250,10 +258,6 @@ func (rc routeContext) groupInsertionDeltaRiderScore(ctx context.Context, driver
 		return 0, nil
 	}
 
-	before, err := rc.riderScore(ctx, driver, stops)
-	if err != nil {
-		return 0, err
-	}
 	afterStops := insertGroupAt(stops, group, pos)
 	after, err := rc.riderScore(ctx, driver, afterStops)
 	if err != nil {

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -65,6 +65,34 @@ func (rc routeContext) routeDuration(ctx context.Context, driver *models.Driver,
 	})
 }
 
+func (rc routeContext) riderScore(ctx context.Context, driver *models.Driver, stops []*models.Participant) (float64, error) {
+	if driver == nil {
+		return 0, fmt.Errorf("route driver is required")
+	}
+	if len(stops) == 0 {
+		return 0, nil
+	}
+
+	total := 0.0
+	cumulative := 0.0
+	prev := rc.origin(driver)
+	for i, stop := range stops {
+		if stop == nil {
+			return 0, fmt.Errorf("route stop %d is missing participant data", i)
+		}
+
+		dist, err := rc.distanceCalc.GetDistance(ctx, prev, stop.GetCoords())
+		if err != nil {
+			return 0, err
+		}
+		cumulative += dist.DurationSecs
+		total += cumulative
+		prev = stop.GetCoords()
+	}
+
+	return total, nil
+}
+
 func (rc routeContext) evaluateParticipants(ctx context.Context, driver *models.Driver, stops []*models.Participant) (*routeMetrics, error) {
 	if driver == nil {
 		return nil, fmt.Errorf("route driver is required")
@@ -214,7 +242,7 @@ func (rc routeContext) insertionDelta(ctx context.Context, driver *models.Driver
 	return selector(prevToParticipant) + selector(participantToNext) - selector(prevToNext), nil
 }
 
-func (rc routeContext) groupInsertionDeltaDuration(ctx context.Context, driver *models.Driver, stops []*models.Participant, group *participantGroup, pos int) (float64, error) {
+func (rc routeContext) groupInsertionDeltaRiderScore(ctx context.Context, driver *models.Driver, stops []*models.Participant, group *participantGroup, pos int) (float64, error) {
 	if driver == nil {
 		return 0, fmt.Errorf("route driver is required")
 	}
@@ -222,59 +250,17 @@ func (rc routeContext) groupInsertionDeltaDuration(ctx context.Context, driver *
 		return 0, nil
 	}
 
-	prev := rc.origin(driver)
-	if pos > 0 {
-		prev = stops[pos-1].GetCoords()
-	}
-
-	if pos == len(stops) && !rc.objectiveIncludesTerminal() {
-		total := 0.0
-		current := prev
-		for i, member := range group.members {
-			if member == nil {
-				return 0, fmt.Errorf("group member %d is missing participant data", i)
-			}
-
-			dist, err := rc.distanceCalc.GetDistance(ctx, current, member.GetCoords())
-			if err != nil {
-				return 0, err
-			}
-			total += dist.DurationSecs
-			current = member.GetCoords()
-		}
-		return total, nil
-	}
-
-	next := rc.destination(driver)
-	if pos < len(stops) {
-		next = stops[pos].GetCoords()
-	}
-
-	total := 0.0
-	current := prev
-	for i, member := range group.members {
-		if member == nil {
-			return 0, fmt.Errorf("group member %d is missing participant data", i)
-		}
-
-		dist, err := rc.distanceCalc.GetDistance(ctx, current, member.GetCoords())
-		if err != nil {
-			return 0, err
-		}
-		total += dist.DurationSecs
-		current = member.GetCoords()
-	}
-
-	lastToNext, err := rc.distanceCalc.GetDistance(ctx, current, next)
+	before, err := rc.riderScore(ctx, driver, stops)
 	if err != nil {
 		return 0, err
 	}
-	prevToNext, err := rc.distanceCalc.GetDistance(ctx, prev, next)
+	afterStops := insertGroupAt(stops, group, pos)
+	after, err := rc.riderScore(ctx, driver, afterStops)
 	if err != nil {
 		return 0, err
 	}
 
-	return total + lastToNext.DurationSecs - prevToNext.DurationSecs, nil
+	return after - before, nil
 }
 
 func PopulateRouteMetrics(ctx context.Context, distanceCalc distance.DistanceCalculator, instituteCoords models.Coordinates, mode RouteMode, route *models.CalculatedRoute) error {
@@ -323,12 +309,42 @@ func (rc routeContext) twoOptDistance(ctx context.Context, driver *models.Driver
 	})
 }
 
-func (rc routeContext) twoOptDuration(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
-	return twoOptByDelta(stops, func(candidate []*models.Participant, i, j int) (float64, error) {
-		return rc.twoOptDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
-			return result.DurationSecs
-		})
-	})
+func (rc routeContext) twoOptRiderScore(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
+	blocks := routeHouseholdBlocks(stops)
+	if len(blocks) < 2 {
+		return stops, nil
+	}
+
+	currentBlocks := append([]*participantGroup(nil), blocks...)
+	currentStops := flattenParticipantGroups(currentBlocks)
+	currentScore, err := rc.riderScore(ctx, driver, currentStops)
+	if err != nil {
+		return nil, err
+	}
+
+	improved := true
+	for improved {
+		improved = false
+		for i := 0; i < len(currentBlocks)-1; i++ {
+			for j := i + 2; j <= len(currentBlocks); j++ {
+				candidateBlocks := append([]*participantGroup(nil), currentBlocks...)
+				reverseGroups(candidateBlocks, i, j-1)
+				candidateStops := flattenParticipantGroups(candidateBlocks)
+				candidateScore, err := rc.riderScore(ctx, driver, candidateStops)
+				if err != nil {
+					return nil, err
+				}
+				if candidateScore < currentScore-scoreImprovementEpsilon {
+					currentBlocks = candidateBlocks
+					currentStops = candidateStops
+					currentScore = candidateScore
+					improved = true
+				}
+			}
+		}
+	}
+
+	return currentStops, nil
 }
 
 func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, stops []*models.Participant, i, j int, selector func(*distance.DistanceResult) float64) (float64, error) {

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -160,40 +160,6 @@ func (rc routeContext) objectiveIncludesTerminal() bool {
 	return rc.mode == RouteModePickup
 }
 
-func (rc routeContext) objectiveCost(ctx context.Context, driver *models.Driver, stops []*models.Participant, selector func(*distance.DistanceResult) float64) (float64, error) {
-	if driver == nil {
-		return 0, fmt.Errorf("route driver is required")
-	}
-	if len(stops) == 0 {
-		return 0, nil
-	}
-
-	total := 0.0
-	prev := rc.origin(driver)
-	for i, stop := range stops {
-		if stop == nil {
-			return 0, fmt.Errorf("route stop %d is missing participant data", i)
-		}
-
-		dist, err := rc.distanceCalc.GetDistance(ctx, prev, stop.GetCoords())
-		if err != nil {
-			return 0, err
-		}
-		total += selector(dist)
-		prev = stop.GetCoords()
-	}
-
-	if rc.objectiveIncludesTerminal() {
-		dist, err := rc.distanceCalc.GetDistance(ctx, prev, rc.destination(driver))
-		if err != nil {
-			return 0, err
-		}
-		total += selector(dist)
-	}
-
-	return total, nil
-}
-
 func (rc routeContext) insertionDeltaDistance(ctx context.Context, driver *models.Driver, stops []*models.Participant, participant *models.Participant, pos int) (float64, error) {
 	return rc.insertionDelta(ctx, driver, stops, participant, pos, func(result *distance.DistanceResult) float64 {
 		return result.DistanceMeters
@@ -317,44 +283,6 @@ func (rc routeContext) twoOptDistance(ctx context.Context, driver *models.Driver
 			return result.DistanceMeters
 		})
 	})
-}
-
-func (rc routeContext) twoOptRiderScore(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
-	blocks := routeHouseholdBlocks(stops)
-	if len(blocks) < 2 {
-		return stops, nil
-	}
-
-	currentBlocks := append([]*participantGroup(nil), blocks...)
-	currentStops := flattenParticipantGroups(currentBlocks)
-	currentScore, err := rc.riderScore(ctx, driver, currentStops)
-	if err != nil {
-		return nil, err
-	}
-
-	improved := true
-	for improved {
-		improved = false
-		for i := 0; i < len(currentBlocks)-1; i++ {
-			for j := i + 2; j <= len(currentBlocks); j++ {
-				candidateBlocks := append([]*participantGroup(nil), currentBlocks...)
-				reverseGroups(candidateBlocks, i, j-1)
-				candidateStops := flattenParticipantGroups(candidateBlocks)
-				candidateScore, err := rc.riderScore(ctx, driver, candidateStops)
-				if err != nil {
-					return nil, err
-				}
-				if candidateScore < currentScore-scoreImprovementEpsilon {
-					currentBlocks = candidateBlocks
-					currentStops = candidateStops
-					currentScore = candidateScore
-					improved = true
-				}
-			}
-		}
-	}
-
-	return currentStops, nil
 }
 
 func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -61,6 +61,96 @@ func (c *countingDistanceCalculator) GetDistance(ctx context.Context, origin, de
 	return c.stableDistanceCalculator.GetDistance(ctx, origin, dest)
 }
 
+func TestRouteContextRiderScoreWeightsCumulativeStopTimes(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   RouteMode
+		driver *models.Driver
+		want   float64
+	}{
+		{
+			name:   "dropoff uses cumulative home arrival time",
+			mode:   RouteModeDropoff,
+			driver: &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0, VehicleCapacity: 3},
+			want:   5000,
+		},
+		{
+			name:   "pickup uses cumulative pickup time",
+			mode:   RouteModePickup,
+			driver: &models.Driver{ID: 1, Name: "Driver", Lat: 0, Lng: 0, VehicleCapacity: 3},
+			want:   5000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := newRouteContext(stableDistanceCalculator{}, models.Coordinates{Lat: 0, Lng: 0}, tt.mode)
+			stops := []*models.Participant{
+				{ID: 1, Name: "Sibling A", Lat: 1, Lng: 0},
+				{ID: 2, Name: "Sibling B", Lat: 1, Lng: 0},
+				{ID: 3, Name: "Farther", Lat: 3, Lng: 0},
+			}
+
+			got, err := rc.riderScore(context.Background(), tt.driver, stops)
+			if err != nil {
+				t.Fatalf("riderScore() error = %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("riderScore() = %.0f, want %.0f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupInsertionDeltaRiderScorePrefersEarlierDropoff(t *testing.T) {
+	rc := newRouteContext(stableDistanceCalculator{}, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
+	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 20, Lng: 0, VehicleCapacity: 2}
+	stops := []*models.Participant{
+		{ID: 1, Name: "Far", Lat: 10, Lng: 0},
+	}
+	group := &participantGroup{
+		members: []*models.Participant{{ID: 2, Name: "Near", Lat: 1, Lng: 0}},
+	}
+
+	startDelta, err := rc.groupInsertionDeltaRiderScore(context.Background(), driver, stops, group, 0)
+	if err != nil {
+		t.Fatalf("start delta error = %v", err)
+	}
+	endDelta, err := rc.groupInsertionDeltaRiderScore(context.Background(), driver, stops, group, 1)
+	if err != nil {
+		t.Fatalf("end delta error = %v", err)
+	}
+
+	if startDelta >= endDelta {
+		t.Fatalf("start delta %.0f should be less than end delta %.0f", startDelta, endDelta)
+	}
+}
+
+func TestGroupInsertionDeltaRiderScorePrefersEarlierPickup(t *testing.T) {
+	rc := newRouteContext(stableDistanceCalculator{}, models.Coordinates{Lat: 20, Lng: 0}, RouteModePickup)
+	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 0, Lng: 0, VehicleCapacity: 2}
+	stops := []*models.Participant{
+		{ID: 1, Name: "Far", Lat: 10, Lng: 0},
+	}
+	group := &participantGroup{
+		members: []*models.Participant{{ID: 2, Name: "Near", Lat: 1, Lng: 0}},
+	}
+
+	startDelta, err := rc.groupInsertionDeltaRiderScore(context.Background(), driver, stops, group, 0)
+	if err != nil {
+		t.Fatalf("start delta error = %v", err)
+	}
+	endDelta, err := rc.groupInsertionDeltaRiderScore(context.Background(), driver, stops, group, 1)
+	if err != nil {
+		t.Fatalf("end delta error = %v", err)
+	}
+
+	if startDelta >= endDelta {
+		t.Fatalf("start delta %.0f should be less than end delta %.0f", startDelta, endDelta)
+	}
+}
+
 func TestInsertionDeltaDistance_DropoffInsertAtEndPreservesLegacyBehavior(t *testing.T) {
 	rc := newRouteContext(stableDistanceCalculator{}, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
 	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0}

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -242,6 +242,30 @@ func TestPopulateRouteMetrics_PickupIncludesActivityDestination(t *testing.T) {
 	}
 }
 
+func TestOptimizeRouteOrder_ReordersAndRefreshesMetrics(t *testing.T) {
+	route := &models.CalculatedRoute{
+		Driver: &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0},
+		Stops: []models.RouteStop{
+			{Participant: &models.Participant{ID: 1, Name: "Destination Side", Lat: 9, Lng: 0}},
+			{Participant: &models.Participant{ID: 2, Name: "Origin Detour", Lat: 1, Lng: 100}},
+		},
+	}
+
+	if err := OptimizeRouteOrder(context.Background(), stableDistanceCalculator{}, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff, route); err != nil {
+		t.Fatalf("OptimizeRouteOrder() error = %v", err)
+	}
+
+	if route.Stops[0].Participant.Name != "Origin Detour" {
+		t.Fatalf("first stop = %q, want Origin Detour", route.Stops[0].Participant.Name)
+	}
+	if route.Stops[0].Order != 0 || route.Stops[1].Order != 1 {
+		t.Fatalf("orders = [%d %d], want [0 1]", route.Stops[0].Order, route.Stops[1].Order)
+	}
+	if route.TotalDistanceMeters == 0 || route.RouteDurationSecs == 0 {
+		t.Fatalf("route metrics were not refreshed: total=%.0f duration=%.0f", route.TotalDistanceMeters, route.RouteDurationSecs)
+	}
+}
+
 func TestBalancedRouterCalculateRouteDuration_PickupIncludesActivityLeg(t *testing.T) {
 	calc := stableDistanceCalculator{}
 	router := &BalancedRouter{distanceCalc: calc}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,7 +82,13 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	geocoder := geocoding.NewNominatimGeocoder()
-	distanceCalc := distance.NewOSRMCalculator(db.DistanceCache())
+	distanceCalc := distance.NewGoogleCalculator(db.DistanceCache(), func() (string, error) {
+		config, err := database.LoadConfig()
+		if err != nil {
+			return "", err
+		}
+		return config.GoogleMapsAPIKey, nil
+	})
 	router := routing.NewBalancedRouter(distanceCalc)
 	routeSession := handlers.NewRouteSessionStore()
 
@@ -282,6 +288,7 @@ func setupRoutes(handler *handlers.Handler, staticFS fs.FS) *http.ServeMux {
 	mux.HandleFunc("/api/v1/open-url", requireMethod(http.MethodPost, handleOpenURL))
 	mux.HandleFunc("/api/v1/settings", handleMethods(handler.HandleGetSettings, nil, handler.HandleUpdateSettings, nil))
 	mux.HandleFunc("/api/v1/config/database", handleMethods(handler.HandleGetDatabaseConfig, nil, handler.HandleUpdateDatabaseConfig, nil))
+	mux.HandleFunc("/api/v1/config/routing-provider", handleMethods(handler.HandleGetRoutingProviderConfig, nil, handler.HandleUpdateRoutingProviderConfig, nil))
 	mux.HandleFunc("/api/v1/participants", handleMethods(handler.HandleListParticipants, handler.HandleCreateParticipant, nil, nil))
 	mux.HandleFunc("/api/v1/participants/new", requireMethod(http.MethodGet, handler.HandleParticipantForm))
 	mux.HandleFunc("/api/v1/participants/", handleResourcePath("/api/v1/participants/", "/edit", handler.HandleParticipantForm, handler.HandleGetParticipant, handler.HandleUpdateParticipant, handler.HandleDeleteParticipant))

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -41,6 +41,39 @@
 </div>
 
 <div class="card">
+    <h3>Routing Provider</h3>
+    <p class="text-muted">Google Routes is used for route distance and duration calculations.</p>
+
+    <form id="routing-provider-form"
+          hx-put="/api/v1/config/routing-provider"
+          hx-swap="none"
+          hx-indicator="#routing-provider-loading">
+        <div class="form-group">
+            <label class="form-label">Google Maps API Key</label>
+            <input type="password"
+                   name="google_maps_api_key"
+                   id="google-maps-api-key-input"
+                   class="form-input"
+                   autocomplete="off"
+                   placeholder="{{if .RoutingProviderConfig.GoogleMapsAPIKeyConfigured}}Key configured{{else}}Paste API key{{end}}">
+            <div class="form-help">
+                Status:
+                <strong id="google-maps-key-status">{{if .RoutingProviderConfig.GoogleMapsAPIKeyConfigured}}Configured{{else}}Not configured{{end}}</strong>
+                <br>
+                <small>Saving a new key clears cached distances.</small>
+            </div>
+        </div>
+
+        <div class="d-flex align-center gap-2">
+            <button type="submit" class="btn btn-primary">
+                Save API Key
+            </button>
+            <span class="loading htmx-indicator" id="routing-provider-loading"></span>
+        </div>
+    </form>
+</div>
+
+<div class="card">
     <h3>Database Storage</h3>
     <p class="text-muted">Configure where your data is stored. You can point this to a cloud-synced folder (like Dropbox or iCloud) for automatic backups.</p>
 

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -40,14 +40,15 @@
     </form>
 </div>
 
-<div class="card">
+<div class="card" id="routing-provider-card">
     <h3>Routing Provider</h3>
     <p class="text-muted">Google Routes is used for route distance and duration calculations.</p>
 
     <form id="routing-provider-form"
           hx-put="/api/v1/config/routing-provider"
           hx-swap="none"
-          hx-indicator="#routing-provider-loading">
+          hx-indicator="#routing-provider-loading"
+          hx-on::after-request="if(event.detail.successful && document.getElementById('google-maps-api-key-input').value.trim() !== '') { document.getElementById('google-maps-key-status').textContent = 'Configured'; document.getElementById('google-maps-api-key-input').value = ''; document.getElementById('google-maps-api-key-input').placeholder = 'Key configured'; }">
         <div class="form-group">
             <label class="form-label">Google Maps API Key</label>
             <input type="password"


### PR DESCRIPTION
### Problem

The default router optimized mostly around route duration and load balancing, which could leave riders sitting longer than necessary and could split households whenever a current vehicle was full even if another selected vehicle could fit the household. Normal distance calculation also depended on the public OSRM demo endpoint, which was returning 502s and was not reliable for production use.

### Changes

- Added rider-score based routing helpers for cumulative dropoff arrival time and cumulative pickup time.
- Changed initial route insertion to choose positions by rider-score impact instead of simple route-duration delta.
- Updated route-local optimization to compare exact rider-score recomputes over household blocks.
- Preserved households when any selected effective vehicle capacity can fit them; split only when no selected vehicle can fit the whole household.
- Gated min-max balancing behind route-duration guardrails.
- Replaced the active distance provider with Google Routes Compute Route Matrix.
- Added Settings support for saving a Google Maps API key without rendering the saved key back to the browser.
- Clear the distance cache when a non-empty Google key is saved.
- Added provider-level errors for missing Google configuration instead of generic calculation failures.
- Batched Google matrix calls under the 625 route-element limit and reused the existing cache table.
- Added routing, distance provider, server, database, and settings handler tests.

### Decisions

- Google replaces OSRM for normal distance/duration calculations on this branch.
- OSRM remains only as unwired legacy code.
- The Google Maps API key is stored in `~/.ride-home-router/config.json` as `google_maps_api_key`.
- Google requests use static/non-traffic duration calculations with `TRAFFIC_UNAWARE`.
- Vans remain capacity-only and continue to flow through existing driver capacity substitution.
- Ar explicitly waived the repo ticket-ID commit-message rule for this branch.

### Testing

- `go test ./internal/distance ./internal/database ./internal/server ./internal/handlers ./internal/routing`
- `make test`
- `make lint`

<details>
<summary>Agent Context</summary>

Implementation contract source: `_scratch/_contracts/aryan-binazir/route-optimize.md`.

The implementation intentionally keeps the existing `BalancedRouter` shape instead of introducing a second router. The main behavioral change is the routing objective used for insertion and route-local optimization: cumulative rider score replaces simple duration delta. Dropoff score means earlier home arrival; pickup score means earlier pickup time. Min-max balancing is still duration-based, but now only runs when the longest route exceeds the configured guardrails.

The distance provider change keeps the existing `DistanceCalculator` interface and cache table. Google Routes Compute Route Matrix is wired as the active provider in `internal/server/server.go`, with the API key loaded lazily from the config file at calculation time. Settings can save a key, but only display configured/not configured state. Saving a non-empty key clears `distance_cache` immediately so OSRM-derived values do not leak into Google-backed routing.

Review fallback note: Claude CLI review was attempted but blocked by usage limit, so the final review loop used detached Codex exec review passes. All Codex findings were patched before final validation.

</details>
