### PR TITLE
feat(add-labels): add reusable labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ A desktop app that optimizes driver assignments for getting people home after ev
 - [Features](#features)
 - [Privacy First](#privacy-first)
 - [Installation](#installation)
+- [Google Routes API Setup](#google-routes-api-setup)
 - [Usage](#usage)
 - [Technical Details](#technical-details)
-- [Rate Limiting](#rate-limiting)
+- [API Usage & Limits](#api-usage--limits)
 - [Disclaimer](#disclaimer)
 - [Contributing](#contributing)
 - [License](#license)
@@ -42,6 +43,7 @@ Manually figuring out who goes with whom is tedious and often results in unfair 
 - **Capacity Aware** — Respects each driver's vehicle capacity
 - **Van Support** — Save shared vans and assign them to drivers during planning when personal vehicles are not enough
 - **Address Autocomplete** — Search and select addresses with live suggestions from OpenStreetMap
+- **Google Drive-Time Routing** — Uses Google Routes for route distance and duration calculations
 - **Multiple Activity Locations** — Save different starting points (office, place of worship, school, etc.)
 - **Event History** — Keep records of past events for reference
 - **Manual Adjustments** — Move participants between routes or swap drivers after calculation
@@ -52,13 +54,13 @@ Manually figuring out who goes with whom is tedious and often results in unfair 
 
 ## Privacy First
 
-**All your data stays on your computer.** Names, addresses, and event history are stored locally in `~/.ride-home-router/`.
+**Persistent app data stays on your computer.** Names, addresses, API configuration, and event history are stored locally in `~/.ride-home-router/`. During route calculation, coordinates are sent to Google Routes; during address search, the search text is sent to Nominatim.
 
 The only external services used are:
-- **OSRM** — Open source routing service (calculates driving distances between coordinates)
+- **Google Routes API** — Calculates driving distances and durations between coordinates. Route calculation requires a Google Maps API key saved in Settings.
 - **Nominatim** — OpenStreetMap geocoder (converts addresses to coordinates)
 
-No accounts. No cloud sync. No tracking.
+No Ride Home Router account. No cloud sync. No tracking.
 
 ---
 
@@ -124,6 +126,22 @@ sudo dnf install gtk3-devel webkit2gtk4.0-devel
 
 ---
 
+## Google Routes API Setup
+
+Route calculation now uses Google's Routes API instead of the public OSRM demo server. Address search still uses Nominatim/OpenStreetMap.
+
+Before calculating routes:
+
+1. Create or choose a Google Cloud project.
+2. Enable the **Routes API** for that project.
+3. Create a Google Maps API key with permission to call the Routes API.
+4. Open **Settings** in Ride Home Router.
+5. Paste the key under **Routing Provider** and click **Save API Key**.
+
+The key is stored in `~/.ride-home-router/config.json` as `google_maps_api_key`. Saving a new key clears cached distances so future route calculations use the new provider credentials. If no key is configured, route calculation fails with a Settings prompt; address autocomplete still works.
+
+---
+
 ## Usage
 
 ### Quick Start
@@ -132,7 +150,8 @@ sudo dnf install gtk3-devel webkit2gtk4.0-devel
 2. **Add Participants** — People who need rides
 3. **Add Drivers** — People with vehicles, including their capacity
 4. **Add Vans** (Optional) — Save shared vans on the Vans page for overflow events
-5. **Calculate Routes** — Select participants, drivers, activity location, optional van assignments, and mode, then click Calculate
+5. **Configure Google Routes** — Add a Google Maps API key in Settings before the first route calculation
+6. **Calculate Routes** — Select participants, drivers, activity location, optional van assignments, and mode, then click Calculate
 
 ### Workflow
 
@@ -182,7 +201,7 @@ ride-home-router/
 │   ├── sqlite/          # SQLite storage implementation
 │   ├── handlers/        # HTTP request handlers
 │   ├── routing/         # Route optimization algorithms
-│   ├── distance/        # OSRM API client
+│   ├── distance/        # Google Routes distance provider and legacy OSRM client
 │   ├── geocoding/       # Nominatim API client
 │   ├── httpx/           # HTTP constants and helpers
 │   ├── templateutil/    # Shared template helper functions
@@ -202,7 +221,7 @@ ride-home-router/
 - **Frontend**: HTML templates + [HTMX](https://htmx.org/) for dynamic updates
 - **Desktop**: [Wails v2](https://wails.io/) (Go + WebView)
 - **Storage**: SQLite database in `~/.ride-home-router/`
-- **Routing**: OSRM public API
+- **Routing**: Google Routes API `computeRouteMatrix`
 - **Geocoding**: Nominatim (OpenStreetMap)
 
 ### Development
@@ -227,20 +246,21 @@ All data is stored in `~/.ride-home-router/`:
 
 ```
 ~/.ride-home-router/
+├── config.json            # App config, including database path and Google Maps API key
 └── data.db                # SQLite database (participants, drivers, settings, events, distance cache)
 ```
 
 ---
 
-## Rate Limiting
+## API Usage & Limits
 
-This app uses public APIs that have usage limits:
+This app uses external APIs that have usage limits:
 
-- **OSRM (Open Source Routing Machine)**: The public demo server at `router.project-osrm.org` is provided for light use only. For heavy usage or production deployments, consider [running your own OSRM instance](https://github.com/Project-OSRM/osrm-backend).
+- **Google Routes API**: Route distance and duration calculations use `routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix`. Google Cloud billing, quotas, and API key restrictions apply. The app caches distance results in SQLite and batches route matrix calls up to 625 elements per request.
 
 - **Nominatim (OpenStreetMap Geocoding)**: The public Nominatim service has a [usage policy](https://operations.osmfoundation.org/policies/nominatim/) limiting requests to 1 per second. The app includes built-in delays to respect this limit.
 
-For typical community group usage (under 150 participants per event), the public APIs should work fine. If you experience slow responses or errors, it may be due to rate limiting—try waiting a few minutes before retrying.
+For typical community group usage, address search should stay within Nominatim's public limits. Route calculation depends on your Google Cloud quota and billing configuration. If route calculation fails, first verify the API key in Settings, that the Routes API is enabled, and that the key is allowed to call it.
 
 ---
 
@@ -250,7 +270,7 @@ For typical community group usage (under 150 participants per event), the public
 
 - **Driver vetting**: This software only calculates routes—it does not screen or verify drivers. You are solely responsible for vetting all drivers, including performing background checks as appropriate for your organization.
 - **Route accuracy**: Route suggestions are approximations based on heuristic algorithms. They may not be optimal, accurate, or safe. Always verify addresses and routes before driving.
-- **Third-party services**: This tool relies on OSRM and Nominatim (OpenStreetMap) for routing and geocoding. Accuracy and availability depend on these external services, which are outside our control.
+- **Third-party services**: This tool relies on Google Routes and Nominatim (OpenStreetMap) for routing and geocoding. Accuracy, availability, quotas, and costs depend on these external services, which are outside our control.
 - **Data security**: While data is stored locally on your computer, we make no guarantees about data protection or security. You are responsible for securing your own device and backups.
 - **No liability**: The developers are not responsible for any damages, losses, injuries, data breaches, or incidents arising from use of this software or the transportation it helps coordinate.
 

--- a/internal/database/interfaces.go
+++ b/internal/database/interfaces.go
@@ -17,6 +17,7 @@ type DataStore interface {
 	OrganizationVehicles() OrganizationVehicleRepository
 	Events() EventRepository
 	DistanceCache() DistanceCacheRepository
+	Labels() LabelRepository
 }
 
 // ParticipantRepository handles participant persistence
@@ -37,6 +38,25 @@ type DriverRepository interface {
 	Create(ctx context.Context, d *models.Driver) (*models.Driver, error)
 	Update(ctx context.Context, d *models.Driver) (*models.Driver, error)
 	Delete(ctx context.Context, id int64) error
+}
+
+// LabelRepository handles label persistence and memberships.
+type LabelRepository interface {
+	List(ctx context.Context) ([]models.Label, error)
+	GetByID(ctx context.Context, id int64) (*models.Label, error)
+	Create(ctx context.Context, label *models.Label) (*models.Label, error)
+	Update(ctx context.Context, label *models.Label) (*models.Label, error)
+	Delete(ctx context.Context, id int64) error
+	ListLabelsForParticipant(ctx context.Context, participantID int64) ([]models.Label, error)
+	ListLabelsForDriver(ctx context.Context, driverID int64) ([]models.Label, error)
+	SetLabelsForParticipant(ctx context.Context, participantID int64, labelIDs []int64) error
+	SetLabelsForDriver(ctx context.Context, driverID int64, labelIDs []int64) error
+	AddLabelToParticipants(ctx context.Context, labelID int64, participantIDs []int64) error
+	RemoveLabelFromParticipants(ctx context.Context, labelID int64, participantIDs []int64) error
+	AddLabelToDrivers(ctx context.Context, labelID int64, driverIDs []int64) error
+	RemoveLabelFromDrivers(ctx context.Context, labelID int64, driverIDs []int64) error
+	ListLabelIDsForParticipants(ctx context.Context) (map[int64][]int64, error)
+	ListLabelIDsForDrivers(ctx context.Context) (map[int64][]int64, error)
 }
 
 // SettingsRepository handles settings persistence

--- a/internal/database/interfaces.go
+++ b/internal/database/interfaces.go
@@ -26,7 +26,9 @@ type ParticipantRepository interface {
 	GetByID(ctx context.Context, id int64) (*models.Participant, error)
 	GetByIDs(ctx context.Context, ids []int64) ([]models.Participant, error)
 	Create(ctx context.Context, p *models.Participant) (*models.Participant, error)
+	CreateWithLabels(ctx context.Context, p *models.Participant, labelIDs []int64) (*models.Participant, error)
 	Update(ctx context.Context, p *models.Participant) (*models.Participant, error)
+	UpdateWithLabels(ctx context.Context, p *models.Participant, labelIDs []int64) (*models.Participant, error)
 	Delete(ctx context.Context, id int64) error
 }
 
@@ -36,7 +38,9 @@ type DriverRepository interface {
 	GetByID(ctx context.Context, id int64) (*models.Driver, error)
 	GetByIDs(ctx context.Context, ids []int64) ([]models.Driver, error)
 	Create(ctx context.Context, d *models.Driver) (*models.Driver, error)
+	CreateWithLabels(ctx context.Context, d *models.Driver, labelIDs []int64) (*models.Driver, error)
 	Update(ctx context.Context, d *models.Driver) (*models.Driver, error)
+	UpdateWithLabels(ctx context.Context, d *models.Driver, labelIDs []int64) (*models.Driver, error)
 	Delete(ctx context.Context, id int64) error
 }
 
@@ -44,6 +48,7 @@ type DriverRepository interface {
 type LabelRepository interface {
 	List(ctx context.Context) ([]models.Label, error)
 	GetByID(ctx context.Context, id int64) (*models.Label, error)
+	GetByIDs(ctx context.Context, ids []int64) ([]models.Label, error)
 	Create(ctx context.Context, label *models.Label) (*models.Label, error)
 	Update(ctx context.Context, label *models.Label) (*models.Label, error)
 	Delete(ctx context.Context, id int64) error

--- a/internal/handlers/drivers.go
+++ b/internal/handlers/drivers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -13,8 +14,14 @@ import (
 
 // DriverListResponse represents the list response
 type DriverListResponse struct {
-	Drivers []models.Driver `json:"drivers"`
-	Total   int             `json:"total"`
+	Drivers []DriverResponse `json:"drivers"`
+	Total   int              `json:"total"`
+}
+
+// DriverResponse represents a driver API response.
+type DriverResponse struct {
+	models.Driver
+	LabelIDs []int64 `json:"label_ids"`
 }
 
 // HandleListDrivers handles GET /api/v1/drivers
@@ -44,8 +51,15 @@ func (h *Handler) HandleListDrivers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	responseDrivers, err := h.driverResponses(r.Context(), drivers)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load driver labels for list: err=%v", err)
+		h.handleInternalError(w, err)
+		return
+	}
+
 	h.writeJSON(w, http.StatusOK, DriverListResponse{
-		Drivers: drivers,
+		Drivers: responseDrivers,
 		Total:   len(drivers),
 	})
 }
@@ -74,7 +88,14 @@ func (h *Handler) HandleGetDriver(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, driver)
+	response, err := h.driverResponse(r.Context(), driver)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load driver labels: id=%d err=%v", driver.ID, err)
+		h.handleInternalError(w, err)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
 }
 
 // HandleCreateDriver handles POST /api/v1/drivers
@@ -164,7 +185,7 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 		VehicleCapacity: req.VehicleCapacity,
 	}
 
-	driver, err = h.DB.Drivers().Create(r.Context(), driver)
+	driver, err = h.DB.Drivers().CreateWithLabels(r.Context(), driver, labelIDs)
 	if err != nil {
 		log.Printf("[ERROR] Failed to create driver: name=%s err=%v", req.Name, err)
 		if h.isHTMX(r) {
@@ -176,15 +197,6 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[HTTP] Created driver: id=%d name=%s", driver.ID, driver.Name)
-	if err := h.DB.Labels().SetLabelsForDriver(r.Context(), driver.ID, labelIDs); err != nil {
-		log.Printf("[ERROR] Failed to set driver labels: id=%d err=%v", driver.ID, err)
-		if h.isHTMX(r) {
-			h.renderError(w, r, err)
-			return
-		}
-		h.handleInternalError(w, err)
-		return
-	}
 	if h.isHTMX(r) {
 		drivers, err := h.DB.Drivers().List(r.Context(), "")
 		if err != nil {
@@ -202,7 +214,14 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeJSON(w, http.StatusCreated, driver)
+	response, err := h.driverResponse(r.Context(), driver)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load driver labels after create: id=%d err=%v", driver.ID, err)
+		h.handleInternalError(w, err)
+		return
+	}
+
+	h.writeJSON(w, http.StatusCreated, response)
 }
 
 // HandleUpdateDriver handles PUT /api/v1/drivers/{id}
@@ -337,7 +356,11 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 		driver.Lng = geocodeResult.Coords.Lng
 	}
 
-	driver, err = h.DB.Drivers().Update(r.Context(), driver)
+	if shouldSetLabels {
+		driver, err = h.DB.Drivers().UpdateWithLabels(r.Context(), driver, labelIDs)
+	} else {
+		driver, err = h.DB.Drivers().Update(r.Context(), driver)
+	}
 	if err != nil {
 		log.Printf("[ERROR] Failed to update driver: id=%d err=%v", id, err)
 		if h.isHTMX(r) {
@@ -359,17 +382,6 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[HTTP] Updated driver: id=%d name=%s", driver.ID, driver.Name)
-	if shouldSetLabels {
-		if err := h.DB.Labels().SetLabelsForDriver(r.Context(), driver.ID, labelIDs); err != nil {
-			log.Printf("[ERROR] Failed to set driver labels: id=%d err=%v", driver.ID, err)
-			if h.isHTMX(r) {
-				h.renderError(w, r, err)
-				return
-			}
-			h.handleInternalError(w, err)
-			return
-		}
-	}
 	if h.isHTMX(r) {
 		drivers, err := h.DB.Drivers().List(r.Context(), "")
 		if err != nil {
@@ -387,7 +399,14 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, driver)
+	response, err := h.driverResponse(r.Context(), driver)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load driver labels after update: id=%d err=%v", driver.ID, err)
+		h.handleInternalError(w, err)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
 }
 
 // HandleDeleteDriver handles DELETE /api/v1/drivers/{id}
@@ -510,4 +529,39 @@ func (h *Handler) loadLabelsForDriver(r *http.Request, driverID int64) ([]models
 		return nil, nil, err
 	}
 	return labels, buildSelectedLabelIDMap(selectedLabels), nil
+}
+
+func (h *Handler) driverResponse(ctx context.Context, driver *models.Driver) (DriverResponse, error) {
+	labels, err := h.DB.Labels().ListLabelsForDriver(ctx, driver.ID)
+	if err != nil {
+		return DriverResponse{}, err
+	}
+	labelIDs := make([]int64, 0, len(labels))
+	for _, label := range labels {
+		labelIDs = append(labelIDs, label.ID)
+	}
+	return DriverResponse{
+		Driver:   *driver,
+		LabelIDs: labelIDs,
+	}, nil
+}
+
+func (h *Handler) driverResponses(ctx context.Context, drivers []models.Driver) ([]DriverResponse, error) {
+	labelIDsByDriver, err := h.DB.Labels().ListLabelIDsForDrivers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]DriverResponse, 0, len(drivers))
+	for _, driver := range drivers {
+		labelIDs := append([]int64{}, labelIDsByDriver[driver.ID]...)
+		if labelIDs == nil {
+			labelIDs = []int64{}
+		}
+		responses = append(responses, DriverResponse{
+			Driver:   driver,
+			LabelIDs: labelIDs,
+		})
+	}
+	return responses, nil
 }

--- a/internal/handlers/drivers.go
+++ b/internal/handlers/drivers.go
@@ -233,12 +233,13 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name            string  `json:"name"`
-		Address         string  `json:"address"`
-		VehicleCapacity int     `json:"vehicle_capacity"`
-		LabelIDs        []int64 `json:"label_ids"`
+		Name            string   `json:"name"`
+		Address         string   `json:"address"`
+		VehicleCapacity int      `json:"vehicle_capacity"`
+		LabelIDs        *[]int64 `json:"label_ids"`
 	}
 	var labelIDs []int64
+	shouldSetLabels := false
 
 	if h.isHTMX(r) {
 		if err := r.ParseForm(); err != nil {
@@ -262,12 +263,16 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		labelIDs = parsedLabelIDs
+		shouldSetLabels = true
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			h.handleValidationError(w, messageInvalidRequestBody)
 			return
 		}
-		labelIDs = req.LabelIDs
+		if req.LabelIDs != nil {
+			labelIDs = *req.LabelIDs
+			shouldSetLabels = true
+		}
 	}
 
 	if req.Name == "" || req.Address == "" {
@@ -334,14 +339,16 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[HTTP] Updated driver: id=%d name=%s", driver.ID, driver.Name)
-	if err := h.DB.Labels().SetLabelsForDriver(r.Context(), driver.ID, labelIDs); err != nil {
-		log.Printf("[ERROR] Failed to set driver labels: id=%d err=%v", driver.ID, err)
-		if h.isHTMX(r) {
-			h.renderError(w, r, err)
+	if shouldSetLabels {
+		if err := h.DB.Labels().SetLabelsForDriver(r.Context(), driver.ID, labelIDs); err != nil {
+			log.Printf("[ERROR] Failed to set driver labels: id=%d err=%v", driver.ID, err)
+			if h.isHTMX(r) {
+				h.renderError(w, r, err)
+				return
+			}
+			h.handleInternalError(w, err)
 			return
 		}
-		h.handleInternalError(w, err)
-		return
 	}
 	if h.isHTMX(r) {
 		drivers, err := h.DB.Drivers().List(r.Context(), "")

--- a/internal/handlers/drivers.go
+++ b/internal/handlers/drivers.go
@@ -35,7 +35,12 @@ func (h *Handler) HandleListDrivers(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[HTTP] Listed drivers: count=%d", len(drivers))
 	if h.isHTMX(r) {
-		h.renderTemplate(w, "driver_list", DriverListView{Drivers: drivers})
+		view, err := h.driverListView(r, drivers)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		h.renderTemplate(w, "driver_list", view)
 		return
 	}
 
@@ -75,10 +80,12 @@ func (h *Handler) HandleGetDriver(w http.ResponseWriter, r *http.Request) {
 // HandleCreateDriver handles POST /api/v1/drivers
 func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name            string `json:"name"`
-		Address         string `json:"address"`
-		VehicleCapacity int    `json:"vehicle_capacity"`
+		Name            string  `json:"name"`
+		Address         string  `json:"address"`
+		VehicleCapacity int     `json:"vehicle_capacity"`
+		LabelIDs        []int64 `json:"label_ids"`
 	}
+	var labelIDs []int64
 
 	if h.isHTMX(r) {
 		if err := r.ParseForm(); err != nil {
@@ -96,11 +103,18 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 			}
 			req.VehicleCapacity = capacity
 		}
+		parsedLabelIDs, err := parseLabelIDs(r)
+		if err != nil {
+			h.renderError(w, r, errors.New("Invalid label selection"))
+			return
+		}
+		labelIDs = parsedLabelIDs
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			h.handleValidationError(w, messageInvalidRequestBody)
 			return
 		}
+		labelIDs = req.LabelIDs
 	}
 
 	if req.Name == "" || req.Address == "" {
@@ -153,6 +167,15 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[HTTP] Created driver: id=%d name=%s", driver.ID, driver.Name)
+	if err := h.DB.Labels().SetLabelsForDriver(r.Context(), driver.ID, labelIDs); err != nil {
+		log.Printf("[ERROR] Failed to set driver labels: id=%d err=%v", driver.ID, err)
+		if h.isHTMX(r) {
+			h.renderError(w, r, err)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
 	if h.isHTMX(r) {
 		drivers, err := h.DB.Drivers().List(r.Context(), "")
 		if err != nil {
@@ -161,7 +184,12 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.setHTMXToastWithEvent(w, "driverCreated", messageEntityAdded("Driver", driver.Name), toastTypeSuccess)
-		h.renderTemplate(w, "driver_list", DriverListView{Drivers: drivers})
+		view, err := h.driverListView(r, drivers)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		h.renderTemplate(w, "driver_list", view)
 		return
 	}
 
@@ -205,10 +233,12 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name            string `json:"name"`
-		Address         string `json:"address"`
-		VehicleCapacity int    `json:"vehicle_capacity"`
+		Name            string  `json:"name"`
+		Address         string  `json:"address"`
+		VehicleCapacity int     `json:"vehicle_capacity"`
+		LabelIDs        []int64 `json:"label_ids"`
 	}
+	var labelIDs []int64
 
 	if h.isHTMX(r) {
 		if err := r.ParseForm(); err != nil {
@@ -226,11 +256,18 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 			}
 			req.VehicleCapacity = capacity
 		}
+		parsedLabelIDs, err := parseLabelIDs(r)
+		if err != nil {
+			h.renderError(w, r, errors.New("Invalid label selection"))
+			return
+		}
+		labelIDs = parsedLabelIDs
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			h.handleValidationError(w, messageInvalidRequestBody)
 			return
 		}
+		labelIDs = req.LabelIDs
 	}
 
 	if req.Name == "" || req.Address == "" {
@@ -297,6 +334,15 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[HTTP] Updated driver: id=%d name=%s", driver.ID, driver.Name)
+	if err := h.DB.Labels().SetLabelsForDriver(r.Context(), driver.ID, labelIDs); err != nil {
+		log.Printf("[ERROR] Failed to set driver labels: id=%d err=%v", driver.ID, err)
+		if h.isHTMX(r) {
+			h.renderError(w, r, err)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
 	if h.isHTMX(r) {
 		drivers, err := h.DB.Drivers().List(r.Context(), "")
 		if err != nil {
@@ -305,7 +351,12 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.setHTMXToastWithEvent(w, "driverUpdated", messageEntityUpdated("Driver", driver.Name), toastTypeSuccess)
-		h.renderTemplate(w, "driver_list", DriverListView{Drivers: drivers})
+		view, err := h.driverListView(r, drivers)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		h.renderTemplate(w, "driver_list", view)
 		return
 	}
 
@@ -363,6 +414,11 @@ func (h *Handler) HandleDriverForm(w http.ResponseWriter, r *http.Request) {
 	idStr = strings.TrimSuffix(idStr, "/edit")
 
 	var driver *models.Driver
+	var (
+		labels           []models.Label
+		selectedLabelIDs map[int64]bool
+		err              error
+	)
 	if idStr != "new" && idStr != "" {
 		id, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
@@ -379,9 +435,52 @@ func (h *Handler) HandleDriverForm(w http.ResponseWriter, r *http.Request) {
 			h.renderError(w, r, errors.New(messageDriverNotFound))
 			return
 		}
+		labels, selectedLabelIDs, err = h.loadLabelsForDriver(r, driver.ID)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
 	} else {
 		driver = &models.Driver{}
+		labels, err = h.DB.Labels().List(r.Context())
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		selectedLabelIDs = map[int64]bool{}
 	}
 
-	h.renderTemplate(w, "driver_form", DriverFormView{Driver: driver})
+	h.renderTemplate(w, "driver_form", DriverFormView{
+		Driver:           driver,
+		Labels:           labels,
+		SelectedLabelIDs: selectedLabelIDs,
+	})
+}
+
+func (h *Handler) driverListView(r *http.Request, drivers []models.Driver) (DriverListView, error) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		return DriverListView{}, err
+	}
+	labelIDs, err := h.DB.Labels().ListLabelIDsForDrivers(r.Context())
+	if err != nil {
+		return DriverListView{}, err
+	}
+	return DriverListView{
+		Drivers:  drivers,
+		Labels:   labels,
+		LabelIDs: labelIDs,
+	}, nil
+}
+
+func (h *Handler) loadLabelsForDriver(r *http.Request, driverID int64) ([]models.Label, map[int64]bool, error) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		return nil, nil, err
+	}
+	selectedLabels, err := h.DB.Labels().ListLabelsForDriver(r.Context(), driverID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return labels, buildSelectedLabelIDMap(selectedLabels), nil
 }

--- a/internal/handlers/drivers.go
+++ b/internal/handlers/drivers.go
@@ -134,6 +134,15 @@ func (h *Handler) HandleCreateDriver(w http.ResponseWriter, r *http.Request) {
 		h.handleValidationError(w, messageVehicleCapacityMustBeGreaterThanZero)
 		return
 	}
+	if err := h.validateLabelIDs(r.Context(), labelIDs); err != nil {
+		log.Printf("[HTTP] POST /api/v1/drivers: invalid_labels err=%v", err)
+		if h.isHTMX(r) {
+			h.renderError(w, r, errors.New(messageInvalidLabelSelection))
+			return
+		}
+		h.handleValidationError(w, messageInvalidLabelSelection)
+		return
+	}
 
 	log.Printf("[HTTP] POST /api/v1/drivers: name=%s address=%s capacity=%d", req.Name, req.Address, req.VehicleCapacity)
 	geocodeResult, err := h.Geocoder.GeocodeWithRetry(r.Context(), req.Address, 3)
@@ -291,6 +300,17 @@ func (h *Handler) HandleUpdateDriver(w http.ResponseWriter, r *http.Request) {
 		}
 		h.handleValidationError(w, messageVehicleCapacityMustBeGreaterThanZero)
 		return
+	}
+	if shouldSetLabels {
+		if err := h.validateLabelIDs(r.Context(), labelIDs); err != nil {
+			log.Printf("[HTTP] PUT /api/v1/drivers/{id}: invalid_labels id=%d err=%v", id, err)
+			if h.isHTMX(r) {
+				h.renderError(w, r, errors.New(messageInvalidLabelSelection))
+				return
+			}
+			h.handleValidationError(w, messageInvalidLabelSelection)
+			return
+		}
 	}
 
 	driver := &models.Driver{

--- a/internal/handlers/labels.go
+++ b/internal/handlers/labels.go
@@ -23,6 +23,11 @@ const (
 	messageSelectDriverForTag      = "Select at least one driver"
 )
 
+var (
+	errInvalidParticipantSelection = errors.New("invalid participant selection")
+	errInvalidDriverSelection      = errors.New("invalid driver selection")
+)
+
 type LabelListResponse struct {
 	Labels []models.Label `json:"labels"`
 	Total  int            `json:"total"`
@@ -264,6 +269,14 @@ func (h *Handler) handleBulkParticipantLabelMembership(w http.ResponseWriter, r 
 		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageSelectParticipantForTag)
 		return
 	}
+	if err := h.validateBulkParticipantIDs(r.Context(), participantIDs); err != nil {
+		if errors.Is(err, errInvalidParticipantSelection) {
+			h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid participant selection")
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
 
 	switch action {
 	case "add":
@@ -309,6 +322,14 @@ func (h *Handler) handleBulkDriverLabelMembership(w http.ResponseWriter, r *http
 	}
 	if len(driverIDs) == 0 {
 		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageSelectDriverForTag)
+		return
+	}
+	if err := h.validateBulkDriverIDs(r.Context(), driverIDs); err != nil {
+		if errors.Is(err, errInvalidDriverSelection) {
+			h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid driver selection")
+			return
+		}
+		h.handleInternalError(w, err)
 		return
 	}
 
@@ -431,25 +452,64 @@ func parseLabelIDs(r *http.Request) ([]int64, error) {
 }
 
 func (h *Handler) validateLabelIDs(ctx context.Context, labelIDs []int64) error {
-	seen := make(map[int64]struct{}, len(labelIDs))
-	for _, labelID := range labelIDs {
-		if labelID <= 0 {
-			return errors.New(messageInvalidLabelSelection)
-		}
-		if _, ok := seen[labelID]; ok {
-			continue
-		}
-		seen[labelID] = struct{}{}
-
-		label, err := h.DB.Labels().GetByID(ctx, labelID)
-		if err != nil {
-			return err
-		}
-		if label == nil {
-			return errors.New(messageInvalidLabelSelection)
-		}
+	uniqueIDs, ok := uniquePositiveIDs(labelIDs)
+	if !ok {
+		return errors.New(messageInvalidLabelSelection)
+	}
+	labels, err := h.DB.Labels().GetByIDs(ctx, uniqueIDs)
+	if err != nil {
+		return err
+	}
+	if len(labels) != len(uniqueIDs) {
+		return errors.New(messageInvalidLabelSelection)
 	}
 	return nil
+}
+
+func (h *Handler) validateBulkParticipantIDs(ctx context.Context, participantIDs []int64) error {
+	uniqueIDs, ok := uniquePositiveIDs(participantIDs)
+	if !ok {
+		return errInvalidParticipantSelection
+	}
+	participants, err := h.DB.Participants().GetByIDs(ctx, uniqueIDs)
+	if err != nil {
+		return err
+	}
+	if len(participants) != len(uniqueIDs) {
+		return errInvalidParticipantSelection
+	}
+	return nil
+}
+
+func (h *Handler) validateBulkDriverIDs(ctx context.Context, driverIDs []int64) error {
+	uniqueIDs, ok := uniquePositiveIDs(driverIDs)
+	if !ok {
+		return errInvalidDriverSelection
+	}
+	drivers, err := h.DB.Drivers().GetByIDs(ctx, uniqueIDs)
+	if err != nil {
+		return err
+	}
+	if len(drivers) != len(uniqueIDs) {
+		return errInvalidDriverSelection
+	}
+	return nil
+}
+
+func uniquePositiveIDs(ids []int64) ([]int64, bool) {
+	seen := make(map[int64]struct{}, len(ids))
+	uniqueIDs := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			return nil, false
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+	return uniqueIDs, true
 }
 
 func buildSelectedLabelIDMap(labels []models.Label) map[int64]bool {

--- a/internal/handlers/labels.go
+++ b/internal/handlers/labels.go
@@ -1,0 +1,445 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"ride-home-router/internal/models"
+)
+
+const (
+	messageLabelNameRequired       = "Label name is required"
+	messageLabelNotFound           = "Label not found"
+	messageDuplicateLabelName      = "A label with that name already exists"
+	messageChooseLabelFirst        = "Choose a label first"
+	messageInvalidLabelSelection   = "Invalid label selection"
+	messageSelectParticipantForTag = "Select at least one participant"
+	messageSelectDriverForTag      = "Select at least one driver"
+)
+
+type LabelListResponse struct {
+	Labels []models.Label `json:"labels"`
+	Total  int            `json:"total"`
+}
+
+func parseLabelID(path string) (int64, error) {
+	idStr := strings.TrimPrefix(path, "/api/v1/labels/")
+	idStr = strings.TrimSuffix(idStr, "/edit")
+	idStr = strings.Trim(idStr, "/")
+	if idStr == "" || strings.Contains(idStr, "/") {
+		return 0, fmt.Errorf("invalid label path")
+	}
+	return strconv.ParseInt(idStr, 10, 64)
+}
+
+func (h *Handler) HandleListLabels(w http.ResponseWriter, r *http.Request) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		if h.isHTMX(r) {
+			h.renderError(w, r, err)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
+
+	if h.isHTMX(r) {
+		h.renderTemplate(w, "label_list", LabelListView{Labels: labels})
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, LabelListResponse{
+		Labels: labels,
+		Total:  len(labels),
+	})
+}
+
+func (h *Handler) HandleGetLabel(w http.ResponseWriter, r *http.Request) {
+	id, err := parseLabelID(r.URL.Path)
+	if err != nil {
+		h.handleValidationError(w, messageInvalidLabelSelection)
+		return
+	}
+
+	label, err := h.DB.Labels().GetByID(r.Context(), id)
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+	if label == nil {
+		h.handleNotFound(w, messageLabelNotFound)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, label)
+}
+
+func (h *Handler) HandleCreateLabel(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name string `json:"name"`
+	}
+
+	if h.isHTMX(r) {
+		if err := r.ParseForm(); err != nil {
+			h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageInvalidFormData)
+			return
+		}
+		req.Name = strings.TrimSpace(r.FormValue("name"))
+	} else {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			h.handleValidationError(w, messageInvalidRequestBody)
+			return
+		}
+		req.Name = strings.TrimSpace(req.Name)
+	}
+
+	if req.Name == "" {
+		h.handleLabelValidationError(w, r, messageLabelNameRequired)
+		return
+	}
+
+	label, err := h.DB.Labels().Create(r.Context(), &models.Label{Name: req.Name})
+	if err != nil {
+		h.handleLabelWriteError(w, r, err)
+		return
+	}
+
+	if h.isHTMX(r) {
+		h.renderLabelsListWithToast(w, r, messageEntityAdded("Label", label.Name))
+		return
+	}
+
+	h.writeJSON(w, http.StatusCreated, label)
+}
+
+func (h *Handler) HandleUpdateLabel(w http.ResponseWriter, r *http.Request) {
+	id, err := parseLabelID(r.URL.Path)
+	if err != nil {
+		h.handleLabelValidationError(w, r, messageInvalidLabelSelection)
+		return
+	}
+
+	existing, err := h.DB.Labels().GetByID(r.Context(), id)
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+	if existing == nil {
+		h.handleLabelNotFound(w, r)
+		return
+	}
+
+	var req struct {
+		Name string `json:"name"`
+	}
+	if h.isHTMX(r) {
+		if err := r.ParseForm(); err != nil {
+			h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageInvalidFormData)
+			return
+		}
+		req.Name = strings.TrimSpace(r.FormValue("name"))
+	} else {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			h.handleValidationError(w, messageInvalidRequestBody)
+			return
+		}
+		req.Name = strings.TrimSpace(req.Name)
+	}
+
+	if req.Name == "" {
+		h.handleLabelValidationError(w, r, messageLabelNameRequired)
+		return
+	}
+
+	label := &models.Label{
+		ID:        id,
+		Name:      req.Name,
+		CreatedAt: existing.CreatedAt,
+	}
+	if _, err := h.DB.Labels().Update(r.Context(), label); err != nil {
+		h.handleLabelWriteError(w, r, err)
+		return
+	}
+
+	if h.isHTMX(r) {
+		h.renderLabelsListWithToast(w, r, messageEntityUpdated("Label", req.Name))
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, label)
+}
+
+func (h *Handler) HandleDeleteLabel(w http.ResponseWriter, r *http.Request) {
+	id, err := parseLabelID(r.URL.Path)
+	if err != nil {
+		h.handleLabelValidationError(w, r, messageInvalidLabelSelection)
+		return
+	}
+
+	if err := h.DB.Labels().Delete(r.Context(), id); err != nil {
+		if h.checkNotFound(err) {
+			h.handleLabelNotFound(w, r)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
+
+	if h.isHTMX(r) {
+		h.renderLabelsListWithToast(w, r, messageEntityDeleted("Label"))
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) HandleLabelForm(w http.ResponseWriter, r *http.Request) {
+	idStr := strings.TrimPrefix(r.URL.Path, "/api/v1/labels/")
+	idStr = strings.TrimSuffix(idStr, "/edit")
+
+	var label *models.Label
+	if idStr != "new" && idStr != "" {
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			h.renderError(w, r, errors.New(messageInvalidLabelSelection))
+			return
+		}
+		label, err = h.DB.Labels().GetByID(r.Context(), id)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		if label == nil {
+			h.renderError(w, r, errors.New(messageLabelNotFound))
+			return
+		}
+	} else {
+		label = &models.Label{}
+	}
+
+	h.renderTemplate(w, "label_form", LabelFormView{Label: label})
+}
+
+func (h *Handler) HandleAddParticipantsToLabel(w http.ResponseWriter, r *http.Request) {
+	h.handleBulkParticipantLabelMembership(w, r, "add")
+}
+
+func (h *Handler) HandleRemoveParticipantsFromLabel(w http.ResponseWriter, r *http.Request) {
+	h.handleBulkParticipantLabelMembership(w, r, "remove")
+}
+
+func (h *Handler) HandleAddDriversToLabel(w http.ResponseWriter, r *http.Request) {
+	h.handleBulkDriverLabelMembership(w, r, "add")
+}
+
+func (h *Handler) HandleRemoveDriversFromLabel(w http.ResponseWriter, r *http.Request) {
+	h.handleBulkDriverLabelMembership(w, r, "remove")
+}
+
+func (h *Handler) handleBulkParticipantLabelMembership(w http.ResponseWriter, r *http.Request, action string) {
+	labelID, label, ok := h.parseBulkLabelAction(w, r)
+	if !ok {
+		return
+	}
+	participantIDs, err := parseInt64FormValues(r, "participant_ids")
+	if err != nil {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid participant selection")
+		return
+	}
+	if len(participantIDs) == 0 {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageSelectParticipantForTag)
+		return
+	}
+
+	switch action {
+	case "add":
+		err = h.DB.Labels().AddLabelToParticipants(r.Context(), labelID, participantIDs)
+	case "remove":
+		err = h.DB.Labels().RemoveLabelFromParticipants(r.Context(), labelID, participantIDs)
+	default:
+		err = fmt.Errorf("invalid bulk label action")
+	}
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+
+	participants, err := h.DB.Participants().List(r.Context(), "")
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+	data, err := h.participantListView(r, participants)
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+
+	verb := "added to"
+	if action == "remove" {
+		verb = "removed from"
+	}
+	h.setHTMXToast(w, fmt.Sprintf("%d participant%s %s '%s'.", len(participantIDs), pluralSuffix(len(participantIDs)), verb, label.Name), toastTypeSuccess)
+	h.renderTemplate(w, "participant_list", data)
+}
+
+func (h *Handler) handleBulkDriverLabelMembership(w http.ResponseWriter, r *http.Request, action string) {
+	labelID, label, ok := h.parseBulkLabelAction(w, r)
+	if !ok {
+		return
+	}
+	driverIDs, err := parseInt64FormValues(r, "driver_ids")
+	if err != nil {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid driver selection")
+		return
+	}
+	if len(driverIDs) == 0 {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageSelectDriverForTag)
+		return
+	}
+
+	switch action {
+	case "add":
+		err = h.DB.Labels().AddLabelToDrivers(r.Context(), labelID, driverIDs)
+	case "remove":
+		err = h.DB.Labels().RemoveLabelFromDrivers(r.Context(), labelID, driverIDs)
+	default:
+		err = fmt.Errorf("invalid bulk label action")
+	}
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+
+	drivers, err := h.DB.Drivers().List(r.Context(), "")
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+	data, err := h.driverListView(r, drivers)
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+
+	verb := "added to"
+	if action == "remove" {
+		verb = "removed from"
+	}
+	h.setHTMXToast(w, fmt.Sprintf("%d driver%s %s '%s'.", len(driverIDs), pluralSuffix(len(driverIDs)), verb, label.Name), toastTypeSuccess)
+	h.renderTemplate(w, "driver_list", data)
+}
+
+func (h *Handler) parseBulkLabelAction(w http.ResponseWriter, r *http.Request) (int64, *models.Label, bool) {
+	if err := r.ParseForm(); err != nil {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageInvalidFormData)
+		return 0, nil, false
+	}
+
+	labelID, err := strconv.ParseInt(strings.TrimSpace(r.FormValue("label_id")), 10, 64)
+	if err != nil || labelID <= 0 {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", messageChooseLabelFirst)
+		return 0, nil, false
+	}
+
+	label, err := h.DB.Labels().GetByID(r.Context(), labelID)
+	if err != nil {
+		h.handleInternalError(w, err)
+		return 0, nil, false
+	}
+	if label == nil {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusNotFound, "NOT_FOUND", messageLabelNotFound)
+		return 0, nil, false
+	}
+
+	return labelID, label, true
+}
+
+func (h *Handler) renderLabelsListWithToast(w http.ResponseWriter, r *http.Request, message string) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
+
+	h.setHTMXToast(w, message, toastTypeSuccess)
+	h.renderTemplate(w, "label_list", LabelListView{Labels: labels})
+}
+
+func (h *Handler) handleLabelValidationError(w http.ResponseWriter, r *http.Request, message string) {
+	if h.isHTMX(r) {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusBadRequest, "VALIDATION_ERROR", message)
+		return
+	}
+	h.handleValidationError(w, message)
+}
+
+func (h *Handler) handleLabelNotFound(w http.ResponseWriter, r *http.Request) {
+	if h.isHTMX(r) {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusNotFound, "NOT_FOUND", messageLabelNotFound)
+		return
+	}
+	h.handleNotFound(w, messageLabelNotFound)
+}
+
+func (h *Handler) handleLabelWriteError(w http.ResponseWriter, r *http.Request, err error) {
+	if h.checkNotFound(err) {
+		h.handleLabelNotFound(w, r)
+		return
+	}
+	if isUniqueConstraintError(err) {
+		h.handleLabelValidationError(w, r, messageDuplicateLabelName)
+		return
+	}
+	log.Printf("[ERROR] Failed to write label: err=%v", err)
+	if h.isHTMX(r) {
+		h.handleHTMXErrorNoSwap(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", messageGenericInternalError)
+		return
+	}
+	h.handleInternalError(w, err)
+}
+
+func parseInt64FormValues(r *http.Request, fieldName string) ([]int64, error) {
+	values := r.Form[fieldName]
+	ids := make([]int64, 0, len(values))
+	for _, value := range values {
+		id, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func parseLabelIDs(r *http.Request) ([]int64, error) {
+	return parseInt64FormValues(r, "label_ids")
+}
+
+func buildSelectedLabelIDMap(labels []models.Label) map[int64]bool {
+	selected := make(map[int64]bool, len(labels))
+	for _, label := range labels {
+		selected[label.ID] = true
+	}
+	return selected
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "UNIQUE constraint failed") || strings.Contains(message, "constraint failed: UNIQUE")
+}

--- a/internal/handlers/labels.go
+++ b/internal/handlers/labels.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -171,6 +172,14 @@ func (h *Handler) HandleUpdateLabel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	updated, err := h.DB.Labels().GetByID(r.Context(), id)
+	if err != nil {
+		h.handleInternalError(w, err)
+		return
+	}
+	if updated != nil {
+		label = updated
+	}
 	h.writeJSON(w, http.StatusOK, label)
 }
 
@@ -419,6 +428,28 @@ func parseInt64FormValues(r *http.Request, fieldName string) ([]int64, error) {
 
 func parseLabelIDs(r *http.Request) ([]int64, error) {
 	return parseInt64FormValues(r, "label_ids")
+}
+
+func (h *Handler) validateLabelIDs(ctx context.Context, labelIDs []int64) error {
+	seen := make(map[int64]struct{}, len(labelIDs))
+	for _, labelID := range labelIDs {
+		if labelID <= 0 {
+			return errors.New(messageInvalidLabelSelection)
+		}
+		if _, ok := seen[labelID]; ok {
+			continue
+		}
+		seen[labelID] = struct{}{}
+
+		label, err := h.DB.Labels().GetByID(ctx, labelID)
+		if err != nil {
+			return err
+		}
+		if label == nil {
+			return errors.New(messageInvalidLabelSelection)
+		}
+	}
+	return nil
 }
 
 func buildSelectedLabelIDMap(labels []models.Label) map[int64]bool {

--- a/internal/handlers/labels_test.go
+++ b/internal/handlers/labels_test.go
@@ -222,3 +222,82 @@ func TestHandleParticipantForm_RendersSelectedLabels(t *testing.T) {
 		t.Fatalf("expected selected label checkbox, body=%q", body)
 	}
 }
+
+func TestHandleUpdateParticipant_JSONOmittedLabelIDsPreservesLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	body := `{"name":"Participant One Updated","address":"1 Rider Way"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/participants/"+int64ToString(participant.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateParticipant(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	labels, err := store.Labels().ListLabelsForParticipant(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("participant labels = %#v, want existing label preserved", labels)
+	}
+}
+
+func TestHandleUpdateDriver_JSONOmittedLabelIDsPreservesLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	body := `{"name":"Driver One Updated","address":"1 Driver Way","vehicle_capacity":4}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/drivers/"+int64ToString(driver.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateDriver(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	labels, err := store.Labels().ListLabelsForDriver(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("driver labels = %#v, want existing label preserved", labels)
+	}
+}

--- a/internal/handlers/labels_test.go
+++ b/internal/handlers/labels_test.go
@@ -1043,6 +1043,10 @@ func TestHandleUpdateDriver_JSONEmptyLabelIDsClearsLabels(t *testing.T) {
 func TestHandleUpdateParticipant_JSONInvalidLabelDoesNotMutateParticipant(t *testing.T) {
 	handler, store := newTestManagementHandler(t)
 
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
 	participant, err := store.Participants().Create(context.Background(), &models.Participant{
 		Name:    "Participant One",
 		Address: "1 Rider Way",
@@ -1051,6 +1055,9 @@ func TestHandleUpdateParticipant_JSONInvalidLabelDoesNotMutateParticipant(t *tes
 	})
 	if err != nil {
 		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
 	}
 
 	body := `{"name":"Changed","address":"1 Rider Way","label_ids":[9999]}`
@@ -1069,6 +1076,82 @@ func TestHandleUpdateParticipant_JSONInvalidLabelDoesNotMutateParticipant(t *tes
 	}
 	if unchanged.Name != "Participant One" {
 		t.Fatalf("participant name = %q, want unchanged", unchanged.Name)
+	}
+	labels, err := store.Labels().ListLabelsForParticipant(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("participant labels = %#v, want existing label preserved", labels)
+	}
+}
+
+func TestHandleCreateParticipant_JSONInvalidLabelDoesNotCreateParticipant(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	body := `{"name":"Participant One","address":"1 Rider Way","label_ids":[9999]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/participants", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateParticipant(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	participants, err := store.Participants().List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(participants) != 0 {
+		t.Fatalf("participants = %#v, want none created", participants)
+	}
+}
+
+func TestHandleUpdateDriver_JSONInvalidLabelDoesNotMutateDriver(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	body := `{"name":"Changed","address":"1 Driver Way","vehicle_capacity":4,"label_ids":[9999]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/drivers/"+int64ToString(driver.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateDriver(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	unchanged, err := store.Drivers().GetByID(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if unchanged.Name != "Driver One" {
+		t.Fatalf("driver name = %q, want unchanged", unchanged.Name)
+	}
+	labels, err := store.Labels().ListLabelsForDriver(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("driver labels = %#v, want existing label preserved", labels)
 	}
 }
 

--- a/internal/handlers/labels_test.go
+++ b/internal/handlers/labels_test.go
@@ -105,6 +105,35 @@ func TestHandleUpdateLabel_JSONReturnsMembershipCounts(t *testing.T) {
 	}
 }
 
+func TestValidateLabelIDsAcceptsDuplicateExistingLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+
+	if err := handler.validateLabelIDs(context.Background(), []int64{label.ID, label.ID}); err != nil {
+		t.Fatalf("validateLabelIDs() error = %v, want nil", err)
+	}
+}
+
+func TestValidateLabelIDsRejectsNonPositiveLabelIDs(t *testing.T) {
+	handler, _ := newTestManagementHandler(t)
+
+	if err := handler.validateLabelIDs(context.Background(), []int64{0}); err == nil {
+		t.Fatal("validateLabelIDs() error = nil, want invalid label error")
+	}
+}
+
+func TestValidateLabelIDsRejectsMissingLabelIDs(t *testing.T) {
+	handler, _ := newTestManagementHandler(t)
+
+	if err := handler.validateLabelIDs(context.Background(), []int64{9999}); err == nil {
+		t.Fatal("validateLabelIDs() error = nil, want missing label error")
+	}
+}
+
 func TestHandleAddParticipantsToLabel_HTMXAddsMembershipsIdempotently(t *testing.T) {
 	handler, store := newTestManagementHandler(t)
 
@@ -172,6 +201,136 @@ func TestHandleAddParticipantsToLabel_HTMXAddsMembershipsIdempotently(t *testing
 	}
 }
 
+func TestHandleAddParticipantsToLabel_HTMXRejectsInvalidParticipantIDWithoutPartialMutation(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Summer Camp"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("label_id", int64ToString(label.ID))
+	form.Add("participant_ids", int64ToString(participant.ID))
+	form.Add("participant_ids", "9999")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/participants/labels/add", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleAddParticipantsToLabel(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if got := rr.Header().Get("HX-Reswap"); got != "none" {
+		t.Fatalf("HX-Reswap = %q, want %q", got, "none")
+	}
+	labels, err := store.Labels().ListLabelsForParticipant(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("participant labels = %#v, want no partial mutation", labels)
+	}
+}
+
+func TestHandleRemoveParticipantsFromLabel_HTMXRejectsInvalidParticipantIDWithoutPartialMutation(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Summer Camp"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("label_id", int64ToString(label.ID))
+	form.Add("participant_ids", int64ToString(participant.ID))
+	form.Add("participant_ids", "9999")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/participants/labels/remove", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleRemoveParticipantsFromLabel(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	labels, err := store.Labels().ListLabelsForParticipant(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("participant labels = %#v, want original label preserved", labels)
+	}
+}
+
+func TestHandleAddDriversToLabel_HTMXRejectsInvalidDriverIDWithoutPartialMutation(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("label_id", int64ToString(label.ID))
+	form.Add("driver_ids", int64ToString(driver.ID))
+	form.Add("driver_ids", "9999")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drivers/labels/add", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleAddDriversToLabel(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	labels, err := store.Labels().ListLabelsForDriver(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("driver labels = %#v, want no partial mutation", labels)
+	}
+}
+
 func TestHandleRemoveDriversFromLabel_HTMXRemovesMembershipsIdempotently(t *testing.T) {
 	handler, store := newTestManagementHandler(t)
 
@@ -227,6 +386,51 @@ func TestHandleRemoveDriversFromLabel_HTMXRemovesMembershipsIdempotently(t *test
 	}
 }
 
+func TestHandleRemoveDriversFromLabel_HTMXRejectsInvalidDriverIDWithoutPartialMutation(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("label_id", int64ToString(label.ID))
+	form.Add("driver_ids", int64ToString(driver.ID))
+	form.Add("driver_ids", "9999")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drivers/labels/remove", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleRemoveDriversFromLabel(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	labels, err := store.Labels().ListLabelsForDriver(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("driver labels = %#v, want original label preserved", labels)
+	}
+}
+
 func TestHandleParticipantForm_RendersSelectedLabels(t *testing.T) {
 	handler, store := newTestManagementHandler(t)
 
@@ -259,6 +463,75 @@ func TestHandleParticipantForm_RendersSelectedLabels(t *testing.T) {
 	body := rr.Body.String()
 	if !strings.Contains(body, `name="label_ids"`) || !strings.Contains(body, `checked`) {
 		t.Fatalf("expected selected label checkbox, body=%q", body)
+	}
+}
+
+func TestHandleListParticipants_HTMXRendersAssignedLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/participants", nil)
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleListParticipants(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Youth Conference") {
+		t.Fatalf("expected assigned label name in participant list, body=%q", rr.Body.String())
+	}
+}
+
+func TestHandleListDrivers_HTMXRendersAssignedLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/drivers", nil)
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleListDrivers(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Drivers") {
+		t.Fatalf("expected assigned label name in driver list, body=%q", rr.Body.String())
 	}
 }
 
@@ -338,6 +611,432 @@ func TestHandleUpdateDriver_JSONOmittedLabelIDsPreservesLabels(t *testing.T) {
 	}
 	if len(labels) != 1 || labels[0].ID != label.ID {
 		t.Fatalf("driver labels = %#v, want existing label preserved", labels)
+	}
+}
+
+func TestHandleGetDriver_JSONIncludesLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/drivers/"+int64ToString(driver.ID), nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleGetDriver(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		ID       int64   `json:"id"`
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID != driver.ID || len(response.LabelIDs) != 1 || response.LabelIDs[0] != label.ID {
+		t.Fatalf("response = %#v, want driver with label_ids [%d]", response, label.ID)
+	}
+}
+
+func TestHandleListDrivers_JSONIncludesLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/drivers", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleListDrivers(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		Drivers []struct {
+			ID       int64   `json:"id"`
+			LabelIDs []int64 `json:"label_ids"`
+		} `json:"drivers"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Total != 1 || len(response.Drivers) != 1 {
+		t.Fatalf("response = %#v, want one driver", response)
+	}
+	got := response.Drivers[0]
+	if got.ID != driver.ID || len(got.LabelIDs) != 1 || got.LabelIDs[0] != label.ID {
+		t.Fatalf("driver response = %#v, want label_ids [%d]", got, label.ID)
+	}
+}
+
+func TestHandleGetParticipant_JSONIncludesLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/participants/"+int64ToString(participant.ID), nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleGetParticipant(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		ID       int64   `json:"id"`
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID != participant.ID || len(response.LabelIDs) != 1 || response.LabelIDs[0] != label.ID {
+		t.Fatalf("response = %#v, want participant with label_ids [%d]", response, label.ID)
+	}
+}
+
+func TestHandleListParticipants_JSONIncludesLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/participants", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleListParticipants(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		Participants []struct {
+			ID       int64   `json:"id"`
+			LabelIDs []int64 `json:"label_ids"`
+		} `json:"participants"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Total != 1 || len(response.Participants) != 1 {
+		t.Fatalf("response = %#v, want one participant", response)
+	}
+	got := response.Participants[0]
+	if got.ID != participant.ID || len(got.LabelIDs) != 1 || got.LabelIDs[0] != label.ID {
+		t.Fatalf("participant response = %#v, want label_ids [%d]", got, label.ID)
+	}
+}
+
+func TestHandleCreateParticipant_JSONReturnsLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+
+	body := `{"name":"Participant One","address":"1 Rider Way","label_ids":[` + int64ToString(label.ID) + `]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/participants", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateParticipant(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+	var response struct {
+		ID       int64   `json:"id"`
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID == 0 || len(response.LabelIDs) != 1 || response.LabelIDs[0] != label.ID {
+		t.Fatalf("response = %#v, want created participant with label_ids [%d]", response, label.ID)
+	}
+}
+
+func TestHandleCreateDriver_JSONReturnsLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+
+	body := `{"name":"Driver One","address":"1 Driver Way","vehicle_capacity":4,"label_ids":[` + int64ToString(label.ID) + `]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drivers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateDriver(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+	var response struct {
+		ID       int64   `json:"id"`
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID == 0 || len(response.LabelIDs) != 1 || response.LabelIDs[0] != label.ID {
+		t.Fatalf("response = %#v, want created driver with label_ids [%d]", response, label.ID)
+	}
+}
+
+func TestHandleUpdateParticipant_JSONReturnsLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	oldLabel, err := store.Labels().Create(context.Background(), &models.Label{Name: "Old"})
+	if err != nil {
+		t.Fatalf("create old label: %v", err)
+	}
+	newLabel, err := store.Labels().Create(context.Background(), &models.Label{Name: "New"})
+	if err != nil {
+		t.Fatalf("create new label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{oldLabel.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	body := `{"name":"Participant One Updated","address":"1 Rider Way","label_ids":[` + int64ToString(newLabel.ID) + `]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/participants/"+int64ToString(participant.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateParticipant(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		ID       int64   `json:"id"`
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID != participant.ID || len(response.LabelIDs) != 1 || response.LabelIDs[0] != newLabel.ID {
+		t.Fatalf("response = %#v, want updated participant with label_ids [%d]", response, newLabel.ID)
+	}
+}
+
+func TestHandleUpdateDriver_JSONReturnsLabelIDs(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	oldLabel, err := store.Labels().Create(context.Background(), &models.Label{Name: "Old"})
+	if err != nil {
+		t.Fatalf("create old label: %v", err)
+	}
+	newLabel, err := store.Labels().Create(context.Background(), &models.Label{Name: "New"})
+	if err != nil {
+		t.Fatalf("create new label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{oldLabel.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	body := `{"name":"Driver One Updated","address":"1 Driver Way","vehicle_capacity":4,"label_ids":[` + int64ToString(newLabel.ID) + `]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/drivers/"+int64ToString(driver.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateDriver(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		ID       int64   `json:"id"`
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.ID != driver.ID || len(response.LabelIDs) != 1 || response.LabelIDs[0] != newLabel.ID {
+		t.Fatalf("response = %#v, want updated driver with label_ids [%d]", response, newLabel.ID)
+	}
+}
+
+func TestHandleUpdateParticipant_JSONEmptyLabelIDsClearsLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	body := `{"name":"Participant One Updated","address":"1 Rider Way","label_ids":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/participants/"+int64ToString(participant.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateParticipant(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.LabelIDs) != 0 {
+		t.Fatalf("response label_ids = %#v, want empty", response.LabelIDs)
+	}
+	labels, err := store.Labels().ListLabelsForParticipant(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("participant labels = %#v, want cleared", labels)
+	}
+}
+
+func TestHandleUpdateDriver_JSONEmptyLabelIDsClearsLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	body := `{"name":"Driver One Updated","address":"1 Driver Way","vehicle_capacity":4,"label_ids":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/drivers/"+int64ToString(driver.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateDriver(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response struct {
+		LabelIDs []int64 `json:"label_ids"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.LabelIDs) != 0 {
+		t.Fatalf("response label_ids = %#v, want empty", response.LabelIDs)
+	}
+	labels, err := store.Labels().ListLabelsForDriver(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("driver labels = %#v, want cleared", labels)
 	}
 }
 

--- a/internal/handlers/labels_test.go
+++ b/internal/handlers/labels_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -63,6 +64,44 @@ func TestHandleUpdateLabel_HTMXRejectsDuplicateName(t *testing.T) {
 	}
 	if !strings.Contains(rr.Header().Get("HX-Trigger"), messageDuplicateLabelName) {
 		t.Fatalf("expected duplicate label toast, HX-Trigger=%q", rr.Header().Get("HX-Trigger"))
+	}
+}
+
+func TestHandleUpdateLabel_JSONReturnsMembershipCounts(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Old"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/labels/"+int64ToString(label.ID), strings.NewReader(`{"name":"New"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateLabel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var response models.Label
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Name != "New" || response.ParticipantCount != 1 {
+		t.Fatalf("response = %#v, want renamed label with participant count", response)
 	}
 }
 
@@ -299,5 +338,59 @@ func TestHandleUpdateDriver_JSONOmittedLabelIDsPreservesLabels(t *testing.T) {
 	}
 	if len(labels) != 1 || labels[0].ID != label.ID {
 		t.Fatalf("driver labels = %#v, want existing label preserved", labels)
+	}
+}
+
+func TestHandleUpdateParticipant_JSONInvalidLabelDoesNotMutateParticipant(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+
+	body := `{"name":"Changed","address":"1 Rider Way","label_ids":[9999]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/participants/"+int64ToString(participant.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateParticipant(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	unchanged, err := store.Participants().GetByID(context.Background(), participant.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if unchanged.Name != "Participant One" {
+		t.Fatalf("participant name = %q, want unchanged", unchanged.Name)
+	}
+}
+
+func TestHandleCreateDriver_JSONInvalidLabelDoesNotCreateDriver(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	body := `{"name":"Driver One","address":"1 Driver Way","vehicle_capacity":4,"label_ids":[9999]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drivers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateDriver(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	drivers, err := store.Drivers().List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(drivers) != 0 {
+		t.Fatalf("drivers = %#v, want none created", drivers)
 	}
 }

--- a/internal/handlers/labels_test.go
+++ b/internal/handlers/labels_test.go
@@ -1,0 +1,224 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"ride-home-router/internal/models"
+)
+
+func TestHandleCreateLabel_HTMXTrimsAndRendersList(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	form := url.Values{}
+	form.Set("name", "  Youth Conference  ")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/labels", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateLabel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Youth Conference") {
+		t.Fatalf("expected rendered label list, body=%q", rr.Body.String())
+	}
+	labels, err := store.Labels().List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].Name != "Youth Conference" {
+		t.Fatalf("labels = %#v, want one trimmed label", labels)
+	}
+}
+
+func TestHandleUpdateLabel_HTMXRejectsDuplicateName(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	first, err := store.Labels().Create(context.Background(), &models.Label{Name: "First"})
+	if err != nil {
+		t.Fatalf("create first label: %v", err)
+	}
+	if _, err := store.Labels().Create(context.Background(), &models.Label{Name: "Second"}); err != nil {
+		t.Fatalf("create second label: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("name", "Second")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/labels/"+int64ToString(first.ID), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleUpdateLabel(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if !strings.Contains(rr.Header().Get("HX-Trigger"), messageDuplicateLabelName) {
+		t.Fatalf("expected duplicate label toast, HX-Trigger=%q", rr.Header().Get("HX-Trigger"))
+	}
+}
+
+func TestHandleAddParticipantsToLabel_HTMXAddsMembershipsIdempotently(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Summer Camp"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participantOne, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant one: %v", err)
+	}
+	participantTwo, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant Two",
+		Address: "2 Rider Way",
+		Lat:     40.2,
+		Lng:     -73.8,
+	})
+	if err != nil {
+		t.Fatalf("create participant two: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("label_id", int64ToString(label.ID))
+	form.Add("participant_ids", int64ToString(participantOne.ID))
+	form.Add("participant_ids", int64ToString(participantTwo.ID))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/participants/labels/add", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleAddParticipantsToLabel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if !strings.Contains(rr.Header().Get("HX-Trigger"), "2 participants added to") {
+		t.Fatalf("expected bulk success toast, HX-Trigger=%q", rr.Header().Get("HX-Trigger"))
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/api/v1/participants/labels/add", strings.NewReader(form.Encode()))
+	secondReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	secondReq.Header.Set("HX-Request", "true")
+	secondRR := httptest.NewRecorder()
+
+	handler.HandleAddParticipantsToLabel(secondRR, secondReq)
+
+	if secondRR.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want %d body=%q", secondRR.Code, http.StatusOK, secondRR.Body.String())
+	}
+	labelIDs, err := store.Labels().ListLabelIDsForParticipants(context.Background())
+	if err != nil {
+		t.Fatalf("ListLabelIDsForParticipants() error = %v", err)
+	}
+	if got := labelIDs[participantOne.ID]; len(got) != 1 || got[0] != label.ID {
+		t.Fatalf("participant one label IDs = %#v, want [%d]", got, label.ID)
+	}
+	if got := labelIDs[participantTwo.ID]; len(got) != 1 || got[0] != label.ID {
+		t.Fatalf("participant two label IDs = %#v, want [%d]", got, label.ID)
+	}
+}
+
+func TestHandleRemoveDriversFromLabel_HTMXRemovesMembershipsIdempotently(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Drivers"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().AddLabelToDrivers(context.Background(), label.ID, []int64{driver.ID}); err != nil {
+		t.Fatalf("AddLabelToDrivers() error = %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("label_id", int64ToString(label.ID))
+	form.Add("driver_ids", int64ToString(driver.ID))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/drivers/labels/remove", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleRemoveDriversFromLabel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	driverLabels, err := store.Labels().ListLabelsForDriver(context.Background(), driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(driverLabels) != 0 {
+		t.Fatalf("driver labels = %#v, want empty", driverLabels)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/api/v1/drivers/labels/remove", strings.NewReader(form.Encode()))
+	secondReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	secondReq.Header.Set("HX-Request", "true")
+	secondRR := httptest.NewRecorder()
+
+	handler.HandleRemoveDriversFromLabel(secondRR, secondReq)
+
+	if secondRR.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want %d body=%q", secondRR.Code, http.StatusOK, secondRR.Body.String())
+	}
+}
+
+func TestHandleParticipantForm_RendersSelectedLabels(t *testing.T) {
+	handler, store := newTestManagementHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/participants/"+int64ToString(participant.ID)+"/edit", nil)
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleParticipantForm(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `name="label_ids"`) || !strings.Contains(body, `checked`) {
+		t.Fatalf("expected selected label checkbox, body=%q", body)
+	}
+}

--- a/internal/handlers/pages.go
+++ b/internal/handlers/pages.go
@@ -31,6 +31,21 @@ func (h *Handler) HandleIndexPage(w http.ResponseWriter, r *http.Request) {
 		h.renderError(w, r, err)
 		return
 	}
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
+	participantLabels, err := h.DB.Labels().ListLabelIDsForParticipants(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
+	driverLabels, err := h.DB.Labels().ListLabelIDsForDrivers(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
 
 	h.renderTemplate(w, "index.html", IndexPageView{
 		BasePageView: BasePageView{
@@ -39,6 +54,9 @@ func (h *Handler) HandleIndexPage(w http.ResponseWriter, r *http.Request) {
 		},
 		Participants:      participants,
 		Drivers:           drivers,
+		Labels:            labels,
+		ParticipantLabels: participantLabels,
+		DriverLabels:      driverLabels,
 		ActivityLocations: activityLocations,
 		OrgVehicles:       orgVehicles,
 	})
@@ -51,6 +69,16 @@ func (h *Handler) HandleParticipantsPage(w http.ResponseWriter, r *http.Request)
 		h.renderError(w, r, err)
 		return
 	}
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
+	labelIDs, err := h.DB.Labels().ListLabelIDsForParticipants(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
 
 	h.renderTemplate(w, "participants.html", ParticipantsPageView{
 		BasePageView: BasePageView{
@@ -58,6 +86,8 @@ func (h *Handler) HandleParticipantsPage(w http.ResponseWriter, r *http.Request)
 			ActivePage: ActivePageParticipants,
 		},
 		Participants: participants,
+		Labels:       labels,
+		LabelIDs:     labelIDs,
 	})
 }
 
@@ -68,13 +98,42 @@ func (h *Handler) HandleDriversPage(w http.ResponseWriter, r *http.Request) {
 		h.renderError(w, r, err)
 		return
 	}
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
+	labelIDs, err := h.DB.Labels().ListLabelIDsForDrivers(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
 
 	h.renderTemplate(w, "drivers.html", DriversPageView{
 		BasePageView: BasePageView{
 			Title:      "Drivers",
 			ActivePage: ActivePageDrivers,
 		},
-		Drivers: drivers,
+		Drivers:  drivers,
+		Labels:   labels,
+		LabelIDs: labelIDs,
+	})
+}
+
+// HandleLabelsPage handles GET /labels
+func (h *Handler) HandleLabelsPage(w http.ResponseWriter, r *http.Request) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		h.renderError(w, r, err)
+		return
+	}
+
+	h.renderTemplate(w, "labels.html", LabelsPageView{
+		BasePageView: BasePageView{
+			Title:      "Labels",
+			ActivePage: ActivePageLabels,
+		},
+		Labels: labels,
 	})
 }
 

--- a/internal/handlers/pages_test.go
+++ b/internal/handlers/pages_test.go
@@ -265,6 +265,80 @@ func TestHandleIndexPage_RendersVanAssignmentsPanelWhenVansExist(t *testing.T) {
 	}
 }
 
+func TestHandleLabelsPage_RendersLabelsNavAndTable(t *testing.T) {
+	handler, store := newTestPageHandler(t)
+
+	if _, err := store.Labels().Create(context.Background(), &models.Label{Name: "Youth Conference"}); err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/labels", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleLabelsPage(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `href="/labels" class="active"`) {
+		t.Fatalf("expected Labels nav item to be active, body=%q", body)
+	}
+	if !strings.Contains(body, "Youth Conference") {
+		t.Fatalf("expected saved label to render, body=%q", body)
+	}
+}
+
+func TestHandleIndexPage_RendersLabelFiltersAndRowMetadata(t *testing.T) {
+	handler, store := newTestPageHandler(t)
+
+	label, err := store.Labels().Create(context.Background(), &models.Label{Name: "Summer Camp"})
+	if err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    "Participant One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.2,
+		Lng:             -73.8,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(context.Background(), participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(context.Background(), driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleIndexPage(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `data-label-id="`+int64ToString(label.ID)+`"`) {
+		t.Fatalf("expected label filter chip hook, body=%q", body)
+	}
+	if !strings.Contains(body, `data-labels="`+int64ToString(label.ID)+`"`) {
+		t.Fatalf("expected row label metadata, body=%q", body)
+	}
+}
+
 func newTestPageHandler(t *testing.T) (*Handler, *sqlite.Store) {
 	t.Helper()
 

--- a/internal/handlers/participants.go
+++ b/internal/handlers/participants.go
@@ -118,6 +118,15 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 		h.handleValidationError(w, messageNameAndAddressRequired)
 		return
 	}
+	if err := h.validateLabelIDs(r.Context(), labelIDs); err != nil {
+		log.Printf("[HTTP] POST /api/v1/participants: invalid_labels err=%v", err)
+		if h.isHTMX(r) {
+			h.renderError(w, r, errors.New(messageInvalidLabelSelection))
+			return
+		}
+		h.handleValidationError(w, messageInvalidLabelSelection)
+		return
+	}
 
 	log.Printf("[HTTP] POST /api/v1/participants: name=%s address=%s", req.Name, req.Address)
 	geocodeResult, err := h.Geocoder.GeocodeWithRetry(r.Context(), req.Address, 3)
@@ -259,6 +268,17 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 		}
 		h.handleValidationError(w, messageNameAndAddressRequired)
 		return
+	}
+	if shouldSetLabels {
+		if err := h.validateLabelIDs(r.Context(), labelIDs); err != nil {
+			log.Printf("[HTTP] PUT /api/v1/participants/{id}: invalid_labels id=%d err=%v", id, err)
+			if h.isHTMX(r) {
+				h.renderError(w, r, errors.New(messageInvalidLabelSelection))
+				return
+			}
+			h.handleValidationError(w, messageInvalidLabelSelection)
+			return
+		}
 	}
 
 	participant := &models.Participant{

--- a/internal/handlers/participants.go
+++ b/internal/handlers/participants.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -13,8 +14,14 @@ import (
 
 // ParticipantListResponse represents the list response
 type ParticipantListResponse struct {
-	Participants []models.Participant `json:"participants"`
-	Total        int                  `json:"total"`
+	Participants []ParticipantResponse `json:"participants"`
+	Total        int                   `json:"total"`
+}
+
+// ParticipantResponse represents a participant API response.
+type ParticipantResponse struct {
+	models.Participant
+	LabelIDs []int64 `json:"label_ids"`
 }
 
 // HandleListParticipants handles GET /api/v1/participants
@@ -44,8 +51,15 @@ func (h *Handler) HandleListParticipants(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	responseParticipants, err := h.participantResponses(r.Context(), participants)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load participant labels for list: err=%v", err)
+		h.handleInternalError(w, err)
+		return
+	}
+
 	h.writeJSON(w, http.StatusOK, ParticipantListResponse{
-		Participants: participants,
+		Participants: responseParticipants,
 		Total:        len(participants),
 	})
 }
@@ -74,7 +88,14 @@ func (h *Handler) HandleGetParticipant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, participant)
+	response, err := h.participantResponse(r.Context(), participant)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load participant labels: id=%d err=%v", participant.ID, err)
+		h.handleInternalError(w, err)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
 }
 
 // HandleCreateParticipant handles POST /api/v1/participants
@@ -147,7 +168,7 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 		Lng:     geocodeResult.Coords.Lng,
 	}
 
-	participant, err = h.DB.Participants().Create(r.Context(), participant)
+	participant, err = h.DB.Participants().CreateWithLabels(r.Context(), participant, labelIDs)
 	if err != nil {
 		log.Printf("[ERROR] Failed to create participant: name=%s address=%s err=%v", req.Name, req.Address, err)
 		if h.isHTMX(r) {
@@ -160,11 +181,6 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 
 	log.Printf("[HTTP] Created participant: id=%d name=%s", participant.ID, participant.Name)
 	if h.isHTMX(r) {
-		if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
-			log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
-			h.renderError(w, r, err)
-			return
-		}
 		participants, err := h.DB.Participants().List(r.Context(), "")
 		if err != nil {
 			log.Printf("[ERROR] Failed to list participants after create: err=%v", err)
@@ -180,13 +196,15 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 		h.renderTemplate(w, "participant_list", view)
 		return
 	}
-	if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
-		log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
+
+	response, err := h.participantResponse(r.Context(), participant)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load participant labels after create: id=%d err=%v", participant.ID, err)
 		h.handleInternalError(w, err)
 		return
 	}
 
-	h.writeJSON(w, http.StatusCreated, participant)
+	h.writeJSON(w, http.StatusCreated, response)
 }
 
 // HandleUpdateParticipant handles PUT /api/v1/participants/{id}
@@ -304,7 +322,11 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 		participant.Lng = geocodeResult.Coords.Lng
 	}
 
-	participant, err = h.DB.Participants().Update(r.Context(), participant)
+	if shouldSetLabels {
+		participant, err = h.DB.Participants().UpdateWithLabels(r.Context(), participant, labelIDs)
+	} else {
+		participant, err = h.DB.Participants().Update(r.Context(), participant)
+	}
 	if err != nil {
 		log.Printf("[ERROR] Failed to update participant: id=%d err=%v", id, err)
 		if h.isHTMX(r) {
@@ -326,17 +348,6 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 	}
 
 	log.Printf("[HTTP] Updated participant: id=%d name=%s", participant.ID, participant.Name)
-	if shouldSetLabels {
-		if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
-			log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
-			if h.isHTMX(r) {
-				h.renderError(w, r, err)
-				return
-			}
-			h.handleInternalError(w, err)
-			return
-		}
-	}
 	if h.isHTMX(r) {
 		participants, err := h.DB.Participants().List(r.Context(), "")
 		if err != nil {
@@ -354,7 +365,14 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	h.writeJSON(w, http.StatusOK, participant)
+	response, err := h.participantResponse(r.Context(), participant)
+	if err != nil {
+		log.Printf("[ERROR] Failed to load participant labels after update: id=%d err=%v", participant.ID, err)
+		h.handleInternalError(w, err)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
 }
 
 // HandleDeleteParticipant handles DELETE /api/v1/participants/{id}
@@ -477,4 +495,39 @@ func (h *Handler) loadLabelsForParticipant(r *http.Request, participantID int64)
 		return nil, nil, err
 	}
 	return labels, buildSelectedLabelIDMap(selectedLabels), nil
+}
+
+func (h *Handler) participantResponse(ctx context.Context, participant *models.Participant) (ParticipantResponse, error) {
+	labels, err := h.DB.Labels().ListLabelsForParticipant(ctx, participant.ID)
+	if err != nil {
+		return ParticipantResponse{}, err
+	}
+	labelIDs := make([]int64, 0, len(labels))
+	for _, label := range labels {
+		labelIDs = append(labelIDs, label.ID)
+	}
+	return ParticipantResponse{
+		Participant: *participant,
+		LabelIDs:    labelIDs,
+	}, nil
+}
+
+func (h *Handler) participantResponses(ctx context.Context, participants []models.Participant) ([]ParticipantResponse, error) {
+	labelIDsByParticipant, err := h.DB.Labels().ListLabelIDsForParticipants(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]ParticipantResponse, 0, len(participants))
+	for _, participant := range participants {
+		labelIDs := append([]int64{}, labelIDsByParticipant[participant.ID]...)
+		if labelIDs == nil {
+			labelIDs = []int64{}
+		}
+		responses = append(responses, ParticipantResponse{
+			Participant: participant,
+			LabelIDs:    labelIDs,
+		})
+	}
+	return responses, nil
 }

--- a/internal/handlers/participants.go
+++ b/internal/handlers/participants.go
@@ -220,11 +220,12 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 	}
 
 	var req struct {
-		Name     string  `json:"name"`
-		Address  string  `json:"address"`
-		LabelIDs []int64 `json:"label_ids"`
+		Name     string   `json:"name"`
+		Address  string   `json:"address"`
+		LabelIDs *[]int64 `json:"label_ids"`
 	}
 	var labelIDs []int64
+	shouldSetLabels := false
 
 	if h.isHTMX(r) {
 		if err := r.ParseForm(); err != nil {
@@ -239,12 +240,16 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 			return
 		}
 		labelIDs = parsedLabelIDs
+		shouldSetLabels = true
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			h.handleValidationError(w, messageInvalidRequestBody)
 			return
 		}
-		labelIDs = req.LabelIDs
+		if req.LabelIDs != nil {
+			labelIDs = *req.LabelIDs
+			shouldSetLabels = true
+		}
 	}
 
 	if req.Name == "" || req.Address == "" {
@@ -301,14 +306,16 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 	}
 
 	log.Printf("[HTTP] Updated participant: id=%d name=%s", participant.ID, participant.Name)
-	if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
-		log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
-		if h.isHTMX(r) {
-			h.renderError(w, r, err)
+	if shouldSetLabels {
+		if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
+			log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
+			if h.isHTMX(r) {
+				h.renderError(w, r, err)
+				return
+			}
+			h.handleInternalError(w, err)
 			return
 		}
-		h.handleInternalError(w, err)
-		return
 	}
 	if h.isHTMX(r) {
 		participants, err := h.DB.Participants().List(r.Context(), "")

--- a/internal/handlers/participants.go
+++ b/internal/handlers/participants.go
@@ -35,7 +35,12 @@ func (h *Handler) HandleListParticipants(w http.ResponseWriter, r *http.Request)
 
 	log.Printf("[HTTP] Listed participants: count=%d", len(participants))
 	if h.isHTMX(r) {
-		h.renderTemplate(w, "participant_list", ParticipantListView{Participants: participants})
+		view, err := h.participantListView(r, participants)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		h.renderTemplate(w, "participant_list", view)
 		return
 	}
 
@@ -75,9 +80,11 @@ func (h *Handler) HandleGetParticipant(w http.ResponseWriter, r *http.Request) {
 // HandleCreateParticipant handles POST /api/v1/participants
 func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name    string `json:"name"`
-		Address string `json:"address"`
+		Name     string  `json:"name"`
+		Address  string  `json:"address"`
+		LabelIDs []int64 `json:"label_ids"`
 	}
+	var labelIDs []int64
 
 	if h.isHTMX(r) {
 		if err := r.ParseForm(); err != nil {
@@ -87,12 +94,19 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 		}
 		req.Name = r.FormValue("name")
 		req.Address = r.FormValue("address")
+		parsedLabelIDs, err := parseLabelIDs(r)
+		if err != nil {
+			h.renderError(w, r, errors.New("Invalid label selection"))
+			return
+		}
+		labelIDs = parsedLabelIDs
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			log.Printf("[HTTP] POST /api/v1/participants: invalid_body err=%v", err)
 			h.handleValidationError(w, messageInvalidRequestBody)
 			return
 		}
+		labelIDs = req.LabelIDs
 	}
 
 	if req.Name == "" || req.Address == "" {
@@ -137,6 +151,11 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 
 	log.Printf("[HTTP] Created participant: id=%d name=%s", participant.ID, participant.Name)
 	if h.isHTMX(r) {
+		if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
+			log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
+			h.renderError(w, r, err)
+			return
+		}
 		participants, err := h.DB.Participants().List(r.Context(), "")
 		if err != nil {
 			log.Printf("[ERROR] Failed to list participants after create: err=%v", err)
@@ -144,7 +163,17 @@ func (h *Handler) HandleCreateParticipant(w http.ResponseWriter, r *http.Request
 			return
 		}
 		h.setHTMXToastWithEvent(w, "participantCreated", messageEntityAdded("Participant", participant.Name), toastTypeSuccess)
-		h.renderTemplate(w, "participant_list", ParticipantListView{Participants: participants})
+		view, err := h.participantListView(r, participants)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		h.renderTemplate(w, "participant_list", view)
+		return
+	}
+	if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
+		log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
+		h.handleInternalError(w, err)
 		return
 	}
 
@@ -191,9 +220,11 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 	}
 
 	var req struct {
-		Name    string `json:"name"`
-		Address string `json:"address"`
+		Name     string  `json:"name"`
+		Address  string  `json:"address"`
+		LabelIDs []int64 `json:"label_ids"`
 	}
+	var labelIDs []int64
 
 	if h.isHTMX(r) {
 		if err := r.ParseForm(); err != nil {
@@ -202,11 +233,18 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 		}
 		req.Name = r.FormValue("name")
 		req.Address = r.FormValue("address")
+		parsedLabelIDs, err := parseLabelIDs(r)
+		if err != nil {
+			h.renderError(w, r, errors.New("Invalid label selection"))
+			return
+		}
+		labelIDs = parsedLabelIDs
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			h.handleValidationError(w, messageInvalidRequestBody)
 			return
 		}
+		labelIDs = req.LabelIDs
 	}
 
 	if req.Name == "" || req.Address == "" {
@@ -263,6 +301,15 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 	}
 
 	log.Printf("[HTTP] Updated participant: id=%d name=%s", participant.ID, participant.Name)
+	if err := h.DB.Labels().SetLabelsForParticipant(r.Context(), participant.ID, labelIDs); err != nil {
+		log.Printf("[ERROR] Failed to set participant labels: id=%d err=%v", participant.ID, err)
+		if h.isHTMX(r) {
+			h.renderError(w, r, err)
+			return
+		}
+		h.handleInternalError(w, err)
+		return
+	}
 	if h.isHTMX(r) {
 		participants, err := h.DB.Participants().List(r.Context(), "")
 		if err != nil {
@@ -271,7 +318,12 @@ func (h *Handler) HandleUpdateParticipant(w http.ResponseWriter, r *http.Request
 			return
 		}
 		h.setHTMXToastWithEvent(w, "participantUpdated", messageEntityUpdated("Participant", participant.Name), toastTypeSuccess)
-		h.renderTemplate(w, "participant_list", ParticipantListView{Participants: participants})
+		view, err := h.participantListView(r, participants)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		h.renderTemplate(w, "participant_list", view)
 		return
 	}
 
@@ -329,6 +381,11 @@ func (h *Handler) HandleParticipantForm(w http.ResponseWriter, r *http.Request) 
 	idStr = strings.TrimSuffix(idStr, "/edit")
 
 	var participant *models.Participant
+	var (
+		labels           []models.Label
+		selectedLabelIDs map[int64]bool
+		err              error
+	)
 	if idStr != "new" && idStr != "" {
 		id, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
@@ -345,9 +402,52 @@ func (h *Handler) HandleParticipantForm(w http.ResponseWriter, r *http.Request) 
 			h.renderError(w, r, errors.New(messageParticipantNotFound))
 			return
 		}
+		labels, selectedLabelIDs, err = h.loadLabelsForParticipant(r, participant.ID)
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
 	} else {
 		participant = &models.Participant{}
+		labels, err = h.DB.Labels().List(r.Context())
+		if err != nil {
+			h.renderError(w, r, err)
+			return
+		}
+		selectedLabelIDs = map[int64]bool{}
 	}
 
-	h.renderTemplate(w, "participant_form", ParticipantFormView{Participant: participant})
+	h.renderTemplate(w, "participant_form", ParticipantFormView{
+		Participant:      participant,
+		Labels:           labels,
+		SelectedLabelIDs: selectedLabelIDs,
+	})
+}
+
+func (h *Handler) participantListView(r *http.Request, participants []models.Participant) (ParticipantListView, error) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		return ParticipantListView{}, err
+	}
+	labelIDs, err := h.DB.Labels().ListLabelIDsForParticipants(r.Context())
+	if err != nil {
+		return ParticipantListView{}, err
+	}
+	return ParticipantListView{
+		Participants: participants,
+		Labels:       labels,
+		LabelIDs:     labelIDs,
+	}, nil
+}
+
+func (h *Handler) loadLabelsForParticipant(r *http.Request, participantID int64) ([]models.Label, map[int64]bool, error) {
+	labels, err := h.DB.Labels().List(r.Context())
+	if err != nil {
+		return nil, nil, err
+	}
+	selectedLabels, err := h.DB.Labels().ListLabelsForParticipant(r.Context(), participantID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return labels, buildSelectedLabelIDMap(selectedLabels), nil
 }

--- a/internal/handlers/template_helpers_test.go
+++ b/internal/handlers/template_helpers_test.go
@@ -41,7 +41,7 @@ func loadEmbeddedTemplates(t *testing.T) *TemplateSet {
 	}
 
 	pages := make(map[string]string)
-	pageFiles := []string{"index.html", "participants.html", "drivers.html", "activity_locations.html", "vans.html", "settings.html", "history.html"}
+	pageFiles := []string{"index.html", "participants.html", "drivers.html", "labels.html", "activity_locations.html", "vans.html", "settings.html", "history.html"}
 	for _, name := range pageFiles {
 		content, err := fs.ReadFile(web.Templates, "templates/"+name)
 		if err != nil {

--- a/internal/handlers/view_models.go
+++ b/internal/handlers/view_models.go
@@ -8,6 +8,7 @@ const (
 	ActivePageHome              ActivePage = "home"
 	ActivePageParticipants      ActivePage = "participants"
 	ActivePageDrivers           ActivePage = "drivers"
+	ActivePageLabels            ActivePage = "labels"
 	ActivePageActivityLocations ActivePage = "activity_locations"
 	ActivePageVans              ActivePage = "vans"
 	ActivePageSettings          ActivePage = "settings"
@@ -23,6 +24,9 @@ type IndexPageView struct {
 	BasePageView
 	Participants      []models.Participant
 	Drivers           []models.Driver
+	Labels            []models.Label
+	ParticipantLabels map[int64][]int64
+	DriverLabels      map[int64][]int64
 	ActivityLocations []models.ActivityLocation
 	OrgVehicles       []models.OrganizationVehicle
 }
@@ -30,11 +34,20 @@ type IndexPageView struct {
 type ParticipantsPageView struct {
 	BasePageView
 	Participants []models.Participant
+	Labels       []models.Label
+	LabelIDs     map[int64][]int64
 }
 
 type DriversPageView struct {
 	BasePageView
-	Drivers []models.Driver
+	Drivers  []models.Driver
+	Labels   []models.Label
+	LabelIDs map[int64][]int64
+}
+
+type LabelsPageView struct {
+	BasePageView
+	Labels []models.Label
 }
 
 type ActivityLocationsPageView struct {
@@ -78,18 +91,34 @@ type HistoryPageView struct {
 
 type ParticipantListView struct {
 	Participants []models.Participant
+	LabelIDs     map[int64][]int64
+	Labels       []models.Label
 }
 
 type ParticipantFormView struct {
-	Participant *models.Participant
+	Participant      *models.Participant
+	Labels           []models.Label
+	SelectedLabelIDs map[int64]bool
 }
 
 type DriverListView struct {
-	Drivers []models.Driver
+	Drivers  []models.Driver
+	LabelIDs map[int64][]int64
+	Labels   []models.Label
 }
 
 type DriverFormView struct {
-	Driver *models.Driver
+	Driver           *models.Driver
+	Labels           []models.Label
+	SelectedLabelIDs map[int64]bool
+}
+
+type LabelListView struct {
+	Labels []models.Label
+}
+
+type LabelFormView struct {
+	Label *models.Label
 }
 
 type ActivityLocationFormView struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -74,6 +74,16 @@ func (d *Driver) GetCoords() Coordinates {
 	return Coordinates{Lat: d.Lat, Lng: d.Lng}
 }
 
+// Label represents a reusable participant and/or driver cohort.
+type Label struct {
+	ID               int64     `json:"id"`
+	Name             string    `json:"name"`
+	ParticipantCount int       `json:"participant_count"`
+	DriverCount      int       `json:"driver_count"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
 // ActivityLocation represents a location where activities take place
 type ActivityLocation struct {
 	ID      int64   `json:"id"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -193,7 +193,7 @@ func loadTemplates(templatesFS fs.FS) (*handlers.TemplateSet, error) {
 
 	// Load page templates as strings (don't parse into base)
 	pages := make(map[string]string)
-	pageFiles := []string{"index.html", "participants.html", "drivers.html", "activity_locations.html", "vans.html", "settings.html", "history.html"}
+	pageFiles := []string{"index.html", "participants.html", "drivers.html", "labels.html", "activity_locations.html", "vans.html", "settings.html", "history.html"}
 	for _, name := range pageFiles {
 		content, err := fs.ReadFile(templatesFS, "templates/"+name)
 		if err != nil {
@@ -290,11 +290,18 @@ func setupRoutes(handler *handlers.Handler, staticFS fs.FS) *http.ServeMux {
 	mux.HandleFunc("/api/v1/config/database", handleMethods(handler.HandleGetDatabaseConfig, nil, handler.HandleUpdateDatabaseConfig, nil))
 	mux.HandleFunc("/api/v1/config/routing-provider", handleMethods(handler.HandleGetRoutingProviderConfig, nil, handler.HandleUpdateRoutingProviderConfig, nil))
 	mux.HandleFunc("/api/v1/participants", handleMethods(handler.HandleListParticipants, handler.HandleCreateParticipant, nil, nil))
+	mux.HandleFunc("/api/v1/participants/labels/add", requireMethod(http.MethodPost, handler.HandleAddParticipantsToLabel))
+	mux.HandleFunc("/api/v1/participants/labels/remove", requireMethod(http.MethodPost, handler.HandleRemoveParticipantsFromLabel))
 	mux.HandleFunc("/api/v1/participants/new", requireMethod(http.MethodGet, handler.HandleParticipantForm))
 	mux.HandleFunc("/api/v1/participants/", handleResourcePath("/api/v1/participants/", "/edit", handler.HandleParticipantForm, handler.HandleGetParticipant, handler.HandleUpdateParticipant, handler.HandleDeleteParticipant))
 	mux.HandleFunc("/api/v1/drivers", handleMethods(handler.HandleListDrivers, handler.HandleCreateDriver, nil, nil))
+	mux.HandleFunc("/api/v1/drivers/labels/add", requireMethod(http.MethodPost, handler.HandleAddDriversToLabel))
+	mux.HandleFunc("/api/v1/drivers/labels/remove", requireMethod(http.MethodPost, handler.HandleRemoveDriversFromLabel))
 	mux.HandleFunc("/api/v1/drivers/new", requireMethod(http.MethodGet, handler.HandleDriverForm))
 	mux.HandleFunc("/api/v1/drivers/", handleResourcePath("/api/v1/drivers/", "/edit", handler.HandleDriverForm, handler.HandleGetDriver, handler.HandleUpdateDriver, handler.HandleDeleteDriver))
+	mux.HandleFunc("/api/v1/labels", handleMethods(handler.HandleListLabels, handler.HandleCreateLabel, nil, nil))
+	mux.HandleFunc("/api/v1/labels/new", requireMethod(http.MethodGet, handler.HandleLabelForm))
+	mux.HandleFunc("/api/v1/labels/", handleResourcePath("/api/v1/labels/", "/edit", handler.HandleLabelForm, handler.HandleGetLabel, handler.HandleUpdateLabel, handler.HandleDeleteLabel))
 	mux.HandleFunc("/api/v1/routes/calculate", requireMethod(http.MethodPost, handler.HandleCalculateRoutes))
 	mux.HandleFunc("/api/v1/routes/calculate-with-org-vehicles", requireMethod(http.MethodPost, handler.HandleCalculateRoutesWithOrgVehicles))
 	mux.HandleFunc("/api/v1/routes/edit/move-participant", requireMethod(http.MethodPost, handler.HandleMoveParticipant))
@@ -321,6 +328,7 @@ func setupRoutes(handler *handlers.Handler, staticFS fs.FS) *http.ServeMux {
 
 	mux.HandleFunc("/participants", requireMethod(http.MethodGet, handler.HandleParticipantsPage))
 	mux.HandleFunc("/drivers", requireMethod(http.MethodGet, handler.HandleDriversPage))
+	mux.HandleFunc("/labels", requireMethod(http.MethodGet, handler.HandleLabelsPage))
 	mux.HandleFunc("/activity-locations", requireMethod(http.MethodGet, handler.HandleActivityLocationsPage))
 	mux.HandleFunc("/vans", requireMethod(http.MethodGet, handler.HandleVansPage))
 	mux.HandleFunc("/settings", requireMethod(http.MethodGet, handler.HandleSettingsPage))

--- a/internal/sqlite/drivers.go
+++ b/internal/sqlite/drivers.go
@@ -144,6 +144,45 @@ func (r *driverRepository) Create(ctx context.Context, d *models.Driver) (*model
 	return d, nil
 }
 
+func (r *driverRepository) CreateWithLabels(ctx context.Context, d *models.Driver, labelIDs []int64) (*models.Driver, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin driver label transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	now := time.Now()
+	d.CreatedAt = now
+	d.UpdatedAt = now
+
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO drivers (name, address, lat, lng, vehicle_capacity, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, d.Name, d.Address, d.Lat, d.Lng, d.VehicleCapacity, d.CreatedAt, d.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create driver: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last insert id: %w", err)
+	}
+	d.ID = id
+
+	if err := insertLabelMemberships(ctx, tx, "driver_labels", "driver_id", d.ID, labelIDs); err != nil {
+		return nil, fmt.Errorf("failed to insert driver label memberships: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit driver label transaction: %w", err)
+	}
+
+	return d, nil
+}
+
 func (r *driverRepository) Update(ctx context.Context, d *models.Driver) (*models.Driver, error) {
 	r.store.mu.Lock()
 	defer r.store.mu.Unlock()
@@ -167,6 +206,50 @@ func (r *driverRepository) Update(ctx context.Context, d *models.Driver) (*model
 	}
 	if rows == 0 {
 		return nil, database.ErrNotFound
+	}
+
+	return d, nil
+}
+
+func (r *driverRepository) UpdateWithLabels(ctx context.Context, d *models.Driver, labelIDs []int64) (*models.Driver, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin driver label transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	d.UpdatedAt = time.Now()
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE drivers
+		SET name = ?, address = ?, lat = ?, lng = ?, vehicle_capacity = ?, updated_at = ?
+		WHERE id = ?
+	`, d.Name, d.Address, d.Lat, d.Lng, d.VehicleCapacity, d.UpdatedAt, d.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update driver: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return nil, database.ErrNotFound
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM driver_labels WHERE driver_id = ?`, d.ID); err != nil {
+		return nil, fmt.Errorf("failed to clear driver label memberships: %w", err)
+	}
+
+	if err := insertLabelMemberships(ctx, tx, "driver_labels", "driver_id", d.ID, labelIDs); err != nil {
+		return nil, fmt.Errorf("failed to insert driver label memberships: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit driver label transaction: %w", err)
 	}
 
 	return d, nil

--- a/internal/sqlite/events_test.go
+++ b/internal/sqlite/events_test.go
@@ -24,7 +24,7 @@ func TestStoreMigratesLegacyEventTablesAndPreservesVisibleHistory(t *testing.T) 
 		}
 	})
 
-	assertSchemaVersion(t, store.db, 3)
+	assertSchemaVersion(t, store.db, 4)
 
 	for _, tableName := range []string{
 		"events_legacy",
@@ -112,7 +112,7 @@ func TestStoreMigratesLegacyEventTablesAndPreservesVisibleHistory(t *testing.T) 
 	assertRowCount(t, store.db, "event_summaries_legacy", 1)
 }
 
-func TestStoreFreshSchemaCreatesV3EventTables(t *testing.T) {
+func TestStoreFreshSchemaCreatesV4Tables(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "fresh-schema.db")
 
 	store, err := New(dbPath)
@@ -125,9 +125,12 @@ func TestStoreFreshSchemaCreatesV3EventTables(t *testing.T) {
 		}
 	})
 
-	assertSchemaVersion(t, store.db, 3)
+	assertSchemaVersion(t, store.db, 4)
 
 	for _, tableName := range []string{"events", "event_routes", "event_route_stops", "event_summaries"} {
+		assertTableExists(t, store.db, tableName)
+	}
+	for _, tableName := range []string{"labels", "participant_labels", "driver_labels"} {
 		assertTableExists(t, store.db, tableName)
 	}
 

--- a/internal/sqlite/labels.go
+++ b/internal/sqlite/labels.go
@@ -80,6 +80,60 @@ func (r *labelRepository) GetByID(ctx context.Context, id int64) (*models.Label,
 	return &label, nil
 }
 
+func (r *labelRepository) GetByIDs(ctx context.Context, ids []int64) ([]models.Label, error) {
+	if len(ids) == 0 {
+		return []models.Label{}, nil
+	}
+
+	r.store.mu.RLock()
+	defer r.store.mu.RUnlock()
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	rows, err := r.store.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT l.id, l.name,
+		       COALESCE(pl.participant_count, 0),
+		       COALESCE(dl.driver_count, 0),
+		       l.created_at, l.updated_at
+		FROM labels l
+		LEFT JOIN (
+			SELECT label_id, COUNT(*) AS participant_count
+			FROM participant_labels
+			GROUP BY label_id
+		) pl ON pl.label_id = l.id
+		LEFT JOIN (
+			SELECT label_id, COUNT(*) AS driver_count
+			FROM driver_labels
+			GROUP BY label_id
+		) dl ON dl.label_id = l.id
+		WHERE l.id IN (%s)
+		ORDER BY l.name
+	`, strings.Join(placeholders, ",")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query labels by IDs: %w", err)
+	}
+	defer rows.Close()
+
+	var labels []models.Label
+	for rows.Next() {
+		var label models.Label
+		if err := rows.Scan(&label.ID, &label.Name, &label.ParticipantCount, &label.DriverCount, &label.CreatedAt, &label.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan label: %w", err)
+		}
+		labels = append(labels, label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed iterating labels by IDs: %w", err)
+	}
+
+	return labels, nil
+}
+
 func (r *labelRepository) Create(ctx context.Context, label *models.Label) (*models.Label, error) {
 	r.store.mu.Lock()
 	defer r.store.mu.Unlock()
@@ -244,6 +298,31 @@ func (r *labelRepository) listLabelsForOwner(ctx context.Context, tableName, own
 	}
 
 	return labels, nil
+}
+
+func insertLabelMemberships(ctx context.Context, tx *sql.Tx, tableName, ownerColumn string, ownerID int64, labelIDs []int64) error {
+	if err := validateLabelMembershipTable(tableName, ownerColumn); err != nil {
+		return err
+	}
+
+	seen := make(map[int64]struct{}, len(labelIDs))
+	for _, labelID := range labelIDs {
+		if labelID <= 0 {
+			continue
+		}
+		if _, exists := seen[labelID]; exists {
+			continue
+		}
+		seen[labelID] = struct{}{}
+
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s (label_id, %s)
+			VALUES (?, ?)
+		`, tableName, ownerColumn), labelID, ownerID); err != nil {
+			return fmt.Errorf("failed to insert label membership: %w", err)
+		}
+	}
+	return nil
 }
 
 func (r *labelRepository) replaceMemberships(ctx context.Context, tableName, ownerColumn string, ownerID int64, labelIDs []int64) error {

--- a/internal/sqlite/labels.go
+++ b/internal/sqlite/labels.go
@@ -1,0 +1,408 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"ride-home-router/internal/database"
+	"ride-home-router/internal/models"
+)
+
+type labelRepository struct {
+	store *Store
+}
+
+func (r *labelRepository) List(ctx context.Context) ([]models.Label, error) {
+	r.store.mu.RLock()
+	defer r.store.mu.RUnlock()
+
+	rows, err := r.store.db.QueryContext(ctx, `
+		SELECT l.id, l.name,
+		       COALESCE(pl.participant_count, 0),
+		       COALESCE(dl.driver_count, 0),
+		       l.created_at, l.updated_at
+		FROM labels l
+		LEFT JOIN (
+			SELECT label_id, COUNT(*) AS participant_count
+			FROM participant_labels
+			GROUP BY label_id
+		) pl ON pl.label_id = l.id
+		LEFT JOIN (
+			SELECT label_id, COUNT(*) AS driver_count
+			FROM driver_labels
+			GROUP BY label_id
+		) dl ON dl.label_id = l.id
+		ORDER BY l.name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query labels: %w", err)
+	}
+	defer rows.Close()
+
+	var labels []models.Label
+	for rows.Next() {
+		var label models.Label
+		if err := rows.Scan(&label.ID, &label.Name, &label.ParticipantCount, &label.DriverCount, &label.CreatedAt, &label.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan label: %w", err)
+		}
+		labels = append(labels, label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed iterating labels: %w", err)
+	}
+
+	return labels, nil
+}
+
+func (r *labelRepository) GetByID(ctx context.Context, id int64) (*models.Label, error) {
+	r.store.mu.RLock()
+	defer r.store.mu.RUnlock()
+
+	var label models.Label
+	err := r.store.db.QueryRowContext(ctx, `
+		SELECT l.id, l.name,
+		       COALESCE((SELECT COUNT(*) FROM participant_labels WHERE label_id = l.id), 0),
+		       COALESCE((SELECT COUNT(*) FROM driver_labels WHERE label_id = l.id), 0),
+		       l.created_at, l.updated_at
+		FROM labels l
+		WHERE l.id = ?
+	`, id).Scan(&label.ID, &label.Name, &label.ParticipantCount, &label.DriverCount, &label.CreatedAt, &label.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get label: %w", err)
+	}
+
+	return &label, nil
+}
+
+func (r *labelRepository) Create(ctx context.Context, label *models.Label) (*models.Label, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	label.Name = strings.TrimSpace(label.Name)
+	now := time.Now()
+	label.CreatedAt = now
+	label.UpdatedAt = now
+
+	result, err := r.store.db.ExecContext(ctx, `
+		INSERT INTO labels (name, created_at, updated_at)
+		VALUES (?, ?, ?)
+	`, label.Name, label.CreatedAt, label.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create label: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last insert id: %w", err)
+	}
+	label.ID = id
+
+	return label, nil
+}
+
+func (r *labelRepository) Update(ctx context.Context, label *models.Label) (*models.Label, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	label.Name = strings.TrimSpace(label.Name)
+	label.UpdatedAt = time.Now()
+
+	result, err := r.store.db.ExecContext(ctx, `
+		UPDATE labels
+		SET name = ?, updated_at = ?
+		WHERE id = ?
+	`, label.Name, label.UpdatedAt, label.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update label: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return nil, database.ErrNotFound
+	}
+
+	return label, nil
+}
+
+func (r *labelRepository) Delete(ctx context.Context, id int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	result, err := r.store.db.ExecContext(ctx, `DELETE FROM labels WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete label: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return database.ErrNotFound
+	}
+
+	return nil
+}
+
+func (r *labelRepository) ListLabelsForParticipant(ctx context.Context, participantID int64) ([]models.Label, error) {
+	return r.listLabelsForOwner(ctx, "participant_labels", "participant_id", participantID)
+}
+
+func (r *labelRepository) ListLabelsForDriver(ctx context.Context, driverID int64) ([]models.Label, error) {
+	return r.listLabelsForOwner(ctx, "driver_labels", "driver_id", driverID)
+}
+
+func (r *labelRepository) SetLabelsForParticipant(ctx context.Context, participantID int64, labelIDs []int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	return r.replaceMemberships(ctx, "participant_labels", "participant_id", participantID, labelIDs)
+}
+
+func (r *labelRepository) SetLabelsForDriver(ctx context.Context, driverID int64, labelIDs []int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	return r.replaceMemberships(ctx, "driver_labels", "driver_id", driverID, labelIDs)
+}
+
+func (r *labelRepository) AddLabelToParticipants(ctx context.Context, labelID int64, participantIDs []int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	return r.addMemberships(ctx, "participant_labels", "participant_id", labelID, participantIDs)
+}
+
+func (r *labelRepository) RemoveLabelFromParticipants(ctx context.Context, labelID int64, participantIDs []int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	return r.removeMemberships(ctx, "participant_labels", "participant_id", labelID, participantIDs)
+}
+
+func (r *labelRepository) AddLabelToDrivers(ctx context.Context, labelID int64, driverIDs []int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	return r.addMemberships(ctx, "driver_labels", "driver_id", labelID, driverIDs)
+}
+
+func (r *labelRepository) RemoveLabelFromDrivers(ctx context.Context, labelID int64, driverIDs []int64) error {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	return r.removeMemberships(ctx, "driver_labels", "driver_id", labelID, driverIDs)
+}
+
+func (r *labelRepository) ListLabelIDsForParticipants(ctx context.Context) (map[int64][]int64, error) {
+	return r.listLabelIDsForOwners(ctx, "participant_labels", "participant_id")
+}
+
+func (r *labelRepository) ListLabelIDsForDrivers(ctx context.Context) (map[int64][]int64, error) {
+	return r.listLabelIDsForOwners(ctx, "driver_labels", "driver_id")
+}
+
+func (r *labelRepository) listLabelsForOwner(ctx context.Context, tableName, ownerColumn string, ownerID int64) ([]models.Label, error) {
+	if err := validateLabelMembershipTable(tableName, ownerColumn); err != nil {
+		return nil, err
+	}
+
+	r.store.mu.RLock()
+	defer r.store.mu.RUnlock()
+
+	rows, err := r.store.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT l.id, l.name, l.created_at, l.updated_at
+		FROM labels l
+		INNER JOIN %s membership ON membership.label_id = l.id
+		WHERE membership.%s = ?
+		ORDER BY l.name
+	`, tableName, ownerColumn), ownerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query owner labels: %w", err)
+	}
+	defer rows.Close()
+
+	var labels []models.Label
+	for rows.Next() {
+		var label models.Label
+		if err := rows.Scan(&label.ID, &label.Name, &label.CreatedAt, &label.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan owner label: %w", err)
+		}
+		labels = append(labels, label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed iterating owner labels: %w", err)
+	}
+
+	return labels, nil
+}
+
+func (r *labelRepository) replaceMemberships(ctx context.Context, tableName, ownerColumn string, ownerID int64, labelIDs []int64) error {
+	if err := validateLabelMembershipTable(tableName, ownerColumn); err != nil {
+		return err
+	}
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin label membership transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s = ?`, tableName, ownerColumn), ownerID); err != nil {
+		return fmt.Errorf("failed to clear label memberships: %w", err)
+	}
+
+	seen := make(map[int64]struct{}, len(labelIDs))
+	for _, labelID := range labelIDs {
+		if labelID <= 0 {
+			continue
+		}
+		if _, exists := seen[labelID]; exists {
+			continue
+		}
+		seen[labelID] = struct{}{}
+
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s (label_id, %s)
+			VALUES (?, ?)
+		`, tableName, ownerColumn), labelID, ownerID); err != nil {
+			return fmt.Errorf("failed to insert label membership: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit label membership transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (r *labelRepository) addMemberships(ctx context.Context, tableName, ownerColumn string, labelID int64, ownerIDs []int64) error {
+	if err := validateLabelMembershipTable(tableName, ownerColumn); err != nil {
+		return err
+	}
+	if labelID <= 0 {
+		return nil
+	}
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin add label memberships transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	seen := make(map[int64]struct{}, len(ownerIDs))
+	for _, ownerID := range ownerIDs {
+		if ownerID <= 0 {
+			continue
+		}
+		if _, exists := seen[ownerID]; exists {
+			continue
+		}
+		seen[ownerID] = struct{}{}
+
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT OR IGNORE INTO %s (label_id, %s)
+			VALUES (?, ?)
+		`, tableName, ownerColumn), labelID, ownerID); err != nil {
+			return fmt.Errorf("failed to add label membership: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit add label memberships transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (r *labelRepository) removeMemberships(ctx context.Context, tableName, ownerColumn string, labelID int64, ownerIDs []int64) error {
+	if err := validateLabelMembershipTable(tableName, ownerColumn); err != nil {
+		return err
+	}
+	if labelID <= 0 || len(ownerIDs) == 0 {
+		return nil
+	}
+
+	placeholders := make([]string, 0, len(ownerIDs))
+	args := make([]any, 0, len(ownerIDs)+1)
+	args = append(args, labelID)
+	seen := make(map[int64]struct{}, len(ownerIDs))
+	for _, ownerID := range ownerIDs {
+		if ownerID <= 0 {
+			continue
+		}
+		if _, exists := seen[ownerID]; exists {
+			continue
+		}
+		seen[ownerID] = struct{}{}
+		placeholders = append(placeholders, "?")
+		args = append(args, ownerID)
+	}
+	if len(placeholders) == 0 {
+		return nil
+	}
+
+	_, err := r.store.db.ExecContext(ctx, fmt.Sprintf(`
+		DELETE FROM %s
+		WHERE label_id = ? AND %s IN (%s)
+	`, tableName, ownerColumn, strings.Join(placeholders, ",")), args...)
+	if err != nil {
+		return fmt.Errorf("failed to remove label memberships: %w", err)
+	}
+
+	return nil
+}
+
+func (r *labelRepository) listLabelIDsForOwners(ctx context.Context, tableName, ownerColumn string) (map[int64][]int64, error) {
+	if err := validateLabelMembershipTable(tableName, ownerColumn); err != nil {
+		return nil, err
+	}
+
+	r.store.mu.RLock()
+	defer r.store.mu.RUnlock()
+
+	rows, err := r.store.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT %s, label_id
+		FROM %s
+		ORDER BY %s, label_id
+	`, ownerColumn, tableName, ownerColumn))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query label IDs: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[int64][]int64)
+	for rows.Next() {
+		var ownerID, labelID int64
+		if err := rows.Scan(&ownerID, &labelID); err != nil {
+			return nil, fmt.Errorf("failed to scan label ID: %w", err)
+		}
+		result[ownerID] = append(result[ownerID], labelID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed iterating label IDs: %w", err)
+	}
+
+	return result, nil
+}
+
+func validateLabelMembershipTable(tableName, ownerColumn string) error {
+	switch {
+	case tableName == "participant_labels" && ownerColumn == "participant_id":
+		return nil
+	case tableName == "driver_labels" && ownerColumn == "driver_id":
+		return nil
+	default:
+		return fmt.Errorf("invalid label membership target")
+	}
+}

--- a/internal/sqlite/labels.go
+++ b/internal/sqlite/labels.go
@@ -308,7 +308,7 @@ func insertLabelMemberships(ctx context.Context, tx *sql.Tx, tableName, ownerCol
 	seen := make(map[int64]struct{}, len(labelIDs))
 	for _, labelID := range labelIDs {
 		if labelID <= 0 {
-			continue
+			return fmt.Errorf("invalid label ID: %d", labelID)
 		}
 		if _, exists := seen[labelID]; exists {
 			continue
@@ -340,22 +340,8 @@ func (r *labelRepository) replaceMemberships(ctx context.Context, tableName, own
 		return fmt.Errorf("failed to clear label memberships: %w", err)
 	}
 
-	seen := make(map[int64]struct{}, len(labelIDs))
-	for _, labelID := range labelIDs {
-		if labelID <= 0 {
-			continue
-		}
-		if _, exists := seen[labelID]; exists {
-			continue
-		}
-		seen[labelID] = struct{}{}
-
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-			INSERT INTO %s (label_id, %s)
-			VALUES (?, ?)
-		`, tableName, ownerColumn), labelID, ownerID); err != nil {
-			return fmt.Errorf("failed to insert label membership: %w", err)
-		}
+	if err := insertLabelMemberships(ctx, tx, tableName, ownerColumn, ownerID, labelIDs); err != nil {
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/sqlite/labels_test.go
+++ b/internal/sqlite/labels_test.go
@@ -129,7 +129,7 @@ func TestLabelRepository_SetAndBulkMembershipsAreIdempotent(t *testing.T) {
 	participantTwo := createTestParticipant(t, store, "Rider Two")
 	driver := createTestDriver(t, store, "Driver One")
 
-	if err := store.Labels().SetLabelsForParticipant(ctx, participantOne.ID, []int64{firstLabel.ID, firstLabel.ID, 0, secondLabel.ID}); err != nil {
+	if err := store.Labels().SetLabelsForParticipant(ctx, participantOne.ID, []int64{firstLabel.ID, firstLabel.ID, secondLabel.ID}); err != nil {
 		t.Fatalf("SetLabelsForParticipant() error = %v", err)
 	}
 	participantLabels, err := store.Labels().ListLabelsForParticipant(ctx, participantOne.ID)
@@ -194,6 +194,37 @@ func TestLabelRepository_SetAndBulkMembershipsAreIdempotent(t *testing.T) {
 	}
 }
 
+func TestLabelRepository_SetLabelsRejectsNonPositiveLabelIDWithoutMutation(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	firstLabel, err := store.Labels().Create(ctx, &models.Label{Name: "First"})
+	if err != nil {
+		t.Fatalf("create first label: %v", err)
+	}
+	secondLabel, err := store.Labels().Create(ctx, &models.Label{Name: "Second"})
+	if err != nil {
+		t.Fatalf("create second label: %v", err)
+	}
+	participant := createTestParticipant(t, store, "Rider One")
+	if err := store.Labels().SetLabelsForParticipant(ctx, participant.ID, []int64{firstLabel.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() initial error = %v", err)
+	}
+
+	err = store.Labels().SetLabelsForParticipant(ctx, participant.ID, []int64{secondLabel.ID, 0})
+	if err == nil {
+		t.Fatal("SetLabelsForParticipant() error = nil, want invalid label error")
+	}
+
+	labels, err := store.Labels().ListLabelsForParticipant(ctx, participant.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != firstLabel.ID {
+		t.Fatalf("participant labels = %#v, want original label preserved", labels)
+	}
+}
+
 func TestParticipantRepository_CreateWithLabelsRollsBackOnInvalidLabel(t *testing.T) {
 	store := newTestLabelStore(t)
 	ctx := context.Background()
@@ -204,6 +235,24 @@ func TestParticipantRepository_CreateWithLabelsRollsBackOnInvalidLabel(t *testin
 		Lat:     40.1,
 		Lng:     -73.9,
 	}, []int64{9999})
+	if err == nil {
+		t.Fatal("CreateWithLabels() error = nil, want invalid label error")
+	}
+
+	assertRowCount(t, store.db, "participants", 0)
+	assertRowCount(t, store.db, "participant_labels", 0)
+}
+
+func TestParticipantRepository_CreateWithLabelsRollsBackOnNonPositiveLabel(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	_, err := store.Participants().CreateWithLabels(ctx, &models.Participant{
+		Name:    "Rider With Bad Label",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	}, []int64{0})
 	if err == nil {
 		t.Fatal("CreateWithLabels() error = nil, want invalid label error")
 	}

--- a/internal/sqlite/labels_test.go
+++ b/internal/sqlite/labels_test.go
@@ -84,6 +84,35 @@ func TestLabelRepository_CRUDCountsAndUniqueness(t *testing.T) {
 	assertRowCount(t, store.db, "driver_labels", 0)
 }
 
+func TestLabelRepository_GetByIDsReturnsExistingLabels(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	first, err := store.Labels().Create(ctx, &models.Label{Name: "First"})
+	if err != nil {
+		t.Fatalf("create first label: %v", err)
+	}
+	second, err := store.Labels().Create(ctx, &models.Label{Name: "Second"})
+	if err != nil {
+		t.Fatalf("create second label: %v", err)
+	}
+
+	labels, err := store.Labels().GetByIDs(ctx, []int64{second.ID, first.ID, second.ID, 9999})
+	if err != nil {
+		t.Fatalf("GetByIDs() error = %v", err)
+	}
+	if len(labels) != 2 {
+		t.Fatalf("labels = %#v, want two existing unique labels", labels)
+	}
+	found := map[int64]bool{}
+	for _, label := range labels {
+		found[label.ID] = true
+	}
+	if !found[first.ID] || !found[second.ID] {
+		t.Fatalf("labels = %#v, want first and second labels", labels)
+	}
+}
+
 func TestLabelRepository_SetAndBulkMembershipsAreIdempotent(t *testing.T) {
 	store := newTestLabelStore(t)
 	ctx := context.Background()
@@ -163,6 +192,85 @@ func TestLabelRepository_SetAndBulkMembershipsAreIdempotent(t *testing.T) {
 	if len(driverLabels) != 1 || driverLabels[0].ID != secondLabel.ID {
 		t.Fatalf("driver labels = %#v, want second label only", driverLabels)
 	}
+}
+
+func TestParticipantRepository_CreateWithLabelsRollsBackOnInvalidLabel(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	_, err := store.Participants().CreateWithLabels(ctx, &models.Participant{
+		Name:    "Rider With Bad Label",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	}, []int64{9999})
+	if err == nil {
+		t.Fatal("CreateWithLabels() error = nil, want invalid label error")
+	}
+
+	assertRowCount(t, store.db, "participants", 0)
+	assertRowCount(t, store.db, "participant_labels", 0)
+}
+
+func TestParticipantRepository_UpdateWithLabelsRollsBackOnInvalidLabel(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+	participant := createTestParticipant(t, store, "Original Rider")
+
+	participant.Name = "Changed Rider"
+	_, err := store.Participants().UpdateWithLabels(ctx, participant, []int64{9999})
+	if err == nil {
+		t.Fatal("UpdateWithLabels() error = nil, want invalid label error")
+	}
+
+	unchanged, err := store.Participants().GetByID(ctx, participant.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if unchanged.Name != "Original Rider" {
+		t.Fatalf("participant name = %q, want rollback to Original Rider", unchanged.Name)
+	}
+	assertRowCount(t, store.db, "participant_labels", 0)
+}
+
+func TestDriverRepository_CreateWithLabelsRollsBackOnInvalidLabel(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	_, err := store.Drivers().CreateWithLabels(ctx, &models.Driver{
+		Name:            "Driver With Bad Label",
+		Address:         "1 Driver Way",
+		Lat:             40.1,
+		Lng:             -73.9,
+		VehicleCapacity: 4,
+	}, []int64{9999})
+	if err == nil {
+		t.Fatal("CreateWithLabels() error = nil, want invalid label error")
+	}
+
+	assertRowCount(t, store.db, "drivers", 0)
+	assertRowCount(t, store.db, "driver_labels", 0)
+}
+
+func TestDriverRepository_UpdateWithLabelsRollsBackOnInvalidLabel(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+	driver := createTestDriver(t, store, "Original Driver")
+
+	driver.Name = "Changed Driver"
+	_, err := store.Drivers().UpdateWithLabels(ctx, driver, []int64{9999})
+	if err == nil {
+		t.Fatal("UpdateWithLabels() error = nil, want invalid label error")
+	}
+
+	unchanged, err := store.Drivers().GetByID(ctx, driver.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if unchanged.Name != "Original Driver" {
+		t.Fatalf("driver name = %q, want rollback to Original Driver", unchanged.Name)
+	}
+	assertRowCount(t, store.db, "driver_labels", 0)
 }
 
 func TestStoreMigratesV3DatabaseToV4LabelsSchema(t *testing.T) {

--- a/internal/sqlite/labels_test.go
+++ b/internal/sqlite/labels_test.go
@@ -1,0 +1,269 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"ride-home-router/internal/database"
+	"ride-home-router/internal/models"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestLabelRepository_CRUDCountsAndUniqueness(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	label, err := store.Labels().Create(ctx, &models.Label{Name: "  Youth Conference  "})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if label.Name != "Youth Conference" {
+		t.Fatalf("label.Name = %q, want trimmed name", label.Name)
+	}
+
+	if _, err := store.Labels().Create(ctx, &models.Label{Name: "Youth Conference"}); err == nil {
+		t.Fatal("Create() duplicate error = nil, want unique constraint error")
+	}
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{
+		Name:    "Rider One",
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{
+		Name:            "Driver One",
+		Address:         "1 Driver Way",
+		Lat:             40.2,
+		Lng:             -73.8,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	if err := store.Labels().SetLabelsForParticipant(ctx, participant.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+	if err := store.Labels().SetLabelsForDriver(ctx, driver.ID, []int64{label.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+
+	labels, err := store.Labels().List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(labels) != 1 {
+		t.Fatalf("List() len = %d, want 1", len(labels))
+	}
+	if labels[0].ParticipantCount != 1 || labels[0].DriverCount != 1 {
+		t.Fatalf("counts = participants:%d drivers:%d, want 1/1", labels[0].ParticipantCount, labels[0].DriverCount)
+	}
+
+	label.Name = "Updated Label"
+	updated, err := store.Labels().Update(ctx, label)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.Name != "Updated Label" {
+		t.Fatalf("updated.Name = %q, want Updated Label", updated.Name)
+	}
+
+	if err := store.Labels().Delete(ctx, label.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if err := store.Labels().Delete(ctx, label.ID); err != database.ErrNotFound {
+		t.Fatalf("second Delete() error = %v, want ErrNotFound", err)
+	}
+	assertRowCount(t, store.db, "participant_labels", 0)
+	assertRowCount(t, store.db, "driver_labels", 0)
+}
+
+func TestLabelRepository_SetAndBulkMembershipsAreIdempotent(t *testing.T) {
+	store := newTestLabelStore(t)
+	ctx := context.Background()
+
+	firstLabel, err := store.Labels().Create(ctx, &models.Label{Name: "First"})
+	if err != nil {
+		t.Fatalf("create first label: %v", err)
+	}
+	secondLabel, err := store.Labels().Create(ctx, &models.Label{Name: "Second"})
+	if err != nil {
+		t.Fatalf("create second label: %v", err)
+	}
+	participantOne := createTestParticipant(t, store, "Rider One")
+	participantTwo := createTestParticipant(t, store, "Rider Two")
+	driver := createTestDriver(t, store, "Driver One")
+
+	if err := store.Labels().SetLabelsForParticipant(ctx, participantOne.ID, []int64{firstLabel.ID, firstLabel.ID, 0, secondLabel.ID}); err != nil {
+		t.Fatalf("SetLabelsForParticipant() error = %v", err)
+	}
+	participantLabels, err := store.Labels().ListLabelsForParticipant(ctx, participantOne.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForParticipant() error = %v", err)
+	}
+	if len(participantLabels) != 2 {
+		t.Fatalf("participant label count = %d, want 2", len(participantLabels))
+	}
+
+	if err := store.Labels().SetLabelsForParticipant(ctx, participantOne.ID, []int64{secondLabel.ID}); err != nil {
+		t.Fatalf("replace SetLabelsForParticipant() error = %v", err)
+	}
+	labelIDs, err := store.Labels().ListLabelIDsForParticipants(ctx)
+	if err != nil {
+		t.Fatalf("ListLabelIDsForParticipants() error = %v", err)
+	}
+	if got := labelIDs[participantOne.ID]; len(got) != 1 || got[0] != secondLabel.ID {
+		t.Fatalf("participant label IDs = %#v, want [%d]", got, secondLabel.ID)
+	}
+
+	if err := store.Labels().AddLabelToParticipants(ctx, firstLabel.ID, []int64{participantOne.ID, participantTwo.ID, participantTwo.ID}); err != nil {
+		t.Fatalf("AddLabelToParticipants() error = %v", err)
+	}
+	if err := store.Labels().AddLabelToParticipants(ctx, firstLabel.ID, []int64{participantOne.ID}); err != nil {
+		t.Fatalf("second AddLabelToParticipants() error = %v", err)
+	}
+	labelIDs, err = store.Labels().ListLabelIDsForParticipants(ctx)
+	if err != nil {
+		t.Fatalf("ListLabelIDsForParticipants() after add error = %v", err)
+	}
+	if got := labelIDs[participantTwo.ID]; len(got) != 1 || got[0] != firstLabel.ID {
+		t.Fatalf("participant two label IDs = %#v, want [%d]", got, firstLabel.ID)
+	}
+
+	if err := store.Labels().RemoveLabelFromParticipants(ctx, firstLabel.ID, []int64{participantOne.ID, participantTwo.ID}); err != nil {
+		t.Fatalf("RemoveLabelFromParticipants() error = %v", err)
+	}
+	if err := store.Labels().RemoveLabelFromParticipants(ctx, firstLabel.ID, []int64{participantOne.ID}); err != nil {
+		t.Fatalf("second RemoveLabelFromParticipants() error = %v", err)
+	}
+	labelIDs, err = store.Labels().ListLabelIDsForParticipants(ctx)
+	if err != nil {
+		t.Fatalf("ListLabelIDsForParticipants() after remove error = %v", err)
+	}
+	if got := labelIDs[participantTwo.ID]; len(got) != 0 {
+		t.Fatalf("participant two label IDs after remove = %#v, want empty", got)
+	}
+
+	if err := store.Labels().SetLabelsForDriver(ctx, driver.ID, []int64{firstLabel.ID, secondLabel.ID}); err != nil {
+		t.Fatalf("SetLabelsForDriver() error = %v", err)
+	}
+	if err := store.Labels().RemoveLabelFromDrivers(ctx, firstLabel.ID, []int64{driver.ID}); err != nil {
+		t.Fatalf("RemoveLabelFromDrivers() error = %v", err)
+	}
+	driverLabels, err := store.Labels().ListLabelsForDriver(ctx, driver.ID)
+	if err != nil {
+		t.Fatalf("ListLabelsForDriver() error = %v", err)
+	}
+	if len(driverLabels) != 1 || driverLabels[0].ID != secondLabel.ID {
+		t.Fatalf("driver labels = %#v, want second label only", driverLabels)
+	}
+}
+
+func TestStoreMigratesV3DatabaseToV4LabelsSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v3-label-migration.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	_, err = db.Exec(`
+		PRAGMA foreign_keys = ON;
+		CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+		INSERT INTO schema_version (version) VALUES (3);
+		CREATE TABLE participants (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			address TEXT NOT NULL,
+			lat REAL NOT NULL,
+			lng REAL NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE drivers (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			address TEXT NOT NULL,
+			lat REAL NOT NULL,
+			lng REAL NOT NULL,
+			vehicle_capacity INTEGER NOT NULL DEFAULT 4,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		INSERT INTO participants (name, address, lat, lng) VALUES ('Rider', '1 Rider Way', 40.1, -73.9);
+		INSERT INTO drivers (name, address, lat, lng, vehicle_capacity) VALUES ('Driver', '1 Driver Way', 40.2, -73.8, 4);
+	`)
+	if err != nil {
+		t.Fatalf("seed v3 database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close seed database: %v", err)
+	}
+
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	assertSchemaVersion(t, store.db, 4)
+	for _, tableName := range []string{"labels", "participant_labels", "driver_labels"} {
+		assertTableExists(t, store.db, tableName)
+	}
+	assertRowCount(t, store.db, "participants", 1)
+	assertRowCount(t, store.db, "drivers", 1)
+}
+
+func newTestLabelStore(t *testing.T) *Store {
+	t.Helper()
+
+	store, err := New(filepath.Join(t.TempDir(), "labels-test.db"))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	return store
+}
+
+func createTestParticipant(t *testing.T, store *Store, name string) *models.Participant {
+	t.Helper()
+
+	participant, err := store.Participants().Create(context.Background(), &models.Participant{
+		Name:    name,
+		Address: "1 Rider Way",
+		Lat:     40.1,
+		Lng:     -73.9,
+	})
+	if err != nil {
+		t.Fatalf("create participant %q: %v", name, err)
+	}
+	return participant
+}
+
+func createTestDriver(t *testing.T, store *Store, name string) *models.Driver {
+	t.Helper()
+
+	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
+		Name:            name,
+		Address:         "1 Driver Way",
+		Lat:             40.2,
+		Lng:             -73.8,
+		VehicleCapacity: 4,
+	})
+	if err != nil {
+		t.Fatalf("create driver %q: %v", name, err)
+	}
+	return driver
+}

--- a/internal/sqlite/participants.go
+++ b/internal/sqlite/participants.go
@@ -145,6 +145,45 @@ func (r *participantRepository) Create(ctx context.Context, p *models.Participan
 	return p, nil
 }
 
+func (r *participantRepository) CreateWithLabels(ctx context.Context, p *models.Participant, labelIDs []int64) (*models.Participant, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin participant label transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	now := time.Now()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO participants (name, address, lat, lng, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, p.Name, p.Address, p.Lat, p.Lng, p.CreatedAt, p.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create participant: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last insert id: %w", err)
+	}
+	p.ID = id
+
+	if err := insertLabelMemberships(ctx, tx, "participant_labels", "participant_id", p.ID, labelIDs); err != nil {
+		return nil, fmt.Errorf("failed to insert participant label memberships: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit participant label transaction: %w", err)
+	}
+
+	return p, nil
+}
+
 func (r *participantRepository) Update(ctx context.Context, p *models.Participant) (*models.Participant, error) {
 	r.store.mu.Lock()
 	defer r.store.mu.Unlock()
@@ -168,6 +207,50 @@ func (r *participantRepository) Update(ctx context.Context, p *models.Participan
 	}
 	if rows == 0 {
 		return nil, database.ErrNotFound
+	}
+
+	return p, nil
+}
+
+func (r *participantRepository) UpdateWithLabels(ctx context.Context, p *models.Participant, labelIDs []int64) (*models.Participant, error) {
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+
+	tx, err := r.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin participant label transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	p.UpdatedAt = time.Now()
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE participants
+		SET name = ?, address = ?, lat = ?, lng = ?, updated_at = ?
+		WHERE id = ?
+	`, p.Name, p.Address, p.Lat, p.Lng, p.UpdatedAt, p.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update participant: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return nil, database.ErrNotFound
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM participant_labels WHERE participant_id = ?`, p.ID); err != nil {
+		return nil, fmt.Errorf("failed to clear participant label memberships: %w", err)
+	}
+
+	if err := insertLabelMemberships(ctx, tx, "participant_labels", "participant_id", p.ID, labelIDs); err != nil {
+		return nil, fmt.Errorf("failed to insert participant label memberships: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit participant label transaction: %w", err)
 	}
 
 	return p, nil

--- a/internal/sqlite/store.go
+++ b/internal/sqlite/store.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	DefaultDBFileName = "data.db"
-	schemaVersion     = 3
-	sqliteCacheSizeKB = -64000 // 64MB cache (negative = KiB)
+	DefaultDBFileName   = "data.db"
+	schemaVersion       = 4
+	sqliteCacheSizeKB   = -64000 // 64MB cache (negative = KiB)
 	sqliteBusyTimeoutMS = 5000
 )
 
@@ -34,6 +34,7 @@ type Store struct {
 	organizationVehicleRepo database.OrganizationVehicleRepository
 	eventRepo               database.EventRepository
 	distanceCacheRepo       database.DistanceCacheRepository
+	labelRepo               database.LabelRepository
 }
 
 // New creates a new SQLite store at the specified path
@@ -86,6 +87,7 @@ func New(dbPath string) (*Store, error) {
 	store.organizationVehicleRepo = &organizationVehicleRepository{store: store}
 	store.eventRepo = &eventRepository{store: store}
 	store.distanceCacheRepo = &distanceCacheRepository{store: store}
+	store.labelRepo = &labelRepository{store: store}
 
 	return store, nil
 }
@@ -118,7 +120,7 @@ func (s *Store) createSchema() error {
 	CREATE TABLE IF NOT EXISTS schema_version (
 		version INTEGER PRIMARY KEY
 	);
-	INSERT INTO schema_version (version) VALUES (3);
+	INSERT INTO schema_version (version) VALUES (4);
 
 	-- Activity locations
 	CREATE TABLE IF NOT EXISTS activity_locations (
@@ -159,6 +161,30 @@ func (s *Store) createSchema() error {
 		capacity INTEGER NOT NULL,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	-- Labels
+	CREATE TABLE IF NOT EXISTS labels (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL UNIQUE,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS participant_labels (
+		label_id INTEGER NOT NULL,
+		participant_id INTEGER NOT NULL,
+		PRIMARY KEY (label_id, participant_id),
+		FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+		FOREIGN KEY (participant_id) REFERENCES participants(id) ON DELETE CASCADE
+	);
+
+	CREATE TABLE IF NOT EXISTS driver_labels (
+		label_id INTEGER NOT NULL,
+		driver_id INTEGER NOT NULL,
+		PRIMARY KEY (label_id, driver_id),
+		FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+		FOREIGN KEY (driver_id) REFERENCES drivers(id) ON DELETE CASCADE
 	);
 
 	-- Settings (single row table)
@@ -242,6 +268,9 @@ func (s *Store) createSchema() error {
 	-- Indexes for common queries
 	CREATE INDEX IF NOT EXISTS idx_participants_name ON participants(name);
 	CREATE INDEX IF NOT EXISTS idx_drivers_name ON drivers(name);
+	CREATE INDEX IF NOT EXISTS idx_labels_name ON labels(name);
+	CREATE INDEX IF NOT EXISTS idx_participant_labels_participant ON participant_labels(participant_id);
+	CREATE INDEX IF NOT EXISTS idx_driver_labels_driver ON driver_labels(driver_id);
 	CREATE INDEX IF NOT EXISTS idx_events_date ON events(event_date DESC);
 	CREATE INDEX IF NOT EXISTS idx_event_routes_event ON event_routes(event_id);
 	CREATE INDEX IF NOT EXISTS idx_event_route_stops_route ON event_route_stops(event_route_id);
@@ -360,6 +389,39 @@ func (s *Store) runMigrations(fromVersion int) error {
 		}
 		if err := backfillLegacyEventHistory(tx); err != nil {
 			return err
+		}
+	}
+
+	if fromVersion < 4 {
+		if _, err := tx.Exec(`
+			CREATE TABLE IF NOT EXISTS labels (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL UNIQUE,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			);
+
+			CREATE TABLE IF NOT EXISTS participant_labels (
+				label_id INTEGER NOT NULL,
+				participant_id INTEGER NOT NULL,
+				PRIMARY KEY (label_id, participant_id),
+				FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+				FOREIGN KEY (participant_id) REFERENCES participants(id) ON DELETE CASCADE
+			);
+
+			CREATE TABLE IF NOT EXISTS driver_labels (
+				label_id INTEGER NOT NULL,
+				driver_id INTEGER NOT NULL,
+				PRIMARY KEY (label_id, driver_id),
+				FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+				FOREIGN KEY (driver_id) REFERENCES drivers(id) ON DELETE CASCADE
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_labels_name ON labels(name);
+			CREATE INDEX IF NOT EXISTS idx_participant_labels_participant ON participant_labels(participant_id);
+			CREATE INDEX IF NOT EXISTS idx_driver_labels_driver ON driver_labels(driver_id);
+		`); err != nil {
+			return fmt.Errorf("failed to create v4 label tables: %w", err)
 		}
 	}
 
@@ -771,3 +833,4 @@ func (s *Store) OrganizationVehicles() database.OrganizationVehicleRepository {
 }
 func (s *Store) Events() database.EventRepository                { return s.eventRepo }
 func (s *Store) DistanceCache() database.DistanceCacheRepository { return s.distanceCacheRepo }
+func (s *Store) Labels() database.LabelRepository                { return s.labelRepo }

--- a/internal/sqlite/store.go
+++ b/internal/sqlite/store.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	DefaultDBFileName   = "data.db"
-	schemaVersion       = 3
+	schemaVersion       = 4
 	sqliteCacheSizeKB   = -64000 // 64MB cache (negative = KiB)
 	sqliteBusyTimeoutMS = 5000
 )
@@ -34,6 +34,7 @@ type Store struct {
 	organizationVehicleRepo database.OrganizationVehicleRepository
 	eventRepo               database.EventRepository
 	distanceCacheRepo       database.DistanceCacheRepository
+	labelRepo               database.LabelRepository
 }
 
 // New creates a new SQLite store at the specified path
@@ -86,6 +87,7 @@ func New(dbPath string) (*Store, error) {
 	store.organizationVehicleRepo = &organizationVehicleRepository{store: store}
 	store.eventRepo = &eventRepository{store: store}
 	store.distanceCacheRepo = &distanceCacheRepository{store: store}
+	store.labelRepo = &labelRepository{store: store}
 
 	return store, nil
 }
@@ -158,6 +160,30 @@ func (s *Store) createSchema() error {
 		capacity INTEGER NOT NULL,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	-- Labels
+	CREATE TABLE IF NOT EXISTS labels (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL UNIQUE,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS participant_labels (
+		label_id INTEGER NOT NULL,
+		participant_id INTEGER NOT NULL,
+		PRIMARY KEY (label_id, participant_id),
+		FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+		FOREIGN KEY (participant_id) REFERENCES participants(id) ON DELETE CASCADE
+	);
+
+	CREATE TABLE IF NOT EXISTS driver_labels (
+		label_id INTEGER NOT NULL,
+		driver_id INTEGER NOT NULL,
+		PRIMARY KEY (label_id, driver_id),
+		FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+		FOREIGN KEY (driver_id) REFERENCES drivers(id) ON DELETE CASCADE
 	);
 
 	-- Settings (single row table)
@@ -241,6 +267,9 @@ func (s *Store) createSchema() error {
 	-- Indexes for common queries
 	CREATE INDEX IF NOT EXISTS idx_participants_name ON participants(name);
 	CREATE INDEX IF NOT EXISTS idx_drivers_name ON drivers(name);
+	CREATE INDEX IF NOT EXISTS idx_labels_name ON labels(name);
+	CREATE INDEX IF NOT EXISTS idx_participant_labels_participant ON participant_labels(participant_id);
+	CREATE INDEX IF NOT EXISTS idx_driver_labels_driver ON driver_labels(driver_id);
 	CREATE INDEX IF NOT EXISTS idx_events_date ON events(event_date DESC);
 	CREATE INDEX IF NOT EXISTS idx_event_routes_event ON event_routes(event_id);
 	CREATE INDEX IF NOT EXISTS idx_event_route_stops_route ON event_route_stops(event_route_id);
@@ -372,6 +401,39 @@ func (s *Store) runMigrations(fromVersion int) error {
 		}
 		if err := backfillLegacyEventHistory(tx); err != nil {
 			return err
+		}
+	}
+
+	if fromVersion < 4 {
+		if _, err := tx.Exec(`
+			CREATE TABLE IF NOT EXISTS labels (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL UNIQUE,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			);
+
+			CREATE TABLE IF NOT EXISTS participant_labels (
+				label_id INTEGER NOT NULL,
+				participant_id INTEGER NOT NULL,
+				PRIMARY KEY (label_id, participant_id),
+				FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+				FOREIGN KEY (participant_id) REFERENCES participants(id) ON DELETE CASCADE
+			);
+
+			CREATE TABLE IF NOT EXISTS driver_labels (
+				label_id INTEGER NOT NULL,
+				driver_id INTEGER NOT NULL,
+				PRIMARY KEY (label_id, driver_id),
+				FOREIGN KEY (label_id) REFERENCES labels(id) ON DELETE CASCADE,
+				FOREIGN KEY (driver_id) REFERENCES drivers(id) ON DELETE CASCADE
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_labels_name ON labels(name);
+			CREATE INDEX IF NOT EXISTS idx_participant_labels_participant ON participant_labels(participant_id);
+			CREATE INDEX IF NOT EXISTS idx_driver_labels_driver ON driver_labels(driver_id);
+		`); err != nil {
+			return fmt.Errorf("failed to create v4 label tables: %w", err)
 		}
 	}
 
@@ -783,3 +845,4 @@ func (s *Store) OrganizationVehicles() database.OrganizationVehicleRepository {
 }
 func (s *Store) Events() database.EventRepository                { return s.eventRepo }
 func (s *Store) DistanceCache() database.DistanceCacheRepository { return s.distanceCacheRepo }
+func (s *Store) Labels() database.LabelRepository                { return s.labelRepo }

--- a/internal/templateutil/helpers.go
+++ b/internal/templateutil/helpers.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"ride-home-router/internal/models"
 )
 
 const (
@@ -98,6 +100,23 @@ func FuncMap() template.FuncMap {
 				parts = append(parts, strconv.FormatInt(v, 10))
 			}
 			return strings.Join(parts, ",")
+		},
+		"labelNamesFor": func(labels []models.Label, m map[int64][]int64, id int64) []string {
+			values := m[id]
+			if len(values) == 0 {
+				return nil
+			}
+			namesByID := make(map[int64]string, len(labels))
+			for _, label := range labels {
+				namesByID[label.ID] = label.Name
+			}
+			names := make([]string, 0, len(values))
+			for _, labelID := range values {
+				if name, ok := namesByID[labelID]; ok {
+					names = append(names, name)
+				}
+			}
+			return names
 		},
 	}
 }

--- a/internal/templateutil/helpers.go
+++ b/internal/templateutil/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -75,6 +76,28 @@ func FuncMap() template.FuncMap {
 				return ""
 			}
 			return strings.ToUpper(string(first[0]) + string(last[0]))
+		},
+		"dict": func(keyvals ...any) map[string]any {
+			m := make(map[string]any, len(keyvals)/2)
+			for i := 0; i+1 < len(keyvals); i += 2 {
+				key, ok := keyvals[i].(string)
+				if !ok {
+					continue
+				}
+				m[key] = keyvals[i+1]
+			}
+			return m
+		},
+		"labelIDsFor": func(m map[int64][]int64, id int64) string {
+			values := m[id]
+			if len(values) == 0 {
+				return ""
+			}
+			parts := make([]string, 0, len(values))
+			for _, v := range values {
+				parts = append(parts, strconv.FormatInt(v, 10))
+			}
+			return strings.Join(parts, ",")
 		},
 	}
 }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1130,6 +1130,12 @@ tbody tr:last-child td {
     border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border));
 }
 
+.table-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
 .list-card {
     margin-bottom: 0.75rem;
     padding: 1rem 1.1rem;

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -456,6 +456,20 @@ p {
     padding: 0 1.25rem 0.85rem;
 }
 
+.panel-toolbar-stack {
+    align-items: stretch;
+    flex-direction: column;
+}
+
+.bulk-toolbar,
+.filter-chip-toolbar,
+.filter-chip-list {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
 .panel-body {
     padding: 0 1.25rem 1.25rem;
 }
@@ -561,6 +575,50 @@ p {
     color: var(--primary);
     background: var(--primary-faint);
     border-color: var(--primary);
+}
+
+.btn-dropdown {
+    position: relative;
+    display: inline-flex;
+}
+
+.btn-dropdown-menu {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 0.35rem);
+    left: 0;
+    display: none;
+    min-width: 12rem;
+    max-height: 16rem;
+    overflow: auto;
+    padding: 0.35rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    box-shadow: var(--shadow-lg);
+}
+
+.btn-dropdown.is-open .btn-dropdown-menu {
+    display: flex;
+    flex-direction: column;
+}
+
+.btn-dropdown-item {
+    width: 100%;
+    padding: 0.55rem 0.65rem;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text);
+    font: inherit;
+    font-size: 0.82rem;
+    text-align: left;
+    cursor: pointer;
+}
+
+.btn-dropdown-item:hover {
+    background: var(--primary-faint);
+    color: var(--primary);
 }
 
 .btn-success {
@@ -736,6 +794,36 @@ p {
     color: var(--text);
     font-size: 0.85rem;
     cursor: pointer;
+}
+
+.checkbox-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.8rem;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text-muted);
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+.filter-chip:hover,
+.filter-chip.is-active {
+    border-color: var(--primary);
+    background: var(--primary-faint);
+    color: var(--primary);
 }
 
 .ui-select {

--- a/web/static/js/ui.js
+++ b/web/static/js/ui.js
@@ -19,6 +19,51 @@ function filterTable(input, tbodyId) {
   });
 }
 
+function updateBulkSelectionCount(tbodyId) {
+  const tbody = document.getElementById(tbodyId);
+  if (!tbody) return;
+
+  const count = tbody.querySelectorAll('input[data-bulk-row]:checked').length;
+  const countEl = document.getElementById(tbodyId.replace('-tbody', '-bulk-selected-count'));
+  if (countEl) countEl.textContent = String(count);
+}
+
+function selectVisibleTableRows(tbodyId, shouldSelect) {
+  const tbody = document.getElementById(tbodyId);
+  if (!tbody) return;
+
+  tbody.querySelectorAll('tr[data-search]').forEach(row => {
+    if (row.classList.contains('hidden')) return;
+
+    const checkbox = row.querySelector('input[data-bulk-row]');
+    if (checkbox) checkbox.checked = !!shouldSelect;
+  });
+
+  updateBulkSelectionCount(tbodyId);
+}
+
+function clearTableSelection(tbodyId) {
+  const tbody = document.getElementById(tbodyId);
+  if (!tbody) return;
+
+  tbody.querySelectorAll('input[data-bulk-row]').forEach(checkbox => {
+    checkbox.checked = false;
+  });
+
+  updateBulkSelectionCount(tbodyId);
+}
+
+function toggleBulkDropdown(button) {
+  const wrapper = button.closest('.btn-dropdown');
+  if (!wrapper) return;
+
+  document.querySelectorAll('.btn-dropdown.is-open').forEach(dropdown => {
+    if (dropdown !== wrapper) dropdown.classList.remove('is-open');
+  });
+
+  wrapper.classList.toggle('is-open');
+}
+
 /**
  * Toggle event detail expansion in history view.
  * @param {HTMLElement} eventItem - The event item element
@@ -370,6 +415,12 @@ function toggleEventDetail(eventItem, eventId) {
     document.querySelectorAll(".ui-select.is-open").forEach((container) => {
       if (container !== clickedSelect) closeSelect(container);
     });
+
+    if (!e.target.closest(".btn-dropdown")) {
+      document.querySelectorAll(".btn-dropdown.is-open").forEach((dropdown) => {
+        dropdown.classList.remove("is-open");
+      });
+    }
   });
 
   function initAddressAutocomplete() {
@@ -425,6 +476,12 @@ function toggleEventDetail(eventItem, eventId) {
     initAll(e.target);
     initSettingsValidation();
     initAddressAutocomplete();
+  });
+
+  document.addEventListener("htmx:beforeRequest", () => {
+    document.querySelectorAll(".btn-dropdown.is-open").forEach((dropdown) => {
+      dropdown.classList.remove("is-open");
+    });
   });
 
   document.addEventListener("htmx:confirm", (e) => {

--- a/web/static/js/ui.js
+++ b/web/static/js/ui.js
@@ -53,6 +53,16 @@ function clearTableSelection(tbodyId) {
   updateBulkSelectionCount(tbodyId);
 }
 
+document.body.addEventListener('htmx:afterSwap', event => {
+  const targetId = event.target && event.target.id;
+  if (targetId === 'participants-list') {
+    updateBulkSelectionCount('participants-tbody');
+  }
+  if (targetId === 'drivers-list') {
+    updateBulkSelectionCount('drivers-tbody');
+  }
+});
+
 function toggleBulkDropdown(button) {
   const wrapper = button.closest('.btn-dropdown');
   if (!wrapper) return;

--- a/web/templates/drivers.html
+++ b/web/templates/drivers.html
@@ -28,7 +28,48 @@
         </div>
     </div>
 
-    <div class="panel-toolbar">
+    <form id="driver-bulk-form" onsubmit="return false">
+    <div class="panel-toolbar panel-toolbar-stack">
+        {{if .Labels}}
+        <div class="bulk-toolbar">
+            <span class="panel-count text-muted"><span id="drivers-bulk-selected-count">0</span> selected</span>
+            <div class="btn-dropdown">
+                <button type="button" class="btn btn-sm btn-outline" onclick="toggleBulkDropdown(this)">Add label</button>
+                <div class="btn-dropdown-menu">
+                    {{range .Labels}}
+                    <button type="button"
+                            class="btn-dropdown-item"
+                            onclick="this.closest('.btn-dropdown').classList.remove('is-open')"
+                            hx-post="/api/v1/drivers/labels/add"
+                            hx-vals='{"label_id": "{{.ID}}"}'
+                            hx-include="#driver-bulk-form input[name='driver_ids']:checked"
+                            hx-target="#drivers-list"
+                            hx-swap="innerHTML">
+                        {{.Name}}
+                    </button>
+                    {{end}}
+                </div>
+            </div>
+            <div class="btn-dropdown">
+                <button type="button" class="btn btn-sm btn-outline" onclick="toggleBulkDropdown(this)">Remove label</button>
+                <div class="btn-dropdown-menu">
+                    {{range .Labels}}
+                    <button type="button"
+                            class="btn-dropdown-item"
+                            onclick="this.closest('.btn-dropdown').classList.remove('is-open')"
+                            hx-post="/api/v1/drivers/labels/remove"
+                            hx-vals='{"label_id": "{{.ID}}"}'
+                            hx-include="#driver-bulk-form input[name='driver_ids']:checked"
+                            hx-target="#drivers-list"
+                            hx-swap="innerHTML">
+                        {{.Name}}
+                    </button>
+                    {{end}}
+                </div>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline" onclick="clearTableSelection('drivers-tbody')">Clear selection</button>
+        </div>
+        {{end}}
         <input type="search"
                class="form-input form-input-search"
                placeholder="Search drivers…"
@@ -39,5 +80,6 @@
     <div id="drivers-list" class="table-container mb-0">
         {{template "driver_list" .}}
     </div>
+    </form>
 </section>
 {{end}}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -92,11 +92,31 @@
             </div>
 
             {{if .Participants}}
-            <div class="panel-toolbar">
+            <div class="panel-toolbar panel-toolbar-stack">
+                {{if .Labels}}
+                <div class="filter-chip-toolbar">
+                    <div class="filter-chip-list" id="participants-label-filters">
+                        {{range .Labels}}
+                        <button type="button"
+                                class="filter-chip label-filter-chip"
+                                data-list-id="participants-selection"
+                                data-label-id="{{.ID}}"
+                                aria-pressed="false"
+                                onclick="toggleLabelFilter(this)">
+                            {{.Name}}
+                        </button>
+                        {{end}}
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline" onclick="clearPlannerFilters('participants-selection')">Clear filters</button>
+                </div>
+                {{end}}
                 <input type="search"
+                       id="participants-search"
                        class="form-input form-input-search"
                        placeholder="Search participants…"
                        aria-label="Search participants"
+                       data-filter-role="search"
+                       data-list-id="participants-selection"
                        oninput="filterSelectList(this, 'participants-selection')">
                 <span class="panel-count text-muted">
                     <span id="participants-selected-count">0</span> selected
@@ -105,7 +125,9 @@
 
             <div class="select-list" id="participants-selection">
                 {{range .Participants}}
-                <label class="select-row" data-search="{{.Name}} {{.Address}}">
+                <label class="select-row"
+                       data-search="{{.Name}} {{.Address}}"
+                       data-labels="{{labelIDsFor $.ParticipantLabels .ID}}">
                     <input type="checkbox"
                            name="participant_ids"
                            value="{{.ID}}"
@@ -137,11 +159,31 @@
             </div>
 
             {{if .Drivers}}
-            <div class="panel-toolbar">
+            <div class="panel-toolbar panel-toolbar-stack">
+                {{if .Labels}}
+                <div class="filter-chip-toolbar">
+                    <div class="filter-chip-list" id="drivers-label-filters">
+                        {{range .Labels}}
+                        <button type="button"
+                                class="filter-chip label-filter-chip"
+                                data-list-id="drivers-selection"
+                                data-label-id="{{.ID}}"
+                                aria-pressed="false"
+                                onclick="toggleLabelFilter(this)">
+                            {{.Name}}
+                        </button>
+                        {{end}}
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline" onclick="clearPlannerFilters('drivers-selection')">Clear filters</button>
+                </div>
+                {{end}}
                 <input type="search"
+                       id="drivers-search"
                        class="form-input form-input-search"
                        placeholder="Search drivers…"
                        aria-label="Search drivers"
+                       data-filter-role="search"
+                       data-list-id="drivers-selection"
                        oninput="filterSelectList(this, 'drivers-selection')">
                 <span class="panel-count text-muted">
                     <span id="drivers-selected-count">0</span> selected •
@@ -151,7 +193,9 @@
 
             <div class="select-list" id="drivers-selection">
                 {{range .Drivers}}
-                <label class="select-row" data-search="{{.Name}} {{.Address}}">
+                <label class="select-row"
+                       data-search="{{.Name}} {{.Address}}"
+                       data-labels="{{labelIDsFor $.DriverLabels .ID}}">
                     <input type="checkbox"
                            name="driver_ids"
                            value="{{.ID}}"
@@ -316,6 +360,7 @@
             mode: selectedMode ? selectedMode.value : 'dropoff',
             routeTime: routeTime ? routeTime.value : '',
             vanAssignments: getVanAssignments(),
+            labelFilters: getPlannerLabelFilters(),
         };
 
         try {
@@ -370,6 +415,9 @@
 
             applyCheckedValues('.participant-checkbox', draft.participantIds);
             applyCheckedValues('.driver-checkbox', draft.driverIds);
+            applyPlannerLabelFilters(draft.labelFilters);
+            recomputeSelectListVisibility('participants-selection');
+            recomputeSelectListVisibility('drivers-selection');
 
             renderVanAssignmentsPanel();
 
@@ -573,23 +621,85 @@
         }
     }
 
-    function filterSelectList(input, listId) {
+    function getActiveLabelFilters(listId) {
+        return Array.from(document.querySelectorAll(`.label-filter-chip[data-list-id="${listId}"].is-active`))
+            .map(button => button.dataset.labelId);
+    }
+
+    function getPlannerLabelFilters() {
+        return {
+            participants: getActiveLabelFilters('participants-selection'),
+            drivers: getActiveLabelFilters('drivers-selection'),
+        };
+    }
+
+    function applyPlannerLabelFilters(filters) {
+        const participantFilters = Array.isArray(filters && filters.participants) ? filters.participants.map(String) : [];
+        const driverFilters = Array.isArray(filters && filters.drivers) ? filters.drivers.map(String) : [];
+
+        setActiveLabelFilters('participants-selection', participantFilters);
+        setActiveLabelFilters('drivers-selection', driverFilters);
+    }
+
+    function setActiveLabelFilters(listId, activeIDs) {
+        const active = new Set(activeIDs || []);
+        document.querySelectorAll(`.label-filter-chip[data-list-id="${listId}"]`).forEach(button => {
+            const isActive = active.has(String(button.dataset.labelId));
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    }
+
+    function recomputeSelectListVisibility(listId) {
         const list = document.getElementById(listId);
         if (!list) return;
 
-        const query = (input.value || '').trim().toLowerCase();
+        const searchInput = document.querySelector(`input[data-filter-role="search"][data-list-id="${listId}"]`);
+        const query = (searchInput ? searchInput.value : '').trim().toLowerCase();
+        const activeLabels = new Set(getActiveLabelFilters(listId));
         const rows = list.querySelectorAll('.select-row');
 
         rows.forEach(row => {
             const haystack = (row.dataset.search || row.textContent || '').toLowerCase();
-            row.classList.toggle('hidden', query.length > 0 && !haystack.includes(query));
+            const matchesSearch = query.length === 0 || haystack.includes(query);
+            const rowLabels = (row.dataset.labels || '').trim();
+            const labelIDs = rowLabels ? rowLabels.split(',').filter(Boolean) : [];
+            const matchesLabels = activeLabels.size === 0 || labelIDs.some(id => activeLabels.has(id));
+            row.classList.toggle('hidden', !(matchesSearch && matchesLabels));
         });
+    }
+
+    function filterSelectList(input, listId) {
+        recomputeSelectListVisibility(listId);
+        saveEventPlannerDraft();
+    }
+
+    function toggleLabelFilter(button) {
+        const isActive = !button.classList.contains('is-active');
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        recomputeSelectListVisibility(button.dataset.listId);
+        saveEventPlannerDraft();
+    }
+
+    function clearPlannerFilters(listId) {
+        setActiveLabelFilters(listId, []);
+        const searchInput = document.querySelector(`input[data-filter-role="search"][data-list-id="${listId}"]`);
+        if (searchInput) searchInput.value = '';
+        recomputeSelectListVisibility(listId);
+        saveEventPlannerDraft();
+    }
+
+    function clearAllPlannerFilters() {
+        clearPlannerFilters('participants-selection');
+        clearPlannerFilters('drivers-selection');
     }
 
     function selectAllParticipants() {
         document.querySelectorAll('.participant-checkbox').forEach(cb => {
-            cb.checked = true;
             const row = cb.closest('.select-row');
+            if (row && row.classList.contains('hidden')) return;
+            cb.checked = true;
             if (row) row.classList.add('is-selected');
         });
         updateEventStats();
@@ -598,8 +708,9 @@
 
     function selectAllDrivers() {
         document.querySelectorAll('.driver-checkbox').forEach(cb => {
-            cb.checked = true;
             const row = cb.closest('.select-row');
+            if (row && row.classList.contains('hidden')) return;
+            cb.checked = true;
             if (row) row.classList.add('is-selected');
         });
         renderVanAssignmentsPanel();
@@ -615,6 +726,14 @@
             if (row) row.classList.remove('is-selected');
         });
         if (form) {
+            setActiveLabelFilters('participants-selection', []);
+            setActiveLabelFilters('drivers-selection', []);
+            form.querySelectorAll('input[data-filter-role="search"]').forEach(input => {
+                input.value = '';
+            });
+            recomputeSelectListVisibility('participants-selection');
+            recomputeSelectListVisibility('drivers-selection');
+
             const activityLocation = form.querySelector('select[name="activity_location_id"]');
             if (activityLocation) {
                 activityLocation.value = '';

--- a/web/templates/labels.html
+++ b/web/templates/labels.html
@@ -1,0 +1,40 @@
+{{define "content"}}
+<div class="page-header">
+    <div>
+        <h2 class="page-title">Labels</h2>
+        <p class="page-subtitle">Create reusable labels for repeat participant and driver cohorts.</p>
+    </div>
+    <div class="page-actions">
+        <button class="btn btn-primary"
+                hx-get="/api/v1/labels/new"
+                hx-target="#label-form-container"
+                hx-swap="innerHTML">
+            Add Label
+        </button>
+    </div>
+</div>
+
+<div id="label-form-container" class="mb-4"></div>
+<div id="error-container"></div>
+
+<section class="panel">
+    <div class="panel-header">
+        <div>
+            <h3 class="panel-title">Saved Labels</h3>
+            <p class="panel-subtitle">Labels can be assigned to participants and drivers, then used as planner filters.</p>
+        </div>
+    </div>
+
+    <div class="panel-toolbar">
+        <input type="search"
+               class="form-input form-input-search"
+               placeholder="Search labels..."
+               aria-label="Search labels"
+               oninput="filterTable(this, 'labels-tbody')">
+    </div>
+
+    <div id="labels-list" class="table-container mb-0">
+        {{template "label_list" .}}
+    </div>
+</section>
+{{end}}

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -20,6 +20,7 @@
                 <a href="/" {{if eq .ActivePage "home"}}class="active"{{end}}>Event Planning</a>
                 <a href="/participants" {{if eq .ActivePage "participants"}}class="active"{{end}}>Participants</a>
                 <a href="/drivers" {{if eq .ActivePage "drivers"}}class="active"{{end}}>Drivers</a>
+                <a href="/labels" {{if eq .ActivePage "labels"}}class="active"{{end}}>Labels</a>
                 <a href="/activity-locations" {{if eq .ActivePage "activity_locations"}}class="active"{{end}}>Activity Locations</a>
                 <a href="/vans" {{if eq .ActivePage "vans"}}class="active"{{end}}>Vans</a>
                 <a href="/history" {{if eq .ActivePage "history"}}class="active"{{end}}>History</a>

--- a/web/templates/partials/driver_form.html
+++ b/web/templates/partials/driver_form.html
@@ -46,6 +46,24 @@
             <div class="form-help">Number of passengers this vehicle can carry (personal vehicle)</div>
         </div>
 
+        {{if .Labels}}
+        <div class="form-group">
+            <label class="form-label">Labels</label>
+            <div class="checkbox-grid">
+                {{range .Labels}}
+                <label class="checkbox-label">
+                    <input type="checkbox"
+                           name="label_ids"
+                           value="{{.ID}}"
+                           class="form-checkbox"
+                           {{if index $.SelectedLabelIDs .ID}}checked{{end}}>
+                    <span>{{.Name}}</span>
+                </label>
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+
         <div class="d-flex align-center gap-2">
             <button type="submit" class="btn btn-primary">
                 {{if .Driver.ID}}Update{{else}}Add{{end}} Driver

--- a/web/templates/partials/driver_list.html
+++ b/web/templates/partials/driver_list.html
@@ -3,6 +3,12 @@
 <table>
     <thead>
         <tr>
+            <th style="width: 42px;">
+                <input type="checkbox"
+                       class="form-checkbox"
+                       aria-label="Select all visible drivers"
+                       onclick="selectVisibleTableRows('drivers-tbody', this.checked)">
+            </th>
             <th>Name</th>
             <th>Address</th>
             <th><abbr title="Available Capacity">Capacity</abbr></th>
@@ -12,7 +18,7 @@
     </thead>
     <tbody id="drivers-tbody">
         {{range .Drivers}}
-        {{template "driver_row" .}}
+        {{template "driver_row" dict "Driver" . "LabelIDs" (labelIDsFor $.LabelIDs .ID)}}
         {{end}}
     </tbody>
 </table>

--- a/web/templates/partials/driver_list.html
+++ b/web/templates/partials/driver_list.html
@@ -11,6 +11,7 @@
             </th>
             <th>Name</th>
             <th>Address</th>
+            <th>Labels</th>
             <th><abbr title="Available Capacity">Capacity</abbr></th>
             <th>Coordinates</th>
             <th style="width: 150px;">Actions</th>
@@ -18,7 +19,7 @@
     </thead>
     <tbody id="drivers-tbody">
         {{range .Drivers}}
-        {{template "driver_row" dict "Driver" . "LabelIDs" (labelIDsFor $.LabelIDs .ID)}}
+        {{template "driver_row" dict "Driver" . "LabelIDs" (labelIDsFor $.LabelIDs .ID) "LabelNames" (labelNamesFor $.Labels $.LabelIDs .ID)}}
         {{end}}
     </tbody>
 </table>

--- a/web/templates/partials/driver_row.html
+++ b/web/templates/partials/driver_row.html
@@ -1,26 +1,36 @@
 {{define "driver_row"}}
-<tr id="driver-{{.ID}}" data-search="{{.Name}} {{.Address}}">
-    <td>{{.Name}}</td>
-    <td>{{.Address}}</td>
-    <td>{{.VehicleCapacity}}</td>
+<tr id="driver-{{.Driver.ID}}" data-search="{{.Driver.Name}} {{.Driver.Address}}" data-labels="{{.LabelIDs}}">
+    <td>
+        <input type="checkbox"
+               name="driver_ids"
+               value="{{.Driver.ID}}"
+               class="form-checkbox bulk-table-checkbox"
+               data-bulk-row
+               onchange="updateBulkSelectionCount('drivers-tbody')">
+    </td>
+    <td>{{.Driver.Name}}</td>
+    <td>{{.Driver.Address}}</td>
+    <td>{{.Driver.VehicleCapacity}}</td>
     <td class="text-muted">
-        {{if and .Lat .Lng}}
-        {{printf "%.4f, %.4f" .Lat .Lng}}
+        {{if and .Driver.Lat .Driver.Lng}}
+        {{printf "%.4f, %.4f" .Driver.Lat .Driver.Lng}}
         {{end}}
     </td>
     <td>
         <div class="table-actions">
-            <button class="btn btn-sm btn-outline"
-                    hx-get="/api/v1/drivers/{{.ID}}/edit"
+            <button type="button"
+                    class="btn btn-sm btn-outline"
+                    hx-get="/api/v1/drivers/{{.Driver.ID}}/edit"
                     hx-target="#driver-form-container"
                     hx-swap="innerHTML">
                 Edit
             </button>
-            <button class="btn btn-sm btn-danger"
-                    hx-delete="/api/v1/drivers/{{.ID}}"
-                    hx-target="#driver-{{.ID}}"
+            <button type="button"
+                    class="btn btn-sm btn-danger"
+                    hx-delete="/api/v1/drivers/{{.Driver.ID}}"
+                    hx-target="#driver-{{.Driver.ID}}"
                     hx-swap="outerHTML swap:1s"
-                    hx-confirm="Are you sure you want to delete {{.Name}}?">
+                    hx-confirm="Are you sure you want to delete {{.Driver.Name}}?">
                 Delete
             </button>
         </div>

--- a/web/templates/partials/driver_row.html
+++ b/web/templates/partials/driver_row.html
@@ -10,6 +10,13 @@
     </td>
     <td>{{.Driver.Name}}</td>
     <td>{{.Driver.Address}}</td>
+    <td>
+        <div class="table-labels">
+            {{range .LabelNames}}
+            <span class="badge badge-muted">{{.}}</span>
+            {{end}}
+        </div>
+    </td>
     <td>{{.Driver.VehicleCapacity}}</td>
     <td class="text-muted">
         {{if and .Driver.Lat .Driver.Lng}}

--- a/web/templates/partials/label_form.html
+++ b/web/templates/partials/label_form.html
@@ -1,0 +1,40 @@
+{{define "label_form"}}
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">{{if .Label.ID}}Edit{{else}}Add New{{end}} Label</h3>
+        <button class="btn btn-sm btn-outline"
+                onclick="document.getElementById('label-form-container').innerHTML = ''">
+            Cancel
+        </button>
+    </div>
+
+    <form {{if .Label.ID}}
+            hx-put="/api/v1/labels/{{.Label.ID}}"
+          {{else}}
+            hx-post="/api/v1/labels"
+          {{end}}
+          hx-target="#labels-list"
+          hx-swap="innerHTML"
+          hx-indicator="#label-form-loading"
+          hx-on::after-request="if(event.detail.successful && event.detail.elt === this) document.getElementById('label-form-container').innerHTML = ''">
+
+        <div class="form-group">
+            <label class="form-label">Name</label>
+            <input type="text"
+                   name="name"
+                   class="form-input"
+                   value="{{.Label.Name}}"
+                   placeholder="Label name"
+                   required>
+            <div class="form-help">Examples: Youth Conference, Summer Camp, Kinston Riders</div>
+        </div>
+
+        <div class="d-flex align-center gap-2">
+            <button type="submit" class="btn btn-primary">
+                {{if .Label.ID}}Update{{else}}Add{{end}} Label
+            </button>
+            <span class="loading htmx-indicator" id="label-form-loading"></span>
+        </div>
+    </form>
+</div>
+{{end}}

--- a/web/templates/partials/label_list.html
+++ b/web/templates/partials/label_list.html
@@ -1,0 +1,47 @@
+{{define "label_list"}}
+{{if .Labels}}
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Participants</th>
+            <th>Drivers</th>
+            <th style="width: 150px;">Actions</th>
+        </tr>
+    </thead>
+    <tbody id="labels-tbody">
+        {{range .Labels}}
+        <tr id="label-{{.ID}}" data-search="{{.Name}}">
+            <td>{{.Name}}</td>
+            <td>{{.ParticipantCount}}</td>
+            <td>{{.DriverCount}}</td>
+            <td>
+                <div class="table-actions">
+                    <button type="button"
+                            class="btn btn-sm btn-outline"
+                            hx-get="/api/v1/labels/{{.ID}}/edit"
+                            hx-target="#label-form-container"
+                            hx-swap="innerHTML">
+                        Edit
+                    </button>
+                    <button type="button"
+                            class="btn btn-sm btn-danger"
+                            hx-delete="/api/v1/labels/{{.ID}}"
+                            hx-target="#labels-list"
+                            hx-swap="innerHTML"
+                            hx-confirm="Are you sure you want to delete {{.Name}}?">
+                        Delete
+                    </button>
+                </div>
+            </td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{else}}
+<div class="empty-state">
+    <h3>No labels yet</h3>
+    <p>Create a label to make repeat event selection faster.</p>
+</div>
+{{end}}
+{{end}}

--- a/web/templates/partials/participant_form.html
+++ b/web/templates/partials/participant_form.html
@@ -34,6 +34,24 @@
             <div class="form-help">Address will be geocoded automatically</div>
         </div>
 
+        {{if .Labels}}
+        <div class="form-group">
+            <label class="form-label">Labels</label>
+            <div class="checkbox-grid">
+                {{range .Labels}}
+                <label class="checkbox-label">
+                    <input type="checkbox"
+                           name="label_ids"
+                           value="{{.ID}}"
+                           class="form-checkbox"
+                           {{if index $.SelectedLabelIDs .ID}}checked{{end}}>
+                    <span>{{.Name}}</span>
+                </label>
+                {{end}}
+            </div>
+        </div>
+        {{end}}
+
         <div class="d-flex align-center gap-2">
             <button type="submit" class="btn btn-primary">
                 {{if .Participant.ID}}Update{{else}}Add{{end}} Participant

--- a/web/templates/partials/participant_list.html
+++ b/web/templates/partials/participant_list.html
@@ -11,13 +11,14 @@
             </th>
             <th>Name</th>
             <th>Address</th>
+            <th>Labels</th>
             <th>Coordinates</th>
             <th style="width: 150px;">Actions</th>
         </tr>
     </thead>
     <tbody id="participants-tbody">
         {{range .Participants}}
-        {{template "participant_row" dict "Participant" . "LabelIDs" (labelIDsFor $.LabelIDs .ID)}}
+        {{template "participant_row" dict "Participant" . "LabelIDs" (labelIDsFor $.LabelIDs .ID) "LabelNames" (labelNamesFor $.Labels $.LabelIDs .ID)}}
         {{end}}
     </tbody>
 </table>

--- a/web/templates/partials/participant_list.html
+++ b/web/templates/partials/participant_list.html
@@ -3,6 +3,12 @@
 <table>
     <thead>
         <tr>
+            <th style="width: 42px;">
+                <input type="checkbox"
+                       class="form-checkbox"
+                       aria-label="Select all visible participants"
+                       onclick="selectVisibleTableRows('participants-tbody', this.checked)">
+            </th>
             <th>Name</th>
             <th>Address</th>
             <th>Coordinates</th>
@@ -11,7 +17,7 @@
     </thead>
     <tbody id="participants-tbody">
         {{range .Participants}}
-        {{template "participant_row" .}}
+        {{template "participant_row" dict "Participant" . "LabelIDs" (labelIDsFor $.LabelIDs .ID)}}
         {{end}}
     </tbody>
 </table>

--- a/web/templates/partials/participant_row.html
+++ b/web/templates/partials/participant_row.html
@@ -10,6 +10,13 @@
     </td>
     <td>{{.Participant.Name}}</td>
     <td>{{.Participant.Address}}</td>
+    <td>
+        <div class="table-labels">
+            {{range .LabelNames}}
+            <span class="badge badge-muted">{{.}}</span>
+            {{end}}
+        </div>
+    </td>
     <td class="text-muted">
         {{if and .Participant.Lat .Participant.Lng}}
         {{printf "%.4f, %.4f" .Participant.Lat .Participant.Lng}}

--- a/web/templates/partials/participant_row.html
+++ b/web/templates/partials/participant_row.html
@@ -1,25 +1,35 @@
 {{define "participant_row"}}
-<tr id="participant-{{.ID}}" data-search="{{.Name}} {{.Address}}">
-    <td>{{.Name}}</td>
-    <td>{{.Address}}</td>
+<tr id="participant-{{.Participant.ID}}" data-search="{{.Participant.Name}} {{.Participant.Address}}" data-labels="{{.LabelIDs}}">
+    <td>
+        <input type="checkbox"
+               name="participant_ids"
+               value="{{.Participant.ID}}"
+               class="form-checkbox bulk-table-checkbox"
+               data-bulk-row
+               onchange="updateBulkSelectionCount('participants-tbody')">
+    </td>
+    <td>{{.Participant.Name}}</td>
+    <td>{{.Participant.Address}}</td>
     <td class="text-muted">
-        {{if and .Lat .Lng}}
-        {{printf "%.4f, %.4f" .Lat .Lng}}
+        {{if and .Participant.Lat .Participant.Lng}}
+        {{printf "%.4f, %.4f" .Participant.Lat .Participant.Lng}}
         {{end}}
     </td>
     <td>
         <div class="table-actions">
-            <button class="btn btn-sm btn-outline"
-                    hx-get="/api/v1/participants/{{.ID}}/edit"
+            <button type="button"
+                    class="btn btn-sm btn-outline"
+                    hx-get="/api/v1/participants/{{.Participant.ID}}/edit"
                     hx-target="#participant-form-container"
                     hx-swap="innerHTML">
                 Edit
             </button>
-            <button class="btn btn-sm btn-danger"
-                    hx-delete="/api/v1/participants/{{.ID}}"
-                    hx-target="#participant-{{.ID}}"
+            <button type="button"
+                    class="btn btn-sm btn-danger"
+                    hx-delete="/api/v1/participants/{{.Participant.ID}}"
+                    hx-target="#participant-{{.Participant.ID}}"
                     hx-swap="outerHTML swap:1s"
-                    hx-confirm="Are you sure you want to delete {{.Name}}?">
+                    hx-confirm="Are you sure you want to delete {{.Participant.Name}}?">
                 Delete
             </button>
         </div>

--- a/web/templates/participants.html
+++ b/web/templates/participants.html
@@ -28,7 +28,48 @@
         </div>
     </div>
 
-    <div class="panel-toolbar">
+    <form id="participant-bulk-form" onsubmit="return false">
+    <div class="panel-toolbar panel-toolbar-stack">
+        {{if .Labels}}
+        <div class="bulk-toolbar">
+            <span class="panel-count text-muted"><span id="participants-bulk-selected-count">0</span> selected</span>
+            <div class="btn-dropdown">
+                <button type="button" class="btn btn-sm btn-outline" onclick="toggleBulkDropdown(this)">Add label</button>
+                <div class="btn-dropdown-menu">
+                    {{range .Labels}}
+                    <button type="button"
+                            class="btn-dropdown-item"
+                            onclick="this.closest('.btn-dropdown').classList.remove('is-open')"
+                            hx-post="/api/v1/participants/labels/add"
+                            hx-vals='{"label_id": "{{.ID}}"}'
+                            hx-include="#participant-bulk-form input[name='participant_ids']:checked"
+                            hx-target="#participants-list"
+                            hx-swap="innerHTML">
+                        {{.Name}}
+                    </button>
+                    {{end}}
+                </div>
+            </div>
+            <div class="btn-dropdown">
+                <button type="button" class="btn btn-sm btn-outline" onclick="toggleBulkDropdown(this)">Remove label</button>
+                <div class="btn-dropdown-menu">
+                    {{range .Labels}}
+                    <button type="button"
+                            class="btn-dropdown-item"
+                            onclick="this.closest('.btn-dropdown').classList.remove('is-open')"
+                            hx-post="/api/v1/participants/labels/remove"
+                            hx-vals='{"label_id": "{{.ID}}"}'
+                            hx-include="#participant-bulk-form input[name='participant_ids']:checked"
+                            hx-target="#participants-list"
+                            hx-swap="innerHTML">
+                        {{.Name}}
+                    </button>
+                    {{end}}
+                </div>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline" onclick="clearTableSelection('participants-tbody')">Clear selection</button>
+        </div>
+        {{end}}
         <input type="search"
                class="form-input form-input-search"
                placeholder="Search participants…"
@@ -39,5 +80,6 @@
     <div id="participants-list" class="table-container mb-0">
         {{template "participant_list" .}}
     </div>
+    </form>
 </section>
 {{end}}


### PR DESCRIPTION
### Problem
Repeated event rosters require manually finding the same participants and drivers each time. There was no reusable cohorting/filtering mechanism for planner selection.

### Changes
- Added SQLite-backed Labels with participant and driver membership tables.
- Added Labels CRUD page/API and nav entry.
- Added label assignment to participant and driver forms.
- Added bulk add/remove label actions to participant and driver management tables.
- Added planner label filters with visible-only Select all, persisted filter draft state, and Clear all filter reset behavior.
- Added repository, handler, page, and template coverage for label flows.

### Decisions
- User-facing and code term is Labels, not Groups, to avoid conflict with routing household groups.
- Label names are required after trimming and unique; labels may have zero members.
- Planner filters are client-side and combine multiple labels with OR, then search narrows results.
- Clear filters does not uncheck people; Clear all resets filters and selections.

### Testing
- `go test ./internal/sqlite ./internal/handlers`
- `go test ./...`
- `make test`
- `make lint`
- `git diff --check`

<details>
<summary>Agent Context</summary>

Implemented from the no-Linear-ticket Rocket-plan spec using branch name `add-labels` as the work identifier. PR #28 was used only as reference; this rebuild follows current typed view model, route helper, and SQLite migration patterns. `_scratch/_context/add-labels.md` was updated locally but is ignored by git. Browser/manual UI verification has not been run yet.

</details>