### PR TITLE
Reduce route solve and edit latency

### DIFF
--- a/internal/distance/google.go
+++ b/internal/distance/google.go
@@ -157,26 +157,41 @@ func (c *googleCalculator) GetDistancesFromPoint(ctx context.Context, origin mod
 	}
 
 	results := make([]DistanceResult, len(destinations))
-	var missingDestinations []models.Coordinates
-	var missingIndexes []int
+	cachePairs := make([]struct{ Origin, Dest models.Coordinates }, 0, len(destinations))
+	cacheIndexes := make([]int, 0, len(destinations))
 	for i, dest := range destinations {
 		if sameRoundedPoint(origin, dest) {
 			continue
 		}
+		cachePairs = append(cachePairs, struct{ Origin, Dest models.Coordinates }{Origin: origin, Dest: dest})
+		cacheIndexes = append(cacheIndexes, i)
+	}
 
-		cached, err := c.cache.Get(ctx, origin, dest)
-		if err != nil && !errors.Is(err, database.ErrCacheMiss) {
-			return nil, err
-		}
-		if cached != nil {
-			results[i] = DistanceResult{
-				DistanceMeters: cached.DistanceMeters,
-				DurationSecs:   cached.DurationSecs,
+	cached, err := c.cache.GetBatch(ctx, cachePairs)
+	if err != nil {
+		return nil, err
+	}
+
+	var missingDestinations []models.Coordinates
+	var missingIndexes []int
+	for pairIndex, pair := range cachePairs {
+		resultIndex := cacheIndexes[pairIndex]
+		entry := cached[googleCacheKey(pair.Origin, pair.Dest)]
+		if entry != nil {
+			results[resultIndex] = DistanceResult{
+				DistanceMeters: entry.DistanceMeters,
+				DurationSecs:   entry.DurationSecs,
 			}
 			continue
 		}
-		missingDestinations = append(missingDestinations, dest)
-		missingIndexes = append(missingIndexes, i)
+		missingDestinations = append(missingDestinations, pair.Dest)
+		missingIndexes = append(missingIndexes, resultIndex)
+	}
+
+	if len(missingDestinations) > 0 {
+		if _, err := c.currentAPIKey(); err != nil {
+			return nil, err
+		}
 	}
 
 	for start := 0; start < len(missingDestinations); start += googleRouteMatrixMaxElements {

--- a/internal/distance/google.go
+++ b/internal/distance/google.go
@@ -216,6 +216,60 @@ func (c *googleCalculator) PrewarmCache(ctx context.Context, points []models.Coo
 	return err
 }
 
+func (c *googleCalculator) PrewarmPairs(ctx context.Context, pairs []DistancePair) error {
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	byOrigin := make(map[string][]models.Coordinates)
+	originCoords := make(map[string]models.Coordinates)
+	seen := make(map[string]struct{}, len(pairs))
+
+	for _, pair := range pairs {
+		if sameRoundedPoint(pair.Origin, pair.Destination) {
+			continue
+		}
+		key := PairCacheKey(pair.Origin, pair.Destination)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		originKey := fmt.Sprintf("%.5f,%.5f",
+			models.RoundCoordinate(pair.Origin.Lat),
+			models.RoundCoordinate(pair.Origin.Lng),
+		)
+		originCoords[originKey] = pair.Origin
+		byOrigin[originKey] = append(byOrigin[originKey], pair.Destination)
+	}
+
+	for originKey, destinations := range byOrigin {
+		destinations = uniqueCoordinates(destinations)
+		if _, err := c.GetDistancesFromPoint(ctx, originCoords[originKey], destinations); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func uniqueCoordinates(points []models.Coordinates) []models.Coordinates {
+	seen := make(map[string]struct{}, len(points))
+	unique := make([]models.Coordinates, 0, len(points))
+	for _, point := range points {
+		key := fmt.Sprintf("%.5f,%.5f",
+			models.RoundCoordinate(point.Lat),
+			models.RoundCoordinate(point.Lng),
+		)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, point)
+	}
+	return unique
+}
+
 type matrixIndex struct {
 	origin      int
 	destination int

--- a/internal/distance/osrm.go
+++ b/internal/distance/osrm.go
@@ -307,16 +307,28 @@ func (c *osrmCalculator) PrewarmPairs(ctx context.Context, pairs []DistancePair)
 
 	byOrigin := make(map[string][]models.Coordinates)
 	originCoords := make(map[string]models.Coordinates)
+	missingPairs := make([]struct{ Origin, Dest models.Coordinates }, 0, len(cachePairs))
 	for _, pair := range cachePairs {
 		if cached[PairCacheKey(pair.Origin, pair.Dest)] != nil {
 			continue
 		}
-		originKey := fmt.Sprintf("%.5f,%.5f",
-			models.RoundCoordinate(pair.Origin.Lat),
-			models.RoundCoordinate(pair.Origin.Lng),
-		)
+		missingPairs = append(missingPairs, pair)
+		originKey := coordinatePointKey(pair.Origin)
 		originCoords[originKey] = pair.Origin
 		byOrigin[originKey] = append(byOrigin[originKey], pair.Dest)
+	}
+
+	if len(missingPairs) == 0 {
+		return nil
+	}
+
+	originRequestCount := 0
+	for _, destinations := range byOrigin {
+		destinations = uniqueCoordinates(destinations)
+		originRequestCount += (len(destinations) + maxOSRMCoordinates - 2) / (maxOSRMCoordinates - 1)
+	}
+	if shouldUseRectangularPairPrewarm(missingPairs, originRequestCount) {
+		return c.prewarmPairRectangle(ctx, missingPairs)
 	}
 
 	for originKey, destinations := range byOrigin {
@@ -356,6 +368,105 @@ func (c *osrmCalculator) PrewarmPairs(ctx context.Context, pairs []DistancePair)
 	}
 
 	return nil
+}
+
+type pairRectangleRequest struct {
+	queryPoints        []models.Coordinates
+	sourceIndexes      []int
+	destinationIndexes []int
+	sourceCoords       []models.Coordinates
+	destinationCoords  []models.Coordinates
+	requestedPairs     map[string]struct{}
+}
+
+func shouldUseRectangularPairPrewarm(pairs []struct{ Origin, Dest models.Coordinates }, originRequestCount int) bool {
+	request, ok := buildPairRectangleRequest(pairs)
+	if !ok || originRequestCount <= 1 {
+		return false
+	}
+
+	rectangularCells := len(request.sourceIndexes) * len(request.destinationIndexes)
+	return rectangularCells <= len(pairs)*2 || originRequestCount > 8
+}
+
+func buildPairRectangleRequest(pairs []struct{ Origin, Dest models.Coordinates }) (*pairRectangleRequest, bool) {
+	request := &pairRectangleRequest{
+		requestedPairs: make(map[string]struct{}, len(pairs)),
+	}
+	sourceSeen := make(map[string]struct{})
+	destinationSeen := make(map[string]struct{})
+	queryIndexByKey := make(map[string]int)
+
+	addQueryPoint := func(point models.Coordinates) int {
+		key := coordinatePointKey(point)
+		if idx, ok := queryIndexByKey[key]; ok {
+			return idx
+		}
+		idx := len(request.queryPoints)
+		queryIndexByKey[key] = idx
+		request.queryPoints = append(request.queryPoints, point)
+		return idx
+	}
+
+	for _, pair := range pairs {
+		request.requestedPairs[PairCacheKey(pair.Origin, pair.Dest)] = struct{}{}
+
+		originKey := coordinatePointKey(pair.Origin)
+		if _, ok := sourceSeen[originKey]; !ok {
+			sourceSeen[originKey] = struct{}{}
+			request.sourceCoords = append(request.sourceCoords, pair.Origin)
+		}
+
+		destinationKey := coordinatePointKey(pair.Dest)
+		if _, ok := destinationSeen[destinationKey]; !ok {
+			destinationSeen[destinationKey] = struct{}{}
+			request.destinationCoords = append(request.destinationCoords, pair.Dest)
+		}
+	}
+
+	for _, source := range request.sourceCoords {
+		request.sourceIndexes = append(request.sourceIndexes, addQueryPoint(source))
+	}
+	for _, destination := range request.destinationCoords {
+		request.destinationIndexes = append(request.destinationIndexes, addQueryPoint(destination))
+	}
+
+	return request, len(request.queryPoints) <= maxOSRMCoordinates
+}
+
+func (c *osrmCalculator) prewarmPairRectangle(ctx context.Context, pairs []struct{ Origin, Dest models.Coordinates }) error {
+	request, ok := buildPairRectangleRequest(pairs)
+	if !ok {
+		return fmt.Errorf("OSRM pair rectangle exceeds coordinate limit")
+	}
+
+	response, err := c.requestTable(ctx, request.queryPoints, request.sourceIndexes, request.destinationIndexes)
+	if err != nil {
+		return err
+	}
+
+	cacheEntries := make([]models.DistanceCacheEntry, 0, len(pairs))
+	for sourceResponseIndex, origin := range request.sourceCoords {
+		for destinationResponseIndex, destination := range request.destinationCoords {
+			if _, ok := request.requestedPairs[PairCacheKey(origin, destination)]; !ok {
+				continue
+			}
+
+			dist := response.Distances[sourceResponseIndex][destinationResponseIndex]
+			dur := response.Durations[sourceResponseIndex][destinationResponseIndex]
+			if dist <= 0 {
+				continue
+			}
+			cacheEntries = append(cacheEntries, models.DistanceCacheEntry{
+				Origin:         origin,
+				Destination:    destination,
+				DistanceMeters: dist,
+				DurationSecs:   dur,
+			})
+		}
+	}
+
+	return c.persistCacheEntries(ctx, cacheEntries)
 }
 
 func (c *osrmCalculator) hydrateMatrixFromCache(ctx context.Context, points []models.Coordinates, matrix [][]DistanceResult) (*missingMatrixPlan, error) {

--- a/internal/distance/osrm.go
+++ b/internal/distance/osrm.go
@@ -286,10 +286,8 @@ func (c *osrmCalculator) PrewarmPairs(ctx context.Context, pairs []DistancePair)
 		return nil
 	}
 
-	byOrigin := make(map[string][]models.Coordinates)
-	originCoords := make(map[string]models.Coordinates)
+	cachePairs := make([]struct{ Origin, Dest models.Coordinates }, 0, len(pairs))
 	seen := make(map[string]struct{}, len(pairs))
-
 	for _, pair := range pairs {
 		if sameRoundedPoint(pair.Origin, pair.Destination) {
 			continue
@@ -299,19 +297,61 @@ func (c *osrmCalculator) PrewarmPairs(ctx context.Context, pairs []DistancePair)
 			continue
 		}
 		seen[key] = struct{}{}
+		cachePairs = append(cachePairs, struct{ Origin, Dest models.Coordinates }{Origin: pair.Origin, Dest: pair.Destination})
+	}
 
+	cached, err := c.cache.GetBatch(ctx, cachePairs)
+	if err != nil {
+		return err
+	}
+
+	byOrigin := make(map[string][]models.Coordinates)
+	originCoords := make(map[string]models.Coordinates)
+	for _, pair := range cachePairs {
+		if cached[PairCacheKey(pair.Origin, pair.Dest)] != nil {
+			continue
+		}
 		originKey := fmt.Sprintf("%.5f,%.5f",
 			models.RoundCoordinate(pair.Origin.Lat),
 			models.RoundCoordinate(pair.Origin.Lng),
 		)
 		originCoords[originKey] = pair.Origin
-		byOrigin[originKey] = append(byOrigin[originKey], pair.Destination)
+		byOrigin[originKey] = append(byOrigin[originKey], pair.Dest)
 	}
 
 	for originKey, destinations := range byOrigin {
 		destinations = uniqueCoordinates(destinations)
-		if _, err := c.GetDistancesFromPoint(ctx, originCoords[originKey], destinations); err != nil {
-			return err
+		origin := originCoords[originKey]
+		for start := 0; start < len(destinations); start += maxOSRMCoordinates - 1 {
+			end := min(start+maxOSRMCoordinates-1, len(destinations))
+			chunkDestinations := destinations[start:end]
+			queryPoints := append([]models.Coordinates{origin}, chunkDestinations...)
+			destinationIndexes := make([]int, len(chunkDestinations))
+			for i := range chunkDestinations {
+				destinationIndexes[i] = i + 1
+			}
+
+			response, err := c.requestTable(ctx, queryPoints, []int{0}, destinationIndexes)
+			if err != nil {
+				return err
+			}
+			cacheEntries := make([]models.DistanceCacheEntry, 0, len(chunkDestinations))
+			for i, destination := range chunkDestinations {
+				dist := response.Distances[0][i]
+				dur := response.Durations[0][i]
+				if dist <= 0 {
+					continue
+				}
+				cacheEntries = append(cacheEntries, models.DistanceCacheEntry{
+					Origin:         origin,
+					Destination:    destination,
+					DistanceMeters: dist,
+					DurationSecs:   dur,
+				})
+			}
+			if err := c.persistCacheEntries(ctx, cacheEntries); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/distance/osrm.go
+++ b/internal/distance/osrm.go
@@ -281,6 +281,43 @@ func (c *osrmCalculator) PrewarmCache(ctx context.Context, points []models.Coord
 	return err
 }
 
+func (c *osrmCalculator) PrewarmPairs(ctx context.Context, pairs []DistancePair) error {
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	byOrigin := make(map[string][]models.Coordinates)
+	originCoords := make(map[string]models.Coordinates)
+	seen := make(map[string]struct{}, len(pairs))
+
+	for _, pair := range pairs {
+		if sameRoundedPoint(pair.Origin, pair.Destination) {
+			continue
+		}
+		key := PairCacheKey(pair.Origin, pair.Destination)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		originKey := fmt.Sprintf("%.5f,%.5f",
+			models.RoundCoordinate(pair.Origin.Lat),
+			models.RoundCoordinate(pair.Origin.Lng),
+		)
+		originCoords[originKey] = pair.Origin
+		byOrigin[originKey] = append(byOrigin[originKey], pair.Destination)
+	}
+
+	for originKey, destinations := range byOrigin {
+		destinations = uniqueCoordinates(destinations)
+		if _, err := c.GetDistancesFromPoint(ctx, originCoords[originKey], destinations); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (c *osrmCalculator) hydrateMatrixFromCache(ctx context.Context, points []models.Coordinates, matrix [][]DistanceResult) (*missingMatrixPlan, error) {
 	n := len(points)
 	plan := &missingMatrixPlan{

--- a/internal/distance/osrm_test.go
+++ b/internal/distance/osrm_test.go
@@ -271,6 +271,67 @@ func TestPrewarmPairs_RequestsOnlyMissingDirectedPairs(t *testing.T) {
 	}
 }
 
+func TestPrewarmPairs_DensePairsUseSingleRectangularRequest(t *testing.T) {
+	cache := newMockDistanceCache()
+	originA := models.Coordinates{Lat: 0, Lng: 0}
+	originB := models.Coordinates{Lat: 1, Lng: 0}
+	destA := models.Coordinates{Lat: 0, Lng: 1}
+	destB := models.Coordinates{Lat: 1, Lng: 1}
+
+	requestCount := 0
+	var requestRawQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		requestRawQuery = r.URL.RawQuery
+		resp := osrmTableResponse{
+			Code: "Ok",
+			Distances: [][]float64{
+				{1100, 1200},
+				{2100, 2200},
+			},
+			Durations: [][]float64{
+				{11, 12},
+				{21, 22},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	calc := &osrmCalculator{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		cache:      cache,
+	}
+
+	err := calc.PrewarmPairs(context.Background(), []DistancePair{
+		{Origin: originA, Destination: destA},
+		{Origin: originA, Destination: destB},
+		{Origin: originB, Destination: destA},
+		{Origin: originB, Destination: destB},
+	})
+	if err != nil {
+		t.Fatalf("PrewarmPairs() error = %v", err)
+	}
+
+	if requestCount != 1 {
+		t.Fatalf("expected one rectangular OSRM request, got %d", requestCount)
+	}
+	if !strings.Contains(requestRawQuery, "sources=0;1") || !strings.Contains(requestRawQuery, "destinations=2;3") {
+		t.Fatalf("expected rectangular request sources=0;1 destinations=2;3, rawQuery=%q", requestRawQuery)
+	}
+	if cache.Count() != 4 {
+		t.Fatalf("cache entries = %d, want 4", cache.Count())
+	}
+	cached, err := cache.Get(context.Background(), originB, destB)
+	if err != nil {
+		t.Fatalf("expected cached originB->destB: %v", err)
+	}
+	if cached.DistanceMeters != 2200 || cached.DurationSecs != 22 {
+		t.Fatalf("originB->destB cache = %.0fm %.0fs, want 2200m 22s", cached.DistanceMeters, cached.DurationSecs)
+	}
+}
+
 func TestGetDistanceMatrix_MostlyColdFallsBackToFullRequest(t *testing.T) {
 	cache := newMockDistanceCache()
 

--- a/internal/distance/osrm_test.go
+++ b/internal/distance/osrm_test.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"ride-home-router/internal/database"
+	"ride-home-router/internal/models"
 	"strings"
 	"testing"
-
-	"ride-home-router/internal/models"
 )
 
 type mockDistanceCache struct {
@@ -35,13 +35,13 @@ func (c *mockDistanceCache) Get(_ context.Context, origin, dest models.Coordinat
 	if entry, ok := c.entries[key]; ok {
 		return entry, nil
 	}
-	return nil, nil
+	return nil, database.ErrCacheMiss
 }
 
-func (c *mockDistanceCache) GetBatch(_ context.Context, pairs []struct{ Origin, Dest models.Coordinates }) (map[string]*models.DistanceCacheEntry, error) {
+func (c *mockDistanceCache) GetBatch(ctx context.Context, pairs []struct{ Origin, Dest models.Coordinates }) (map[string]*models.DistanceCacheEntry, error) {
 	result := make(map[string]*models.DistanceCacheEntry)
 	for _, pair := range pairs {
-		entry, _ := c.Get(context.Background(), pair.Origin, pair.Dest)
+		entry, _ := c.Get(ctx, pair.Origin, pair.Dest)
 		if entry != nil {
 			result[c.cacheKey(pair.Origin, pair.Dest)] = entry
 		}

--- a/internal/distance/osrm_test.go
+++ b/internal/distance/osrm_test.go
@@ -3,16 +3,75 @@ package distance
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"ride-home-router/internal/models"
-	"ride-home-router/internal/testutil"
 	"strings"
 	"testing"
+
+	"ride-home-router/internal/models"
 )
 
+type mockDistanceCache struct {
+	entries map[string]*models.DistanceCacheEntry
+}
+
+func newMockDistanceCache() *mockDistanceCache {
+	return &mockDistanceCache{
+		entries: make(map[string]*models.DistanceCacheEntry),
+	}
+}
+
+func (c *mockDistanceCache) cacheKey(origin, dest models.Coordinates) string {
+	return fmt.Sprintf("%.5f,%.5f->%.5f,%.5f",
+		models.RoundCoordinate(origin.Lat),
+		models.RoundCoordinate(origin.Lng),
+		models.RoundCoordinate(dest.Lat),
+		models.RoundCoordinate(dest.Lng))
+}
+
+func (c *mockDistanceCache) Get(_ context.Context, origin, dest models.Coordinates) (*models.DistanceCacheEntry, error) {
+	key := c.cacheKey(origin, dest)
+	if entry, ok := c.entries[key]; ok {
+		return entry, nil
+	}
+	return nil, nil
+}
+
+func (c *mockDistanceCache) GetBatch(_ context.Context, pairs []struct{ Origin, Dest models.Coordinates }) (map[string]*models.DistanceCacheEntry, error) {
+	result := make(map[string]*models.DistanceCacheEntry)
+	for _, pair := range pairs {
+		entry, _ := c.Get(context.Background(), pair.Origin, pair.Dest)
+		if entry != nil {
+			result[c.cacheKey(pair.Origin, pair.Dest)] = entry
+		}
+	}
+	return result, nil
+}
+
+func (c *mockDistanceCache) Set(_ context.Context, entry *models.DistanceCacheEntry) error {
+	c.entries[c.cacheKey(entry.Origin, entry.Destination)] = entry
+	return nil
+}
+
+func (c *mockDistanceCache) SetBatch(_ context.Context, entries []models.DistanceCacheEntry) error {
+	for _, entry := range entries {
+		c.entries[c.cacheKey(entry.Origin, entry.Destination)] = &entry
+	}
+	return nil
+}
+
+func (c *mockDistanceCache) Clear(_ context.Context) error {
+	c.entries = make(map[string]*models.DistanceCacheEntry)
+	return nil
+}
+
+func (c *mockDistanceCache) Count() int {
+	return len(c.entries)
+}
+
 func TestGetDistanceMatrix_AllCached(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	// Pre-populate cache with all pairs
 	points := []models.Coordinates{
@@ -77,7 +136,7 @@ func TestGetDistanceMatrix_AllCached(t *testing.T) {
 }
 
 func TestGetDistanceMatrix_PartialCache(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	points := []models.Coordinates{
 		{Lat: 0, Lng: 0},
@@ -149,7 +208,7 @@ func TestGetDistanceMatrix_PartialCache(t *testing.T) {
 }
 
 func TestGetDistanceMatrix_MostlyColdFallsBackToFullRequest(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	points := []models.Coordinates{
 		{Lat: 0, Lng: 0},
@@ -211,7 +270,7 @@ func TestGetDistanceMatrix_MostlyColdFallsBackToFullRequest(t *testing.T) {
 }
 
 func TestGetDistanceMatrix_BatchSplitting(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	// Create more points than maxOSRMCoordinates (80)
 	numPoints := 85
@@ -310,7 +369,7 @@ func TestGetDistanceMatrix_BatchSplitting(t *testing.T) {
 }
 
 func TestGetDistanceMatrix_BatchedPartialCache(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	numPoints := 81
 	points := make([]models.Coordinates, numPoints)
@@ -413,7 +472,7 @@ func TestCoordinateRounding_Consistency(t *testing.T) {
 }
 
 func TestGetDistance_SamePoint(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("server should not be called for same point")
@@ -445,7 +504,7 @@ func TestGetDistance_SamePoint(t *testing.T) {
 }
 
 func TestGetDistanceMatrix_Empty(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	calc := &osrmCalculator{
 		baseURL:    "http://not-called",
@@ -464,7 +523,7 @@ func TestGetDistanceMatrix_Empty(t *testing.T) {
 }
 
 func TestGetDistanceMatrix_SinglePoint(t *testing.T) {
-	cache := testutil.NewMockDistanceCache()
+	cache := newMockDistanceCache()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := osrmTableResponse{

--- a/internal/distance/osrm_test.go
+++ b/internal/distance/osrm_test.go
@@ -207,6 +207,70 @@ func TestGetDistanceMatrix_PartialCache(t *testing.T) {
 	}
 }
 
+func TestPrewarmPairs_RequestsOnlyMissingDirectedPairs(t *testing.T) {
+	cache := newMockDistanceCache()
+	origin := models.Coordinates{Lat: 0, Lng: 0}
+	destA := models.Coordinates{Lat: 0.1, Lng: 0}
+	destB := models.Coordinates{Lat: 0, Lng: 0.1}
+
+	requestCount := 0
+	var requestSources string
+	var requestDestinations string
+	var requestRawQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		requestSources = r.URL.Query().Get("sources")
+		requestDestinations = r.URL.Query().Get("destinations")
+		requestRawQuery = r.URL.RawQuery
+		resp := osrmTableResponse{
+			Code:      "Ok",
+			Distances: [][]float64{{11100, 22200}},
+			Durations: [][]float64{{600, 1200}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	calc := &osrmCalculator{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		cache:      cache,
+	}
+
+	err := calc.PrewarmPairs(context.Background(), []DistancePair{
+		{Origin: origin, Destination: destA},
+		{Origin: origin, Destination: destB},
+		{Origin: origin, Destination: destA},
+	})
+	if err != nil {
+		t.Fatalf("PrewarmPairs() error = %v", err)
+	}
+
+	if requestCount != 1 {
+		t.Fatalf("expected one OSRM request, got %d", requestCount)
+	}
+	if requestSources != "0" || !strings.Contains(requestRawQuery, "destinations=1;2") {
+		t.Fatalf("expected exact directed request sources=0 destinations=1;2, got sources=%q destinations=%q rawQuery=%q", requestSources, requestDestinations, requestRawQuery)
+	}
+	if cache.Count() != 2 {
+		t.Fatalf("cache entries = %d, want 2", cache.Count())
+	}
+	cachedA, err := cache.Get(context.Background(), origin, destA)
+	if err != nil {
+		t.Fatalf("expected cached origin->destA: %v", err)
+	}
+	if cachedA.DistanceMeters != 11100 || cachedA.DurationSecs != 600 {
+		t.Fatalf("origin->destA cache = %.0fm %.0fs, want 11100m 600s", cachedA.DistanceMeters, cachedA.DurationSecs)
+	}
+	cachedB, err := cache.Get(context.Background(), origin, destB)
+	if err != nil {
+		t.Fatalf("expected cached origin->destB: %v", err)
+	}
+	if cachedB.DistanceMeters != 22200 || cachedB.DurationSecs != 1200 {
+		t.Fatalf("origin->destB cache = %.0fm %.0fs, want 22200m 1200s", cachedB.DistanceMeters, cachedB.DurationSecs)
+	}
+}
+
 func TestGetDistanceMatrix_MostlyColdFallsBackToFullRequest(t *testing.T) {
 	cache := newMockDistanceCache()
 

--- a/internal/distance/pairs.go
+++ b/internal/distance/pairs.go
@@ -1,0 +1,61 @@
+package distance
+
+import (
+	"context"
+	"fmt"
+
+	"ride-home-router/internal/models"
+)
+
+// DistancePair is a directed origin-destination pair for cache prewarming.
+type DistancePair struct {
+	Origin      models.Coordinates
+	Destination models.Coordinates
+}
+
+// PairPrewarmedDistanceCalculator can prewarm only the directed pairs required
+// for a routing solve instead of a full coordinate matrix.
+type PairPrewarmedDistanceCalculator interface {
+	PrewarmPairs(ctx context.Context, pairs []DistancePair) error
+}
+
+// PrewarmRoutingPairs calls PrewarmPairs when supported, otherwise falls back to
+// PrewarmCache with the unique coordinates from the pair list.
+func PrewarmRoutingPairs(ctx context.Context, calc DistanceCalculator, pairs []DistancePair) error {
+	if len(pairs) == 0 {
+		return nil
+	}
+	if pairPrewarmer, ok := calc.(PairPrewarmedDistanceCalculator); ok {
+		return pairPrewarmer.PrewarmPairs(ctx, pairs)
+	}
+
+	seen := make(map[string]struct{}, len(pairs)*2)
+	points := make([]models.Coordinates, 0, len(pairs)*2)
+	for _, pair := range pairs {
+		for _, coord := range []models.Coordinates{pair.Origin, pair.Destination} {
+			key := coordinatePointKey(coord)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			points = append(points, coord)
+		}
+	}
+	return calc.PrewarmCache(ctx, points)
+}
+
+func coordinatePointKey(coord models.Coordinates) string {
+	return fmt.Sprintf("%.5f,%.5f",
+		models.RoundCoordinate(coord.Lat),
+		models.RoundCoordinate(coord.Lng),
+	)
+}
+
+func PairCacheKey(origin, dest models.Coordinates) string {
+	return fmt.Sprintf("%.5f,%.5f->%.5f,%.5f",
+		models.RoundCoordinate(origin.Lat),
+		models.RoundCoordinate(origin.Lng),
+		models.RoundCoordinate(dest.Lat),
+		models.RoundCoordinate(dest.Lng),
+	)
+}

--- a/internal/distance/pairs.go
+++ b/internal/distance/pairs.go
@@ -3,7 +3,6 @@ package distance
 import (
 	"context"
 	"fmt"
-
 	"ride-home-router/internal/models"
 )
 
@@ -45,14 +44,16 @@ func PrewarmRoutingPairs(ctx context.Context, calc DistanceCalculator, pairs []D
 }
 
 func coordinatePointKey(coord models.Coordinates) string {
-	return fmt.Sprintf("%.5f,%.5f",
+	return fmt.Sprintf(
+		"%.5f,%.5f",
 		models.RoundCoordinate(coord.Lat),
 		models.RoundCoordinate(coord.Lng),
 	)
 }
 
 func PairCacheKey(origin, dest models.Coordinates) string {
-	return fmt.Sprintf("%.5f,%.5f->%.5f,%.5f",
+	return fmt.Sprintf(
+		"%.5f,%.5f->%.5f,%.5f",
 		models.RoundCoordinate(origin.Lat),
 		models.RoundCoordinate(origin.Lng),
 		models.RoundCoordinate(dest.Lat),

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -198,15 +198,18 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		req.Notes = r.FormValue("notes")
 		req.SessionID = r.FormValue("session_id")
 
-		routesJSON := r.FormValue("routes_json")
-		if routesJSON != "" {
-			var routingResult models.RoutingResult
-			if err := json.Unmarshal([]byte(routesJSON), &routingResult); err != nil {
-				log.Printf("[HTTP] POST /api/v1/events: invalid_routes_json err=%v", err)
-				h.handleValidationError(w, messageInvalidRoutesData)
-				return
+		// Session saves load routes from server state; ignore any posted routes_json payload.
+		if req.SessionID == "" {
+			routesJSON := r.FormValue("routes_json")
+			if routesJSON != "" {
+				var routingResult models.RoutingResult
+				if err := json.Unmarshal([]byte(routesJSON), &routingResult); err != nil {
+					log.Printf("[HTTP] POST /api/v1/events: invalid_routes_json err=%v", err)
+					h.handleValidationError(w, messageInvalidRoutesData)
+					return
+				}
+				req.Routes = &routingResult
 			}
-			req.Routes = &routingResult
 		}
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -220,6 +223,18 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[HTTP] POST /api/v1/events: missing event_date")
 		h.handleValidationError(w, messageEventDateRequired)
 		return
+	}
+	if req.Routes == nil {
+		if req.SessionID != "" {
+			session := h.RouteSession.Get(req.SessionID)
+			if session != nil {
+				session.mu.Lock()
+				summary := h.calculateSummary(session.CurrentRoutes)
+				routes := buildRoutingPayload(deepCopyRoutes(session.CurrentRoutes), summary, session.Mode)
+				session.mu.Unlock()
+				req.Routes = &routes
+			}
+		}
 	}
 	if req.Routes == nil {
 		log.Printf("[HTTP] POST /api/v1/events: missing routes")

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -224,19 +224,19 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		h.handleValidationError(w, messageEventDateRequired)
 		return
 	}
-	if req.Routes == nil {
-		if req.SessionID != "" {
-			session := h.RouteSession.Get(req.SessionID)
-			if session != nil {
-				session.mu.Lock()
-				summary := h.calculateSummary(session.CurrentRoutes)
-				routes := buildRoutingPayload(deepCopyRoutes(session.CurrentRoutes), summary, session.Mode)
-				session.mu.Unlock()
-				req.Routes = &routes
-			}
+	if req.SessionID != "" {
+		session := h.RouteSession.Get(req.SessionID)
+		if session == nil {
+			log.Printf("[HTTP] POST /api/v1/events: session_not_found session_id=%s", req.SessionID)
+			h.handleNotFound(w, messageSessionNotFound)
+			return
 		}
-	}
-	if req.Routes == nil {
+		session.mu.Lock()
+		summary := h.calculateSummary(session.CurrentRoutes)
+		routes := buildRoutingPayload(deepCopyRoutes(session.CurrentRoutes), summary, session.Mode)
+		session.mu.Unlock()
+		req.Routes = &routes
+	} else if req.Routes == nil {
 		log.Printf("[HTTP] POST /api/v1/events: missing routes")
 		h.handleValidationError(w, messageRoutesRequired)
 		return

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -198,18 +198,15 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		req.Notes = r.FormValue("notes")
 		req.SessionID = r.FormValue("session_id")
 
-		// Session saves load routes from server state; ignore any posted routes_json payload.
-		if req.SessionID == "" {
-			routesJSON := r.FormValue("routes_json")
-			if routesJSON != "" {
-				var routingResult models.RoutingResult
-				if err := json.Unmarshal([]byte(routesJSON), &routingResult); err != nil {
-					log.Printf("[HTTP] POST /api/v1/events: invalid_routes_json err=%v", err)
-					h.handleValidationError(w, messageInvalidRoutesData)
-					return
-				}
-				req.Routes = &routingResult
+		routesJSON := r.FormValue("routes_json")
+		if routesJSON != "" {
+			var routingResult models.RoutingResult
+			if err := json.Unmarshal([]byte(routesJSON), &routingResult); err != nil {
+				log.Printf("[HTTP] POST /api/v1/events: invalid_routes_json err=%v", err)
+				h.handleValidationError(w, messageInvalidRoutesData)
+				return
 			}
+			req.Routes = &routingResult
 		}
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -227,22 +224,26 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 	if req.SessionID != "" {
 		session := h.RouteSession.Get(req.SessionID)
 		if session == nil {
-			log.Printf("[HTTP] POST /api/v1/events: session_not_found session_id=%s", req.SessionID)
-			h.handleNotFound(w, messageSessionNotFound)
-			return
-		}
-		session.mu.Lock()
-		_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
-		if isOutOfBalance {
+			if req.Routes == nil {
+				log.Printf("[HTTP] POST /api/v1/events: session_not_found session_id=%s", req.SessionID)
+				h.handleNotFound(w, messageSessionNotFound)
+				return
+			}
+			log.Printf("[HTTP] POST /api/v1/events: session_not_found using posted routes fallback session_id=%s", req.SessionID)
+		} else {
+			session.mu.Lock()
+			_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
+			if isOutOfBalance {
+				session.mu.Unlock()
+				log.Printf("[HTTP] POST /api/v1/events: blocked save for out-of-balance session_id=%s", req.SessionID)
+				h.handleValidationError(w, messageRoutesMustBeBalancedBeforeSaving)
+				return
+			}
+			summary := h.calculateSummary(session.CurrentRoutes)
+			routes := buildRoutingPayload(deepCopyRoutes(session.CurrentRoutes), summary, session.Mode)
 			session.mu.Unlock()
-			log.Printf("[HTTP] POST /api/v1/events: blocked save for out-of-balance session_id=%s", req.SessionID)
-			h.handleValidationError(w, messageRoutesMustBeBalancedBeforeSaving)
-			return
+			req.Routes = &routes
 		}
-		summary := h.calculateSummary(session.CurrentRoutes)
-		routes := buildRoutingPayload(deepCopyRoutes(session.CurrentRoutes), summary, session.Mode)
-		session.mu.Unlock()
-		req.Routes = &routes
 	} else if req.Routes == nil {
 		log.Printf("[HTTP] POST /api/v1/events: missing routes")
 		h.handleValidationError(w, messageRoutesRequired)

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -232,6 +232,13 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		session.mu.Lock()
+		_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
+		if isOutOfBalance {
+			session.mu.Unlock()
+			log.Printf("[HTTP] POST /api/v1/events: blocked save for out-of-balance session_id=%s", req.SessionID)
+			h.handleValidationError(w, messageRoutesMustBeBalancedBeforeSaving)
+			return
+		}
 		summary := h.calculateSummary(session.CurrentRoutes)
 		routes := buildRoutingPayload(deepCopyRoutes(session.CurrentRoutes), summary, session.Mode)
 		session.mu.Unlock()
@@ -240,19 +247,6 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[HTTP] POST /api/v1/events: missing routes")
 		h.handleValidationError(w, messageRoutesRequired)
 		return
-	}
-	if req.SessionID != "" {
-		session := h.RouteSession.Get(req.SessionID)
-		if session != nil {
-			session.mu.Lock()
-			_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
-			session.mu.Unlock()
-			if isOutOfBalance {
-				log.Printf("[HTTP] POST /api/v1/events: blocked save for out-of-balance session_id=%s", req.SessionID)
-				h.handleValidationError(w, messageRoutesMustBeBalancedBeforeSaving)
-				return
-			}
-		}
 	}
 
 	eventDate, err := time.Parse("2006-01-02", req.EventDate)

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -185,6 +185,7 @@ func (h *Handler) HandleGetEvent(w http.ResponseWriter, r *http.Request) {
 // HandleCreateEvent handles POST /api/v1/events.
 func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 	var req CreateEventRequest
+	var formRoutesJSON string
 
 	contentType := r.Header.Get(httpx.HeaderContentType)
 	if httpx.HasFormContentType(contentType) {
@@ -197,16 +198,14 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		req.EventDate = r.FormValue("event_date")
 		req.Notes = r.FormValue("notes")
 		req.SessionID = r.FormValue("session_id")
+		formRoutesJSON = r.FormValue("routes_json")
 
-		routesJSON := r.FormValue("routes_json")
-		if routesJSON != "" {
-			var routingResult models.RoutingResult
-			if err := json.Unmarshal([]byte(routesJSON), &routingResult); err != nil {
-				log.Printf("[HTTP] POST /api/v1/events: invalid_routes_json err=%v", err)
-				h.handleValidationError(w, messageInvalidRoutesData)
+		if req.SessionID == "" {
+			routes, ok := h.parsePostedRoutesJSON(w, formRoutesJSON)
+			if !ok {
 				return
 			}
-			req.Routes = &routingResult
+			req.Routes = routes
 		}
 	} else {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -224,6 +223,13 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 	if req.SessionID != "" {
 		session := h.RouteSession.Get(req.SessionID)
 		if session == nil {
+			if req.Routes == nil && formRoutesJSON != "" {
+				routes, ok := h.parsePostedRoutesJSON(w, formRoutesJSON)
+				if !ok {
+					return
+				}
+				req.Routes = routes
+			}
 			if req.Routes == nil {
 				log.Printf("[HTTP] POST /api/v1/events: session_not_found session_id=%s", req.SessionID)
 				h.handleNotFound(w, messageSessionNotFound)
@@ -293,6 +299,19 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, http.StatusCreated, event)
 }
 
+func (h *Handler) parsePostedRoutesJSON(w http.ResponseWriter, routesJSON string) (*models.RoutingResult, bool) {
+	if routesJSON == "" {
+		return nil, true
+	}
+	var routingResult models.RoutingResult
+	if err := json.Unmarshal([]byte(routesJSON), &routingResult); err != nil {
+		log.Printf("[HTTP] POST /api/v1/events: invalid_routes_json err=%v", err)
+		h.handleValidationError(w, messageInvalidRoutesData)
+		return nil, false
+	}
+	return &routingResult, true
+}
+
 // HandleDeleteEvent handles DELETE /api/v1/events/{id}.
 func (h *Handler) HandleDeleteEvent(w http.ResponseWriter, r *http.Request) {
 	idStr := strings.TrimPrefix(r.URL.Path, "/api/v1/events/")
@@ -325,7 +344,6 @@ func (h *Handler) HandleDeleteEvent(w http.ResponseWriter, r *http.Request) {
 				limit = l
 			}
 		}
-
 		view, err := h.buildEventListView(r.Context(), limit, 0)
 		if err != nil {
 			h.renderError(w, r, err)

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -245,6 +245,52 @@ func TestHandleCreateEvent_SessionSaveIgnoresClientSuppliedRoutes(t *testing.T) 
 	}
 }
 
+func TestHandleCreateEvent_SessionSaveIgnoresMalformedRoutesJSON(t *testing.T) {
+	handler, store := newTestEventHandler(t, false)
+
+	session := handler.RouteSession.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 1, Name: "Session Driver", VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+				Mode:              "dropoff",
+			},
+		},
+		[]models.Driver{{ID: 1, Name: "Session Driver", VehicleCapacity: 2}},
+		&models.ActivityLocation{ID: 1, Name: "HQ", Address: "1 Main", Lat: 0, Lng: 0},
+		false,
+		"18:30",
+		"dropoff",
+		nil,
+	)
+
+	form := "event_date=2026-03-14&session_id=" + url.QueryEscape(session.ID) + "&routes_json=%7Bnot-json"
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	events, _, err := store.Events().List(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 saved event, got %d", len(events))
+	}
+	_, routes, _, err := store.Events().GetByID(context.Background(), events[0].ID)
+	if err != nil {
+		t.Fatalf("get event: %v", err)
+	}
+	if routes[0].DriverName != "Session Driver" {
+		t.Fatalf("saved driver = %q, want server session driver", routes[0].DriverName)
+	}
+}
+
 func TestHandleCreateEvent_OutOfBalanceSessionReturnsBadRequest(t *testing.T) {
 	handler, _ := newTestEventHandler(t, false)
 

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -65,6 +65,47 @@ func TestHandleCreateEvent_MissingRoutesReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestHandleCreateEvent_SessionSaveWithoutRoutesJSON(t *testing.T) {
+	handler, store := newTestEventHandler(t, false)
+
+	session := handler.RouteSession.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:              &models.Driver{ID: 1, Name: "Driver 1", VehicleCapacity: 2},
+				EffectiveCapacity:   2,
+				Stops:               []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+				TotalDistanceMeters: 5000,
+				Mode:                "dropoff",
+			},
+		},
+		[]models.Driver{{ID: 1, Name: "Driver 1", VehicleCapacity: 2}},
+		&models.ActivityLocation{ID: 1, Name: "HQ", Address: "1 Main", Lat: 0, Lng: 0},
+		false,
+		"18:30",
+		"dropoff",
+		nil,
+	)
+
+	form := "event_date=2026-03-14&session_id=" + session.ID
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+
+	events, _, err := store.Events().List(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 saved event, got %d", len(events))
+	}
+}
+
 func TestHandleCreateEvent_OutOfBalanceSessionReturnsBadRequest(t *testing.T) {
 	handler, _ := newTestEventHandler(t, false)
 

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -87,7 +87,7 @@ func TestHandleCreateEvent_SessionSaveWithoutRoutesJSON(t *testing.T) {
 	)
 
 	form := "event_date=2026-03-14&session_id=" + session.ID
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 
@@ -103,6 +103,93 @@ func TestHandleCreateEvent_SessionSaveWithoutRoutesJSON(t *testing.T) {
 	}
 	if len(events) != 1 {
 		t.Fatalf("expected 1 saved event, got %d", len(events))
+	}
+}
+
+func TestHandleCreateEvent_ExpiredSessionReturnsNotFound(t *testing.T) {
+	handler, _ := newTestEventHandler(t, false)
+
+	form := "event_date=2026-03-14&session_id=expired-session-id"
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusNotFound, rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleCreateEvent_SessionSaveIgnoresClientSuppliedRoutes(t *testing.T) {
+	handler, store := newTestEventHandler(t, false)
+
+	session := handler.RouteSession.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:              &models.Driver{ID: 1, Name: "Driver 1", VehicleCapacity: 2},
+				EffectiveCapacity:   2,
+				Stops:               []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+				TotalDistanceMeters: 5000,
+				Mode:                "dropoff",
+			},
+		},
+		[]models.Driver{{ID: 1, Name: "Driver 1", VehicleCapacity: 2}},
+		&models.ActivityLocation{ID: 1, Name: "HQ", Address: "1 Main", Lat: 0, Lng: 0},
+		false,
+		"18:30",
+		"dropoff",
+		nil,
+	)
+
+	body := map[string]any{
+		"event_date": "2026-03-14",
+		"session_id": session.ID,
+		"routes": map[string]any{
+			"routes": []map[string]any{
+				{
+					"driver": map[string]any{"id": 99, "name": "Forged Driver", "vehicle_capacity": 1},
+					"stops":  []map[string]any{},
+					"mode":   "dropoff",
+				},
+			},
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+
+	events, _, err := store.Events().List(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 saved event, got %d", len(events))
+	}
+
+	event, routes, _, err := store.Events().GetByID(context.Background(), events[0].ID)
+	if err != nil {
+		t.Fatalf("get event: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event")
+	}
+	if len(routes) != 1 {
+		t.Fatalf("route count = %d, want 1", len(routes))
+	}
+	if routes[0].DriverName != "Driver 1" {
+		t.Fatalf("saved driver = %q, want server session driver", routes[0].DriverName)
 	}
 }
 

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -121,6 +121,58 @@ func TestHandleCreateEvent_ExpiredSessionReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestHandleCreateEvent_ExpiredSessionFallsBackToPostedRoutesJSON(t *testing.T) {
+	handler, store := newTestEventHandler(t, false)
+
+	routingPayload := models.RoutingResult{
+		Routes: []models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 7, Name: "Fallback Driver", VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+				Mode:              "dropoff",
+			},
+		},
+		Summary: models.RoutingSummary{
+			TotalParticipants: 1,
+			TotalDriversUsed:  1,
+		},
+		Mode: "dropoff",
+	}
+	payloadBytes, err := json.Marshal(routingPayload)
+	if err != nil {
+		t.Fatalf("marshal routing payload: %v", err)
+	}
+
+	form := "event_date=2026-03-14&session_id=expired-session-id&routes_json=" + url.QueryEscape(string(payloadBytes))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	events, _, err := store.Events().List(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 saved event, got %d", len(events))
+	}
+	_, routes, _, err := store.Events().GetByID(context.Background(), events[0].ID)
+	if err != nil {
+		t.Fatalf("get event: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("route count = %d, want 1", len(routes))
+	}
+	if routes[0].DriverName != "Fallback Driver" {
+		t.Fatalf("saved driver = %q, want fallback posted route driver", routes[0].DriverName)
+	}
+}
+
 func TestHandleCreateEvent_SessionSaveIgnoresClientSuppliedRoutes(t *testing.T) {
 	handler, store := newTestEventHandler(t, false)
 

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -34,6 +34,7 @@ const (
 	messageRoutingProviderConfigUpdated                  = "Google Maps API key saved. Distance cache cleared."
 	messageRoutesRequired                                = "Routes are required"
 	messageRoutesMustBeBalancedBeforeSaving              = "Routes must be balanced before saving"
+	messageMovesRequired                                 = "At least one move is required"
 	messageSessionNotFound                               = "Session not found"
 	messageSelectedActivityLocationNotFound              = "Selected activity location not found"
 	messageSelectedActivityLocationNotFoundChooseAnother = "Selected activity location not found. Choose another location."

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -35,6 +35,8 @@ const (
 	messageRoutesRequired                                = "Routes are required"
 	messageRoutesMustBeBalancedBeforeSaving              = "Routes must be balanced before saving"
 	messageMovesRequired                                 = "At least one move is required"
+	messageTooManyMoves                                  = "Too many moves in one request"
+	messageDuplicateMoveParticipant                      = "Duplicate participant in move batch"
 	messageSessionNotFound                               = "Session not found"
 	messageSelectedActivityLocationNotFound              = "Selected activity location not found"
 	messageSelectedActivityLocationNotFoundChooseAnother = "Selected activity location not found. Choose another location."

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -36,7 +36,6 @@ const (
 	messageRoutesMustBeBalancedBeforeSaving              = "Routes must be balanced before saving"
 	messageMovesRequired                                 = "At least one move is required"
 	messageTooManyMoves                                  = "Too many moves in one request"
-	messageDuplicateMoveParticipant                      = "Duplicate participant in move batch"
 	messageSessionNotFound                               = "Session not found"
 	messageSelectedActivityLocationNotFound              = "Selected activity location not found"
 	messageSelectedActivityLocationNotFoundChooseAnother = "Selected activity location not found. Choose another location."

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -322,6 +322,17 @@ func markRouteDirty(session *RouteSession, routeIndex int) {
 	session.DirtyRouteIndexes[routeIndex] = struct{}{}
 }
 
+func cloneDirtyRouteIndexes(source map[int]struct{}) map[int]struct{} {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[int]struct{}, len(source))
+	for routeIndex := range source {
+		clone[routeIndex] = struct{}{}
+	}
+	return clone
+}
+
 func (h *Handler) recalculateDirtyRoutes(ctx context.Context, session *RouteSession, backupRoutes []models.CalculatedRoute) error {
 	for routeIndex := range session.DirtyRouteIndexes {
 		if routeIndex < 0 || routeIndex >= len(session.CurrentRoutes) {
@@ -401,28 +412,34 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 	defer session.mu.Unlock()
 
 	backupRoutes := deepCopyRoutes(session.CurrentRoutes)
+	backupDirtyRouteIndexes := cloneDirtyRouteIndexes(session.DirtyRouteIndexes)
+	restoreSession := func() {
+		session.CurrentRoutes = deepCopyRoutes(backupRoutes)
+		session.DirtyRouteIndexes = cloneDirtyRouteIndexes(backupDirtyRouteIndexes)
+	}
 	for _, move := range moves {
 		fromRouteIndex, ok := findParticipantRouteIndex(session.CurrentRoutes, move.ParticipantID)
 		if !ok {
-			session.CurrentRoutes = backupRoutes
+			restoreSession()
 			h.handleValidationErrorHTMX(w, r, messageParticipantNotFound)
 			return
 		}
 		if err := applyParticipantMove(session, move.ParticipantID, fromRouteIndex, move.ToRouteIndex, move.InsertAtPosition); err != nil {
-			session.CurrentRoutes = backupRoutes
+			restoreSession()
 			h.handleValidationErrorHTMX(w, r, err.Error())
 			return
 		}
-	}
 
-	_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
-
-	// Optimize and recalculate all dirty routes once balanced again.
-	// While out of balance, keep previous route metrics visible.
-	if !isOutOfBalance {
-		if err := h.recalculateDirtyRoutes(r.Context(), session, backupRoutes); err != nil {
-			h.handleInternalError(w, err)
-			return
+		// Match sequential move semantics: every balanced interim state refreshes
+		// dirty route order/metrics, while out-of-balance states keep the previous
+		// metrics visible until a later move restores balance.
+		_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
+		if !isOutOfBalance {
+			if err := h.recalculateDirtyRoutes(r.Context(), session, backupRoutes); err != nil {
+				session.DirtyRouteIndexes = cloneDirtyRouteIndexes(backupDirtyRouteIndexes)
+				h.handleInternalError(w, err)
+				return
+			}
 		}
 	}
 

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -451,15 +451,10 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 }
 
 func validateParticipantMoveBatch(moves []participantMove) error {
-	seen := make(map[int64]struct{}, len(moves))
 	for _, move := range moves {
 		if move.ParticipantID == 0 {
 			return fmt.Errorf("%s", messageInvalidParticipantID)
 		}
-		if _, exists := seen[move.ParticipantID]; exists {
-			return fmt.Errorf("%s", messageDuplicateMoveParticipant)
-		}
-		seen[move.ParticipantID] = struct{}{}
 	}
 	return nil
 }

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -17,7 +17,7 @@ import (
 const (
 	routeSessionTTL             = 2 * time.Hour
 	routeSessionCleanupInterval = 15 * time.Minute
-	maxParticipantMovesPerBatch   = 64
+	maxParticipantMovesPerBatch = 64
 )
 
 type participantMove struct {
@@ -353,11 +353,11 @@ func (h *Handler) optimizeRouteOrder(ctx context.Context, activityLocation *mode
 // HandleMoveParticipant handles POST /api/v1/routes/edit/move-participant
 func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		SessionID        string `json:"session_id"`
-		ParticipantID    int64  `json:"participant_id"`
-		FromRouteIndex   int    `json:"from_route_index"`
-		ToRouteIndex     int    `json:"to_route_index"`
-		InsertAtPosition int    `json:"insert_at_position"` // -1 for end
+		SessionID        string            `json:"session_id"`
+		ParticipantID    int64             `json:"participant_id"`
+		FromRouteIndex   int               `json:"from_route_index"`
+		ToRouteIndex     int               `json:"to_route_index"`
+		InsertAtPosition int               `json:"insert_at_position"` // -1 for end
 		Moves            []participantMove `json:"moves"`
 	}
 

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -350,11 +350,34 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 		FromRouteIndex   int    `json:"from_route_index"`
 		ToRouteIndex     int    `json:"to_route_index"`
 		InsertAtPosition int    `json:"insert_at_position"` // -1 for end
+		Moves            []struct {
+			ParticipantID    int64 `json:"participant_id"`
+			FromRouteIndex   int   `json:"from_route_index"`
+			ToRouteIndex     int   `json:"to_route_index"`
+			InsertAtPosition int   `json:"insert_at_position"`
+		} `json:"moves"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		h.handleValidationErrorHTMX(w, r, messageInvalidRequestBody)
 		return
+	}
+
+	moves := req.Moves
+	if len(moves) == 0 {
+		moves = []struct {
+			ParticipantID    int64 `json:"participant_id"`
+			FromRouteIndex   int   `json:"from_route_index"`
+			ToRouteIndex     int   `json:"to_route_index"`
+			InsertAtPosition int   `json:"insert_at_position"`
+		}{
+			{
+				ParticipantID:    req.ParticipantID,
+				FromRouteIndex:   req.FromRouteIndex,
+				ToRouteIndex:     req.ToRouteIndex,
+				InsertAtPosition: req.InsertAtPosition,
+			},
+		}
 	}
 
 	session := h.RouteSession.Get(req.SessionID)
@@ -368,49 +391,13 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 	defer session.mu.Unlock()
 
 	backupRoutes := deepCopyRoutes(session.CurrentRoutes)
-
-	if req.FromRouteIndex < 0 || req.FromRouteIndex >= len(session.CurrentRoutes) ||
-		req.ToRouteIndex < 0 || req.ToRouteIndex >= len(session.CurrentRoutes) {
-		h.handleValidationErrorHTMX(w, r, messageInvalidRouteIndex)
-		return
-	}
-
-	fromRoute := &session.CurrentRoutes[req.FromRouteIndex]
-	toRoute := &session.CurrentRoutes[req.ToRouteIndex]
-
-	// Find and remove participant from source route
-	var participant *models.Participant
-	stopIdx := -1
-	for i, stop := range fromRoute.Stops {
-		if stop.Participant.ID == req.ParticipantID {
-			participant = stop.Participant
-			stopIdx = i
-			break
+	for _, move := range moves {
+		if err := applyParticipantMove(session, move.ParticipantID, move.FromRouteIndex, move.ToRouteIndex, move.InsertAtPosition); err != nil {
+			session.CurrentRoutes = backupRoutes
+			h.handleValidationErrorHTMX(w, r, err.Error())
+			return
 		}
 	}
-
-	if participant == nil {
-		h.handleValidationErrorHTMX(w, r, "Participant not found in source route")
-		return
-	}
-
-	// Remove from source
-	fromRoute.Stops = append(fromRoute.Stops[:stopIdx], fromRoute.Stops[stopIdx+1:]...)
-
-	// Add to destination
-	newStop := models.RouteStop{
-		Participant: participant,
-	}
-
-	if req.InsertAtPosition < 0 || req.InsertAtPosition >= len(toRoute.Stops) {
-		toRoute.Stops = append(toRoute.Stops, newStop)
-	} else {
-		toRoute.Stops = append(toRoute.Stops[:req.InsertAtPosition],
-			append([]models.RouteStop{newStop}, toRoute.Stops[req.InsertAtPosition:]...)...)
-	}
-
-	markRouteDirty(session, req.FromRouteIndex)
-	markRouteDirty(session, req.ToRouteIndex)
 
 	_, isOutOfBalance := calculateOverCapacity(session.CurrentRoutes)
 
@@ -426,8 +413,12 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 	// Recalculate summary
 	summary := h.calculateSummary(session.CurrentRoutes)
 
-	log.Printf("[EDIT] Moved participant %d from route %d to route %d",
-		req.ParticipantID, req.FromRouteIndex, req.ToRouteIndex)
+	if len(moves) == 1 {
+		log.Printf("[EDIT] Moved participant %d from route %d to route %d",
+			moves[0].ParticipantID, moves[0].FromRouteIndex, moves[0].ToRouteIndex)
+	} else {
+		log.Printf("[EDIT] Applied %d participant moves in batch for session %s", len(moves), req.SessionID)
+	}
 
 	// Return updated routes
 	if h.isHTMX(r) {
@@ -441,6 +432,47 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 		SessionID: session.ID,
 		Mode:      session.Mode,
 	})
+}
+
+func applyParticipantMove(session *RouteSession, participantID int64, fromRouteIndex, toRouteIndex, insertAtPosition int) error {
+	if fromRouteIndex < 0 || fromRouteIndex >= len(session.CurrentRoutes) ||
+		toRouteIndex < 0 || toRouteIndex >= len(session.CurrentRoutes) {
+		return fmt.Errorf("%s", messageInvalidRouteIndex)
+	}
+
+	fromRoute := &session.CurrentRoutes[fromRouteIndex]
+	toRoute := &session.CurrentRoutes[toRouteIndex]
+
+	var participant *models.Participant
+	stopIdx := -1
+	for i, stop := range fromRoute.Stops {
+		if stop.Participant.ID == participantID {
+			participant = stop.Participant
+			stopIdx = i
+			break
+		}
+	}
+
+	if participant == nil {
+		return fmt.Errorf("Participant not found in source route")
+	}
+
+	fromRoute.Stops = append(fromRoute.Stops[:stopIdx], fromRoute.Stops[stopIdx+1:]...)
+
+	newStop := models.RouteStop{
+		Participant: participant,
+	}
+
+	if insertAtPosition < 0 || insertAtPosition >= len(toRoute.Stops) {
+		toRoute.Stops = append(toRoute.Stops, newStop)
+	} else {
+		toRoute.Stops = append(toRoute.Stops[:insertAtPosition],
+			append([]models.RouteStop{newStop}, toRoute.Stops[insertAtPosition:]...)...)
+	}
+
+	markRouteDirty(session, fromRouteIndex)
+	markRouteDirty(session, toRouteIndex)
+	return nil
 }
 
 // HandleSwapDrivers handles POST /api/v1/routes/edit/swap-drivers

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -17,7 +17,15 @@ import (
 const (
 	routeSessionTTL             = 2 * time.Hour
 	routeSessionCleanupInterval = 15 * time.Minute
+	maxParticipantMovesPerBatch   = 64
 )
+
+type participantMove struct {
+	ParticipantID    int64 `json:"participant_id"`
+	FromRouteIndex   int   `json:"from_route_index"`
+	ToRouteIndex     int   `json:"to_route_index"`
+	InsertAtPosition int   `json:"insert_at_position"`
+}
 
 // RouteSession stores calculated routes for editing
 type RouteSession struct {
@@ -350,12 +358,7 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 		FromRouteIndex   int    `json:"from_route_index"`
 		ToRouteIndex     int    `json:"to_route_index"`
 		InsertAtPosition int    `json:"insert_at_position"` // -1 for end
-		Moves            []struct {
-			ParticipantID    int64 `json:"participant_id"`
-			FromRouteIndex   int   `json:"from_route_index"`
-			ToRouteIndex     int   `json:"to_route_index"`
-			InsertAtPosition int   `json:"insert_at_position"`
-		} `json:"moves"`
+		Moves            []participantMove `json:"moves"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -363,31 +366,28 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var moves []struct {
-		ParticipantID    int64 `json:"participant_id"`
-		FromRouteIndex   int   `json:"from_route_index"`
-		ToRouteIndex     int   `json:"to_route_index"`
-		InsertAtPosition int   `json:"insert_at_position"`
-	}
+	var moves []participantMove
 	if req.Moves == nil {
-		moves = []struct {
-			ParticipantID    int64 `json:"participant_id"`
-			FromRouteIndex   int   `json:"from_route_index"`
-			ToRouteIndex     int   `json:"to_route_index"`
-			InsertAtPosition int   `json:"insert_at_position"`
-		}{
-			{
-				ParticipantID:    req.ParticipantID,
-				FromRouteIndex:   req.FromRouteIndex,
-				ToRouteIndex:     req.ToRouteIndex,
-				InsertAtPosition: req.InsertAtPosition,
-			},
-		}
+		moves = []participantMove{{
+			ParticipantID:    req.ParticipantID,
+			FromRouteIndex:   req.FromRouteIndex,
+			ToRouteIndex:     req.ToRouteIndex,
+			InsertAtPosition: req.InsertAtPosition,
+		}}
 	} else if len(req.Moves) == 0 {
 		h.handleValidationErrorHTMX(w, r, messageMovesRequired)
 		return
 	} else {
 		moves = req.Moves
+	}
+
+	if len(moves) > maxParticipantMovesPerBatch {
+		h.handleValidationErrorHTMX(w, r, messageTooManyMoves)
+		return
+	}
+	if err := validateParticipantMoveBatch(moves); err != nil {
+		h.handleValidationErrorHTMX(w, r, err.Error())
+		return
 	}
 
 	session := h.RouteSession.Get(req.SessionID)
@@ -402,7 +402,13 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 
 	backupRoutes := deepCopyRoutes(session.CurrentRoutes)
 	for _, move := range moves {
-		if err := applyParticipantMove(session, move.ParticipantID, move.FromRouteIndex, move.ToRouteIndex, move.InsertAtPosition); err != nil {
+		fromRouteIndex, ok := findParticipantRouteIndex(session.CurrentRoutes, move.ParticipantID)
+		if !ok {
+			session.CurrentRoutes = backupRoutes
+			h.handleValidationErrorHTMX(w, r, messageParticipantNotFound)
+			return
+		}
+		if err := applyParticipantMove(session, move.ParticipantID, fromRouteIndex, move.ToRouteIndex, move.InsertAtPosition); err != nil {
 			session.CurrentRoutes = backupRoutes
 			h.handleValidationErrorHTMX(w, r, err.Error())
 			return
@@ -444,6 +450,31 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+func validateParticipantMoveBatch(moves []participantMove) error {
+	seen := make(map[int64]struct{}, len(moves))
+	for _, move := range moves {
+		if move.ParticipantID == 0 {
+			return fmt.Errorf("%s", messageInvalidParticipantID)
+		}
+		if _, exists := seen[move.ParticipantID]; exists {
+			return fmt.Errorf("%s", messageDuplicateMoveParticipant)
+		}
+		seen[move.ParticipantID] = struct{}{}
+	}
+	return nil
+}
+
+func findParticipantRouteIndex(routes []models.CalculatedRoute, participantID int64) (int, bool) {
+	for routeIndex, route := range routes {
+		for _, stop := range route.Stops {
+			if stop.Participant != nil && stop.Participant.ID == participantID {
+				return routeIndex, true
+			}
+		}
+	}
+	return -1, false
+}
+
 func applyParticipantMove(session *RouteSession, participantID int64, fromRouteIndex, toRouteIndex, insertAtPosition int) error {
 	if fromRouteIndex < 0 || fromRouteIndex >= len(session.CurrentRoutes) ||
 		toRouteIndex < 0 || toRouteIndex >= len(session.CurrentRoutes) {
@@ -456,6 +487,9 @@ func applyParticipantMove(session *RouteSession, participantID int64, fromRouteI
 	var participant *models.Participant
 	stopIdx := -1
 	for i, stop := range fromRoute.Stops {
+		if stop.Participant == nil {
+			continue
+		}
 		if stop.Participant.ID == participantID {
 			participant = stop.Participant
 			stopIdx = i
@@ -464,7 +498,7 @@ func applyParticipantMove(session *RouteSession, participantID int64, fromRouteI
 	}
 
 	if participant == nil {
-		return fmt.Errorf("participant not found in source route")
+		return fmt.Errorf("%s", messageParticipantNotFound)
 	}
 
 	fromRoute.Stops = append(fromRoute.Stops[:stopIdx], fromRoute.Stops[stopIdx+1:]...)

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -378,7 +378,8 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var moves []participantMove
-	if req.Moves == nil {
+	legacySingleMove := req.Moves == nil
+	if legacySingleMove {
 		moves = []participantMove{{
 			ParticipantID:    req.ParticipantID,
 			FromRouteIndex:   req.FromRouteIndex,
@@ -422,6 +423,11 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 		if !ok {
 			restoreSession()
 			h.handleValidationErrorHTMX(w, r, messageParticipantNotFound)
+			return
+		}
+		if legacySingleMove && fromRouteIndex != move.FromRouteIndex {
+			restoreSession()
+			h.handleValidationErrorHTMX(w, r, "Participant not found in source route")
 			return
 		}
 		if err := applyParticipantMove(session, move.ParticipantID, fromRouteIndex, move.ToRouteIndex, move.InsertAtPosition); err != nil {

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -363,8 +363,13 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	moves := req.Moves
-	if len(moves) == 0 {
+	var moves []struct {
+		ParticipantID    int64 `json:"participant_id"`
+		FromRouteIndex   int   `json:"from_route_index"`
+		ToRouteIndex     int   `json:"to_route_index"`
+		InsertAtPosition int   `json:"insert_at_position"`
+	}
+	if req.Moves == nil {
 		moves = []struct {
 			ParticipantID    int64 `json:"participant_id"`
 			FromRouteIndex   int   `json:"from_route_index"`
@@ -378,6 +383,11 @@ func (h *Handler) HandleMoveParticipant(w http.ResponseWriter, r *http.Request) 
 				InsertAtPosition: req.InsertAtPosition,
 			},
 		}
+	} else if len(req.Moves) == 0 {
+		h.handleValidationErrorHTMX(w, r, messageMovesRequired)
+		return
+	} else {
+		moves = req.Moves
 	}
 
 	session := h.RouteSession.Get(req.SessionID)
@@ -454,7 +464,7 @@ func applyParticipantMove(session *RouteSession, participantID int64, fromRouteI
 	}
 
 	if participant == nil {
-		return fmt.Errorf("Participant not found in source route")
+		return fmt.Errorf("participant not found in source route")
 	}
 
 	fromRoute.Stops = append(fromRoute.Stops[:stopIdx], fromRoute.Stops[stopIdx+1:]...)

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -730,7 +730,69 @@ func TestHandleMoveParticipant_DuplicateParticipantInBatchMatchesSequentialMoves
 	}
 }
 
-func TestHandleMoveParticipant_StaleFromRouteIndexResolved(t *testing.T) {
+func TestHandleMoveParticipant_BatchStaleFromRouteIndexResolved(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	session := store.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
+			},
+			{
+				Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{},
+			},
+		},
+		[]models.Driver{},
+		activityLocation,
+		false,
+		"18:30",
+		models.RouteModeDropoff,
+		nil,
+	)
+
+	body, err := json.Marshal(map[string]any{
+		"session_id": session.ID,
+		"moves": []map[string]any{
+			{
+				"participant_id":     int64(101),
+				"from_route_index":   1,
+				"to_route_index":     1,
+				"insert_at_position": -1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleMoveParticipant(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	updated := store.Get(session.ID)
+	if len(updated.CurrentRoutes[1].Stops) != 1 {
+		t.Fatalf("expected participant on route 1, got %d stops", len(updated.CurrentRoutes[1].Stops))
+	}
+	if updated.CurrentRoutes[1].Stops[0].Participant.ID != 101 {
+		t.Fatalf("expected participant 101 on route 1, got %d", updated.CurrentRoutes[1].Stops[0].Participant.ID)
+	}
+}
+
+func TestHandleMoveParticipant_LegacyStaleFromRouteIndexRejected(t *testing.T) {
 	store := NewRouteSessionStore()
 	defer store.Close()
 
@@ -775,16 +837,12 @@ func TestHandleMoveParticipant_StaleFromRouteIndexResolved(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.HandleMoveParticipant(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
-
 	updated := store.Get(session.ID)
-	if len(updated.CurrentRoutes[1].Stops) != 1 {
-		t.Fatalf("expected participant on route 1, got %d stops", len(updated.CurrentRoutes[1].Stops))
-	}
-	if updated.CurrentRoutes[1].Stops[0].Participant.ID != 101 {
-		t.Fatalf("expected participant 101 on route 1, got %d", updated.CurrentRoutes[1].Stops[0].Participant.ID)
+	if len(updated.CurrentRoutes[0].Stops) != 1 || len(updated.CurrentRoutes[1].Stops) != 0 {
+		t.Fatalf("legacy stale move mutated routes: route0=%d route1=%d", len(updated.CurrentRoutes[0].Stops), len(updated.CurrentRoutes[1].Stops))
 	}
 }
 

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -478,6 +478,180 @@ func TestHandleMoveParticipant_EmptyMovesReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestHandleMoveParticipant_TooManyMovesReturnsBadRequest(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	session := store.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 100},
+				EffectiveCapacity: 100,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
+			},
+			{
+				Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 100},
+				EffectiveCapacity: 100,
+				Stops:             []models.RouteStop{},
+			},
+		},
+		[]models.Driver{},
+		activityLocation,
+		false,
+		"18:30",
+		models.RouteModeDropoff,
+		nil,
+	)
+
+	moves := make([]map[string]any, maxParticipantMovesPerBatch+1)
+	for i := range moves {
+		moves[i] = map[string]any{
+			"participant_id":     int64(101),
+			"from_route_index":   0,
+			"to_route_index":     1,
+			"insert_at_position": -1,
+		}
+	}
+	body, err := json.Marshal(map[string]any{
+		"session_id": session.ID,
+		"moves":      moves,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleMoveParticipant(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleMoveParticipant_DuplicateParticipantInBatchReturnsBadRequest(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	session := store.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
+			},
+			{
+				Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{},
+			},
+		},
+		[]models.Driver{},
+		activityLocation,
+		false,
+		"18:30",
+		models.RouteModeDropoff,
+		nil,
+	)
+
+	body, err := json.Marshal(map[string]any{
+		"session_id": session.ID,
+		"moves": []map[string]any{
+			{
+				"participant_id":     int64(101),
+				"from_route_index":   0,
+				"to_route_index":     1,
+				"insert_at_position": -1,
+			},
+			{
+				"participant_id":     int64(101),
+				"from_route_index":   1,
+				"to_route_index":     0,
+				"insert_at_position": -1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleMoveParticipant(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleMoveParticipant_StaleFromRouteIndexResolved(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	session := store.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
+			},
+			{
+				Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{},
+			},
+		},
+		[]models.Driver{},
+		activityLocation,
+		false,
+		"18:30",
+		models.RouteModeDropoff,
+		nil,
+	)
+
+	body, err := json.Marshal(map[string]any{
+		"session_id":         session.ID,
+		"participant_id":     int64(101),
+		"from_route_index":   1,
+		"to_route_index":     1,
+		"insert_at_position": -1,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleMoveParticipant(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	updated := store.Get(session.ID)
+	if len(updated.CurrentRoutes[1].Stops) != 1 {
+		t.Fatalf("expected participant on route 1, got %d stops", len(updated.CurrentRoutes[1].Stops))
+	}
+	if updated.CurrentRoutes[1].Stops[0].Participant.ID != 101 {
+		t.Fatalf("expected participant 101 on route 1, got %d", updated.CurrentRoutes[1].Stops[0].Participant.ID)
+	}
+}
+
 func TestCalculateOverCapacity(t *testing.T) {
 	routes := []models.CalculatedRoute{
 		{

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -436,6 +436,112 @@ func TestHandleMoveParticipant_BatchMovesMatchSequentialApplication(t *testing.T
 	}
 }
 
+func TestHandleMoveParticipant_BatchEndingOutOfBalanceMatchesSequentialMetrics(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	baseRoutes := []models.CalculatedRoute{
+		{
+			Driver:              &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 3},
+			EffectiveCapacity:   3,
+			TotalDistanceMeters: 111,
+			Stops: []models.RouteStop{
+				{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}},
+				{Participant: &models.Participant{ID: 102, Name: "P102", Lat: 8, Lng: 0}},
+			},
+		},
+		{
+			Driver:              &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 1},
+			EffectiveCapacity:   1,
+			TotalDistanceMeters: 222,
+			Stops:               []models.RouteStop{},
+		},
+	}
+	moves := []map[string]any{
+		{
+			"participant_id":     int64(101),
+			"from_route_index":   0,
+			"to_route_index":     1,
+			"insert_at_position": -1,
+		},
+		{
+			"participant_id":     int64(102),
+			"from_route_index":   0,
+			"to_route_index":     1,
+			"insert_at_position": -1,
+		},
+	}
+
+	applyMoves := func(sessionID string, batch bool) []models.CalculatedRoute {
+		if batch {
+			body, err := json.Marshal(map[string]any{
+				"session_id": sessionID,
+				"moves":      moves,
+			})
+			if err != nil {
+				t.Fatalf("marshal batch request: %v", err)
+			}
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			handler.HandleMoveParticipant(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("batch status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+		} else {
+			for _, move := range moves {
+				payload := map[string]any{
+					"session_id":         sessionID,
+					"participant_id":     move["participant_id"],
+					"from_route_index":   move["from_route_index"],
+					"to_route_index":     move["to_route_index"],
+					"insert_at_position": move["insert_at_position"],
+				}
+				body, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("marshal single request: %v", err)
+				}
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+				rec := httptest.NewRecorder()
+				handler.HandleMoveParticipant(rec, req)
+				if rec.Code != http.StatusOK {
+					t.Fatalf("sequential status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+				}
+			}
+		}
+		session := store.Get(sessionID)
+		if session == nil {
+			t.Fatal("expected route session to remain available")
+		}
+		return deepCopyRoutes(session.CurrentRoutes)
+	}
+
+	sequentialSession := store.Create(baseRoutes, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+	sequentialRoutes := applyMoves(sequentialSession.ID, false)
+	batchSession := store.Create(baseRoutes, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+	batchRoutes := applyMoves(batchSession.ID, true)
+
+	if !routesEqual(sequentialRoutes, batchRoutes) {
+		t.Fatalf("out-of-balance batch routes differ from sequential application")
+	}
+	if batchRoutes[0].TotalDistanceMeters != sequentialRoutes[0].TotalDistanceMeters ||
+		batchRoutes[1].TotalDistanceMeters != sequentialRoutes[1].TotalDistanceMeters {
+		t.Fatalf("out-of-balance batch metrics = [%.0f %.0f], want sequential [%.0f %.0f]",
+			batchRoutes[0].TotalDistanceMeters,
+			batchRoutes[1].TotalDistanceMeters,
+			sequentialRoutes[0].TotalDistanceMeters,
+			sequentialRoutes[1].TotalDistanceMeters,
+		)
+	}
+	if batchRoutes[0].TotalDistanceMeters == 111 || batchRoutes[1].TotalDistanceMeters == 222 {
+		t.Fatal("batch did not preserve the recalculation from the balanced interim move")
+	}
+}
+
 func TestHandleMoveParticipant_EmptyMovesReturnsBadRequest(t *testing.T) {
 	store := NewRouteSessionStore()
 	defer store.Close()

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -326,6 +326,116 @@ func TestHandleMoveParticipantOptimizesDestinationRoute(t *testing.T) {
 	}
 }
 
+func TestHandleMoveParticipant_BatchMovesMatchSequentialApplication(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	baseRoutes := []models.CalculatedRoute{
+		{
+			Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 3},
+			EffectiveCapacity: 3,
+			Stops: []models.RouteStop{
+				{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}},
+				{Participant: &models.Participant{ID: 102, Name: "P102", Lat: 8, Lng: 0}},
+			},
+		},
+		{
+			Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 2},
+			EffectiveCapacity: 2,
+			Stops: []models.RouteStop{
+				{Participant: &models.Participant{ID: 201, Name: "P201", Lat: 6, Lng: 0}},
+			},
+		},
+	}
+
+	applyMoves := func(sessionID string, batch bool) []models.CalculatedRoute {
+		var body []byte
+		var err error
+		if batch {
+			body, err = json.Marshal(map[string]any{
+				"session_id": sessionID,
+				"moves": []map[string]any{
+					{
+						"participant_id":     int64(101),
+						"from_route_index":   0,
+						"to_route_index":     1,
+						"insert_at_position": -1,
+					},
+					{
+						"participant_id":     int64(102),
+						"from_route_index":   0,
+						"to_route_index":     1,
+						"insert_at_position": -1,
+					},
+				},
+			})
+		} else {
+			for _, move := range []map[string]any{
+				{
+					"session_id":         sessionID,
+					"participant_id":     int64(101),
+					"from_route_index":   0,
+					"to_route_index":     1,
+					"insert_at_position": -1,
+				},
+				{
+					"session_id":         sessionID,
+					"participant_id":     int64(102),
+					"from_route_index":   0,
+					"to_route_index":     1,
+					"insert_at_position": -1,
+				},
+			} {
+				moveBody, marshalErr := json.Marshal(move)
+				if marshalErr != nil {
+					t.Fatalf("marshal request: %v", marshalErr)
+				}
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(moveBody))
+				rec := httptest.NewRecorder()
+				handler.HandleMoveParticipant(rec, req)
+				if rec.Code != http.StatusOK {
+					t.Fatalf("sequential move status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+				}
+			}
+			session := store.Get(sessionID)
+			if session == nil {
+				t.Fatal("expected route session to remain available")
+			}
+			return deepCopyRoutes(session.CurrentRoutes)
+		}
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		handler.HandleMoveParticipant(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("batch move status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+		}
+		session := store.Get(sessionID)
+		if session == nil {
+			t.Fatal("expected route session to remain available")
+		}
+		return deepCopyRoutes(session.CurrentRoutes)
+	}
+
+	sequentialSession := store.Create(baseRoutes, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+	sequentialRoutes := applyMoves(sequentialSession.ID, false)
+
+	batchSession := store.Create(baseRoutes, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+	batchRoutes := applyMoves(batchSession.ID, true)
+
+	if !routesEqual(sequentialRoutes, batchRoutes) {
+		t.Fatalf("batch routes differ from sequential application")
+	}
+}
+
 func TestCalculateOverCapacity(t *testing.T) {
 	routes := []models.CalculatedRoute{
 		{

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -534,7 +534,7 @@ func TestHandleMoveParticipant_TooManyMovesReturnsBadRequest(t *testing.T) {
 	}
 }
 
-func TestHandleMoveParticipant_DuplicateParticipantInBatchReturnsBadRequest(t *testing.T) {
+func TestHandleMoveParticipant_DuplicateParticipantInBatchMatchesSequentialMoves(t *testing.T) {
 	store := NewRouteSessionStore()
 	defer store.Close()
 
@@ -543,54 +543,84 @@ func TestHandleMoveParticipant_DuplicateParticipantInBatchReturnsBadRequest(t *t
 		RouteSession: store,
 	}
 	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
-	session := store.Create(
-		[]models.CalculatedRoute{
-			{
-				Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 2},
-				EffectiveCapacity: 2,
-				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
-			},
-			{
-				Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 2},
-				EffectiveCapacity: 2,
-				Stops:             []models.RouteStop{},
-			},
+	baseRoutes := []models.CalculatedRoute{
+		{
+			Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 2},
+			EffectiveCapacity: 2,
+			Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
 		},
-		[]models.Driver{},
-		activityLocation,
-		false,
-		"18:30",
-		models.RouteModeDropoff,
-		nil,
-	)
-
-	body, err := json.Marshal(map[string]any{
-		"session_id": session.ID,
-		"moves": []map[string]any{
-			{
-				"participant_id":     int64(101),
-				"from_route_index":   0,
-				"to_route_index":     1,
-				"insert_at_position": -1,
-			},
-			{
-				"participant_id":     int64(101),
-				"from_route_index":   1,
-				"to_route_index":     0,
-				"insert_at_position": -1,
-			},
+		{
+			Driver:            &models.Driver{ID: 2, Name: "Driver 2", Lat: 7, Lng: 0, VehicleCapacity: 2},
+			EffectiveCapacity: 2,
+			Stops:             []models.RouteStop{},
 		},
-	})
-	if err != nil {
-		t.Fatalf("marshal request: %v", err)
+	}
+	moves := []map[string]any{
+		{
+			"participant_id":     int64(101),
+			"from_route_index":   0,
+			"to_route_index":     1,
+			"insert_at_position": -1,
+		},
+		{
+			"participant_id":     int64(101),
+			"from_route_index":   1,
+			"to_route_index":     0,
+			"insert_at_position": -1,
+		},
 	}
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
-	rec := httptest.NewRecorder()
-	handler.HandleMoveParticipant(rec, req)
+	applyMoves := func(sessionID string, batch bool) []models.CalculatedRoute {
+		if batch {
+			body, err := json.Marshal(map[string]any{
+				"session_id": sessionID,
+				"moves":      moves,
+			})
+			if err != nil {
+				t.Fatalf("marshal batch request: %v", err)
+			}
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			handler.HandleMoveParticipant(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("batch status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+		} else {
+			for _, move := range moves {
+				payload := map[string]any{
+					"session_id":         sessionID,
+					"participant_id":     move["participant_id"],
+					"from_route_index":   move["from_route_index"],
+					"to_route_index":     move["to_route_index"],
+					"insert_at_position": move["insert_at_position"],
+				}
+				body, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("marshal single request: %v", err)
+				}
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+				rec := httptest.NewRecorder()
+				handler.HandleMoveParticipant(rec, req)
+				if rec.Code != http.StatusOK {
+					t.Fatalf("sequential status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+				}
+			}
+		}
+		session := store.Get(sessionID)
+		if session == nil {
+			t.Fatal("expected route session to remain available")
+		}
+		return deepCopyRoutes(session.CurrentRoutes)
+	}
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	sequentialSession := store.Create(baseRoutes, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+	sequentialRoutes := applyMoves(sequentialSession.ID, false)
+
+	batchSession := store.Create(baseRoutes, []models.Driver{}, activityLocation, false, "18:30", models.RouteModeDropoff, nil)
+	batchRoutes := applyMoves(batchSession.ID, true)
+
+	if !routesEqual(sequentialRoutes, batchRoutes) {
+		t.Fatalf("duplicate-participant batch routes differ from sequential application")
 	}
 }
 

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -395,7 +395,7 @@ func TestHandleMoveParticipant_BatchMovesMatchSequentialApplication(t *testing.T
 				if marshalErr != nil {
 					t.Fatalf("marshal request: %v", marshalErr)
 				}
-				req := httptest.NewRequest(http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(moveBody))
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(moveBody))
 				rec := httptest.NewRecorder()
 				handler.HandleMoveParticipant(rec, req)
 				if rec.Code != http.StatusOK {
@@ -412,7 +412,7 @@ func TestHandleMoveParticipant_BatchMovesMatchSequentialApplication(t *testing.T
 			t.Fatalf("marshal request: %v", err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
 		rec := httptest.NewRecorder()
 		handler.HandleMoveParticipant(rec, req)
 		if rec.Code != http.StatusOK {
@@ -433,6 +433,48 @@ func TestHandleMoveParticipant_BatchMovesMatchSequentialApplication(t *testing.T
 
 	if !routesEqual(sequentialRoutes, batchRoutes) {
 		t.Fatalf("batch routes differ from sequential application")
+	}
+}
+
+func TestHandleMoveParticipant_EmptyMovesReturnsBadRequest(t *testing.T) {
+	store := NewRouteSessionStore()
+	defer store.Close()
+
+	handler := &Handler{
+		DistanceCalc: routeEditDistanceCalculator{},
+		RouteSession: store,
+	}
+	activityLocation := &models.ActivityLocation{ID: 1, Name: "HQ", Lat: 0, Lng: 0}
+	session := store.Create(
+		[]models.CalculatedRoute{
+			{
+				Driver:            &models.Driver{ID: 1, Name: "Driver 1", Lat: 10, Lng: 0, VehicleCapacity: 2},
+				EffectiveCapacity: 2,
+				Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 101, Name: "P101", Lat: 9, Lng: 0}}},
+			},
+		},
+		[]models.Driver{},
+		activityLocation,
+		false,
+		"18:30",
+		models.RouteModeDropoff,
+		nil,
+	)
+
+	body, err := json.Marshal(map[string]any{
+		"session_id": session.ID,
+		"moves":      []map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/edit/move-participant", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleMoveParticipant(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -60,16 +60,9 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 		}
 	}
 
-	// Prewarm distance cache
+	// Prewarm distance cache with only the directed pairs needed for this solve.
 	prewarmStart := time.Now()
-	allPoints := []models.Coordinates{req.InstituteCoords}
-	for _, p := range req.Participants {
-		allPoints = append(allPoints, p.GetCoords())
-	}
-	for _, d := range req.Drivers {
-		allPoints = append(allPoints, d.GetCoords())
-	}
-	if err := r.distanceCalc.PrewarmCache(ctx, allPoints); err != nil {
+	if err := prewarmRoutingDistances(ctx, r.distanceCalc, req, rc.mode); err != nil {
 		return nil, err
 	}
 	log.Printf("[TIMING] Prewarm cache: %v", time.Since(prewarmStart))
@@ -390,6 +383,7 @@ func (r *BalancedRouter) minMaxOptimize(ctx context.Context, rc routeContext, ro
 			id       int64
 			duration float64
 		}
+		routeDurationsByDriverID := make(map[int64]float64, len(driverIDs))
 		routesByDuration := make([]routeDuration, 0, len(driverIDs))
 		for _, id := range driverIDs {
 			route := routes[id]
@@ -397,6 +391,7 @@ func (r *BalancedRouter) minMaxOptimize(ctx context.Context, rc routeContext, ro
 			if err != nil {
 				return iteration
 			}
+			routeDurationsByDriverID[id] = duration
 			routesByDuration = append(routesByDuration, routeDuration{id, duration})
 		}
 		sort.Slice(routesByDuration, func(i, j int) bool {
@@ -454,33 +449,24 @@ func (r *BalancedRouter) minMaxOptimize(ctx context.Context, rc routeContext, ro
 					}
 
 					for _, destPos := range boundaryPositionsByDriver[destID] {
-						// Simulate the move
 						newSrcStops := removeRange(srcRoute.stops, srcPos, srcPos+groupSize)
 						newDestStops := insertGroupAt(destRoute.stops, group, destPos)
 						newSrcStops = coalesceHouseholdStops(newSrcStops)
 						newDestStops = coalesceHouseholdStops(newDestStops)
 
-						oldSrcStops := srcRoute.stops
-						oldDestStops := destRoute.stops
-						srcRoute.stops = newSrcStops
-						destRoute.stops = newDestStops
-
-						// Calculate new max duration
-						newMaxDuration := 0.0
-						for _, id := range driverIDs {
-							duration, err := r.calculateRouteDuration(ctx, rc, routes[id])
-							if err != nil {
-								newMaxDuration = currentMaxDuration
-								break
-							}
-							if duration > newMaxDuration {
-								newMaxDuration = duration
-							}
+						newSrcDuration, err := r.calculateDurationFromStops(ctx, rc, srcRoute.driver, newSrcStops)
+						if err != nil {
+							continue
 						}
-
-						// Restore
-						srcRoute.stops = oldSrcStops
-						destRoute.stops = oldDestStops
+						newDestDuration, err := r.calculateDurationFromStops(ctx, rc, destRoute.driver, newDestStops)
+						if err != nil {
+							continue
+						}
+						newMaxDuration := max(
+							newSrcDuration,
+							newDestDuration,
+							maxCachedRouteDuration(routeDurationsByDriverID, driverIDs, rd.id, destID),
+						)
 
 						// Accept if it reduces the maximum
 						if newMaxDuration < bestMove.newMaxDuration-10 { // 10 second threshold
@@ -519,6 +505,8 @@ func (r *BalancedRouter) minMaxOptimize(ctx context.Context, rc routeContext, ro
 				if err := r.updateRouteDuration(ctx, rc, destRoute); err != nil {
 					return iteration
 				}
+				routeDurationsByDriverID[srcRoute.driver.ID] = srcRoute.totalDuration
+				routeDurationsByDriverID[destRoute.driver.ID] = destRoute.totalDuration
 
 				memberNames := make([]string, len(bestMove.group.members))
 				for i, member := range bestMove.group.members {
@@ -553,6 +541,31 @@ func (r *BalancedRouter) calculateRouteDuration(ctx context.Context, rc routeCon
 		return 0, nil
 	}
 	return rc.routeDuration(ctx, route.driver, route.stops)
+}
+
+func (r *BalancedRouter) calculateDurationFromStops(ctx context.Context, rc routeContext, driver *models.Driver, stops []*models.Participant) (float64, error) {
+	if len(stops) == 0 {
+		return 0, nil
+	}
+	return rc.routeDuration(ctx, driver, stops)
+}
+
+func maxCachedRouteDuration(cached map[int64]float64, driverIDs []int64, exclude ...int64) float64 {
+	excludeSet := make(map[int64]struct{}, len(exclude))
+	for _, id := range exclude {
+		excludeSet[id] = struct{}{}
+	}
+
+	maxDuration := 0.0
+	for _, id := range driverIDs {
+		if _, skip := excludeSet[id]; skip {
+			continue
+		}
+		if duration := cached[id]; duration > maxDuration {
+			maxDuration = duration
+		}
+	}
+	return maxDuration
 }
 
 func (r *BalancedRouter) calculateRouteDurations(ctx context.Context, rc routeContext, routes map[int64]*balancedRoute, driverIDs []int64) ([]float64, error) {

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -621,6 +621,20 @@ func TestOptimizeAllRoutes_FinalOrderingMinimizesTotalDriveTime(t *testing.T) {
 	}
 }
 
+func TestMaxCachedRouteDuration_ExcludesProvidedDrivers(t *testing.T) {
+	cached := map[int64]float64{
+		1: 100,
+		2: 500,
+		3: 300,
+	}
+	driverIDs := []int64{1, 2, 3}
+
+	got := maxCachedRouteDuration(cached, driverIDs, 2, 3)
+	if got != 100 {
+		t.Fatalf("maxCachedRouteDuration() = %.0f, want 100", got)
+	}
+}
+
 func TestShouldRunMinMaxOptimizeUsesGuardrailThresholds(t *testing.T) {
 	if shouldRunMinMaxOptimize([]float64{600, 600, 900}) {
 		t.Fatal("should not run min-max below relative and absolute thresholds")

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -453,6 +453,37 @@ func (a *overrideDistanceAdapter) PrewarmCache(ctx context.Context, points []mod
 	return nil
 }
 
+type trackingDistanceAdapter struct {
+	*overrideDistanceAdapter
+	tracked      map[string]struct{}
+	trackedCalls int
+	trackedEdges []string
+}
+
+func newTrackingDistanceAdapter(defaultDuration float64) *trackingDistanceAdapter {
+	return &trackingDistanceAdapter{
+		overrideDistanceAdapter: newOverrideDistanceAdapter(defaultDuration),
+		tracked:                 make(map[string]struct{}),
+	}
+}
+
+func (a *trackingDistanceAdapter) track(coord models.Coordinates) {
+	a.tracked[coordinateKey(models.RoundCoordinate(coord.Lat), models.RoundCoordinate(coord.Lng))] = struct{}{}
+}
+
+func (a *trackingDistanceAdapter) GetDistance(ctx context.Context, origin, dest models.Coordinates) (*distance.DistanceResult, error) {
+	if a.isTracked(origin) || a.isTracked(dest) {
+		a.trackedCalls++
+		a.trackedEdges = append(a.trackedEdges, distance.PairCacheKey(origin, dest))
+	}
+	return a.overrideDistanceAdapter.GetDistance(ctx, origin, dest)
+}
+
+func (a *trackingDistanceAdapter) isTracked(coord models.Coordinates) bool {
+	_, ok := a.tracked[coordinateKey(models.RoundCoordinate(coord.Lat), models.RoundCoordinate(coord.Lng))]
+	return ok
+}
+
 func TestRoundRobinInsertion_KeepsPickupHouseholdsIntact(t *testing.T) {
 	driverHome := models.Coordinates{Lat: 10, Lng: 10}
 	activity := models.Coordinates{Lat: 0, Lng: 0}
@@ -632,6 +663,68 @@ func TestMaxCachedRouteDuration_ExcludesProvidedDrivers(t *testing.T) {
 	got := maxCachedRouteDuration(cached, driverIDs, 2, 3)
 	if got != 100 {
 		t.Fatalf("maxCachedRouteDuration() = %.0f, want 100", got)
+	}
+}
+
+func TestMinMaxOptimizeDoesNotRecalculateUnaffectedRoutesForCandidates(t *testing.T) {
+	distances := newTrackingDistanceAdapter(100)
+	router := &BalancedRouter{distanceCalc: distances}
+	rc := newRouteContext(distances, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
+
+	sourceDriver := &models.Driver{ID: 1, Name: "Source", Lat: 50, Lng: 0, VehicleCapacity: 6}
+	destDriver := &models.Driver{ID: 2, Name: "Dest", Lat: 60, Lng: 0, VehicleCapacity: 6}
+	unaffectedDriverA := &models.Driver{ID: 3, Name: "Unaffected A", Lat: 70, Lng: 0, VehicleCapacity: 1}
+	unaffectedDriverB := &models.Driver{ID: 4, Name: "Unaffected B", Lat: 80, Lng: 0, VehicleCapacity: 1}
+	destStop := &models.Participant{ID: 20, Name: "Dest Stop", Lat: 20, Lng: 0}
+	unaffectedStopA := &models.Participant{ID: 30, Name: "Unaffected Stop A", Lat: 30, Lng: 0}
+	unaffectedStopB := &models.Participant{ID: 40, Name: "Unaffected Stop B", Lat: 40, Lng: 0}
+	sourceStops := []*models.Participant{
+		{ID: 10, Name: "Source 1", Lat: 10, Lng: 0},
+		{ID: 11, Name: "Source 2", Lat: 11, Lng: 0},
+		{ID: 12, Name: "Source 3", Lat: 12, Lng: 0},
+		{ID: 13, Name: "Source 4", Lat: 13, Lng: 0},
+	}
+	for _, stop := range sourceStops {
+		distances.setDuration(stop.GetCoords(), destStop.GetCoords(), 1000)
+		distances.setDuration(destStop.GetCoords(), stop.GetCoords(), 1000)
+		distances.setDuration(stop.GetCoords(), destDriver.GetCoords(), 1000)
+	}
+	distances.track(unaffectedDriverA.GetCoords())
+	distances.track(unaffectedStopA.GetCoords())
+	distances.track(unaffectedDriverB.GetCoords())
+	distances.track(unaffectedStopB.GetCoords())
+
+	routes := map[int64]*balancedRoute{
+		sourceDriver.ID: {
+			driver: sourceDriver,
+			stops:  sourceStops,
+		},
+		destDriver.ID: {
+			driver: destDriver,
+			stops:  []*models.Participant{destStop},
+		},
+		unaffectedDriverA.ID: {
+			driver: unaffectedDriverA,
+			stops:  []*models.Participant{unaffectedStopA},
+		},
+		unaffectedDriverB.ID: {
+			driver: unaffectedDriverB,
+			stops:  []*models.Participant{unaffectedStopB},
+		},
+	}
+
+	iterations := router.minMaxOptimize(context.Background(), rc, routes, []int64{
+		sourceDriver.ID,
+		destDriver.ID,
+		unaffectedDriverA.ID,
+		unaffectedDriverB.ID,
+	})
+
+	if iterations != 1 {
+		t.Fatalf("minMaxOptimize() iterations = %d, want exactly one no-move pass", iterations)
+	}
+	if distances.trackedCalls != 6 {
+		t.Fatalf("unaffected route distance calls = %d, want only initial route-duration calls (6): %v", distances.trackedCalls, distances.trackedEdges)
 	}
 }
 

--- a/internal/routing/helpers.go
+++ b/internal/routing/helpers.go
@@ -17,14 +17,6 @@ func reverse(stops []*models.Participant, i, j int) {
 	}
 }
 
-func reverseGroups(groups []*participantGroup, i, j int) {
-	for i < j {
-		groups[i], groups[j] = groups[j], groups[i]
-		i++
-		j--
-	}
-}
-
 func flattenParticipantGroups(groups []*participantGroup) []*models.Participant {
 	total := 0
 	for _, group := range groups {

--- a/internal/routing/helpers.go
+++ b/internal/routing/helpers.go
@@ -17,6 +17,14 @@ func reverse(stops []*models.Participant, i, j int) {
 	}
 }
 
+func reverseParticipantGroups(groups []*participantGroup, i, j int) {
+	for i < j {
+		groups[i], groups[j] = groups[j], groups[i]
+		i++
+		j--
+	}
+}
+
 func flattenParticipantGroups(groups []*participantGroup) []*models.Participant {
 	total := 0
 	for _, group := range groups {

--- a/internal/routing/helpers_test.go
+++ b/internal/routing/helpers_test.go
@@ -54,3 +54,7 @@ func (a *mockDistanceAdapter) GetDistancesFromPoint(ctx context.Context, origin 
 func (a *mockDistanceAdapter) PrewarmCache(ctx context.Context, points []models.Coordinates) error {
 	return a.mock.PrewarmCache(ctx, points)
 }
+
+func (a *mockDistanceAdapter) PrewarmPairs(ctx context.Context, pairs []distance.DistancePair) error {
+	return a.mock.PrewarmPairs(ctx, pairs)
+}

--- a/internal/routing/prewarm.go
+++ b/internal/routing/prewarm.go
@@ -1,0 +1,80 @@
+package routing
+
+import (
+	"context"
+
+	"ride-home-router/internal/distance"
+	"ride-home-router/internal/models"
+)
+
+func prewarmRoutingDistances(ctx context.Context, calc distance.DistanceCalculator, req *RoutingRequest, mode RouteMode) error {
+	pairs := collectRoutingPrewarmPairs(mode, req.InstituteCoords, req.Participants, req.Drivers)
+	return distance.PrewarmRoutingPairs(ctx, calc, pairs)
+}
+
+func collectRoutingPrewarmPairs(mode RouteMode, institute models.Coordinates, participants []models.Participant, drivers []models.Driver) []distance.DistancePair {
+	seen := make(map[string]struct{})
+	pairs := make([]distance.DistancePair, 0)
+
+	addPair := func(origin, dest models.Coordinates) {
+		if models.RoundCoordinate(origin.Lat) == models.RoundCoordinate(dest.Lat) &&
+			models.RoundCoordinate(origin.Lng) == models.RoundCoordinate(dest.Lng) {
+			return
+		}
+		key := distance.PairCacheKey(origin, dest)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		pairs = append(pairs, distance.DistancePair{Origin: origin, Destination: dest})
+	}
+
+	participantCoords := make([]models.Coordinates, len(participants))
+	for i := range participants {
+		participantCoords[i] = participants[i].GetCoords()
+	}
+
+	driverCoords := make([]models.Coordinates, len(drivers))
+	for i := range drivers {
+		driverCoords[i] = drivers[i].GetCoords()
+	}
+
+	if mode == RouteModePickup {
+		for _, driverCoord := range driverCoords {
+			for _, participantCoord := range participantCoords {
+				addPair(driverCoord, participantCoord)
+			}
+			addPair(driverCoord, institute)
+		}
+		for i := range participantCoords {
+			for j := range participantCoords {
+				if i == j {
+					continue
+				}
+				addPair(participantCoords[i], participantCoords[j])
+			}
+			addPair(participantCoords[i], institute)
+		}
+		return pairs
+	}
+
+	for _, participantCoord := range participantCoords {
+		addPair(institute, participantCoord)
+	}
+	for i := range participantCoords {
+		for j := range participantCoords {
+			if i == j {
+				continue
+			}
+			addPair(participantCoords[i], participantCoords[j])
+		}
+		for _, driverCoord := range driverCoords {
+			addPair(participantCoords[i], driverCoord)
+		}
+	}
+	for _, driverCoord := range driverCoords {
+		addPair(institute, driverCoord)
+	}
+
+	return pairs
+}

--- a/internal/routing/prewarm.go
+++ b/internal/routing/prewarm.go
@@ -2,7 +2,6 @@ package routing
 
 import (
 	"context"
-
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
 )

--- a/internal/routing/prewarm_test.go
+++ b/internal/routing/prewarm_test.go
@@ -2,10 +2,9 @@ package routing
 
 import (
 	"context"
-	"testing"
-
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
+	"testing"
 )
 
 type countingPrewarmCalculator struct {

--- a/internal/routing/prewarm_test.go
+++ b/internal/routing/prewarm_test.go
@@ -1,0 +1,166 @@
+package routing
+
+import (
+	"context"
+	"testing"
+
+	"ride-home-router/internal/distance"
+	"ride-home-router/internal/models"
+)
+
+type countingPrewarmCalculator struct {
+	stableDistanceCalculator
+	prewarmPairsCalls int
+	prewarmPairCount  int
+	prewarmCacheCalls int
+}
+
+func (c *countingPrewarmCalculator) PrewarmPairs(ctx context.Context, pairs []distance.DistancePair) error {
+	c.prewarmPairsCalls++
+	c.prewarmPairCount += len(pairs)
+	return nil
+}
+
+func (c *countingPrewarmCalculator) PrewarmCache(ctx context.Context, points []models.Coordinates) error {
+	c.prewarmCacheCalls++
+	return nil
+}
+
+func BenchmarkCollectRoutingPrewarmPairs(b *testing.B) {
+	req := &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants:    make([]models.Participant, 20),
+		Drivers:         make([]models.Driver, 5),
+	}
+	for i := range req.Participants {
+		req.Participants[i] = models.Participant{ID: int64(i + 1), Lat: float64(i + 1), Lng: 0}
+	}
+	for i := range req.Drivers {
+		req.Drivers[i] = models.Driver{ID: int64(i + 1), Lat: 10 + float64(i), Lng: 0, VehicleCapacity: 4}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = collectRoutingPrewarmPairs(RouteModePickup, req.InstituteCoords, req.Participants, req.Drivers)
+	}
+}
+
+func TestCollectRoutingPrewarmPairs_PickupUsesDirectedLegsOnly(t *testing.T) {
+	req := &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 1, Name: "P1", Lat: 1, Lng: 0},
+			{ID: 2, Name: "P2", Lat: 2, Lng: 0},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "D1", Lat: 10, Lng: 0, VehicleCapacity: 4},
+			{ID: 2, Name: "D2", Lat: 11, Lng: 0, VehicleCapacity: 4},
+		},
+	}
+
+	pairs := collectRoutingPrewarmPairs(RouteModePickup, req.InstituteCoords, req.Participants, req.Drivers)
+	seen := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		key := distance.PairCacheKey(pair.Origin, pair.Destination)
+		if _, exists := seen[key]; exists {
+			t.Fatalf("duplicate pair in prewarm set: %s", key)
+		}
+		seen[key] = struct{}{}
+	}
+
+	wantDirected := 10
+	if len(pairs) != wantDirected {
+		t.Fatalf("pickup pair count = %d, want %d", len(pairs), wantDirected)
+	}
+}
+
+func TestCollectRoutingPrewarmPairs_DropoffUsesDirectedLegsOnly(t *testing.T) {
+	req := &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 1, Name: "P1", Lat: 1, Lng: 0},
+			{ID: 2, Name: "P2", Lat: 2, Lng: 0},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "D1", Lat: 10, Lng: 0, VehicleCapacity: 4},
+			{ID: 2, Name: "D2", Lat: 11, Lng: 0, VehicleCapacity: 4},
+		},
+	}
+
+	pairs := collectRoutingPrewarmPairs(RouteModeDropoff, req.InstituteCoords, req.Participants, req.Drivers)
+	seen := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		if models.RoundCoordinate(pair.Origin.Lat) == models.RoundCoordinate(pair.Destination.Lat) &&
+			models.RoundCoordinate(pair.Origin.Lng) == models.RoundCoordinate(pair.Destination.Lng) {
+			t.Fatalf("unexpected identity pair: %+v", pair)
+		}
+		key := distance.PairCacheKey(pair.Origin, pair.Destination)
+		if _, exists := seen[key]; exists {
+			t.Fatalf("duplicate pair in prewarm set: %s", key)
+		}
+		seen[key] = struct{}{}
+	}
+
+	wantDirected := 10
+	if len(pairs) != wantDirected {
+		t.Fatalf("dropoff pair count = %d, want %d", len(pairs), wantDirected)
+	}
+}
+
+func TestPrewarmRoutingDistances_UsesPairInterfaceWhenAvailable(t *testing.T) {
+	calc := &countingPrewarmCalculator{}
+	req := &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 1, Name: "P1", Lat: 1, Lng: 0},
+			{ID: 2, Name: "P2", Lat: 2, Lng: 0},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "D1", Lat: 10, Lng: 0, VehicleCapacity: 4},
+		},
+	}
+
+	if err := prewarmRoutingDistances(context.Background(), calc, req, RouteModePickup); err != nil {
+		t.Fatalf("prewarmRoutingDistances() error = %v", err)
+	}
+	if calc.prewarmPairsCalls != 1 {
+		t.Fatalf("PrewarmPairs calls = %d, want 1", calc.prewarmPairsCalls)
+	}
+	if calc.prewarmCacheCalls != 0 {
+		t.Fatalf("PrewarmCache calls = %d, want 0", calc.prewarmCacheCalls)
+	}
+	if calc.prewarmPairCount == 0 {
+		t.Fatal("expected non-zero pair prewarm count")
+	}
+}
+
+func TestPrewarmRoutingDistances_FallsBackToCachePrewarm(t *testing.T) {
+	calc := &cacheOnlyPrewarmCalculator{}
+	req := &RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 1, Name: "P1", Lat: 1, Lng: 0},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "D1", Lat: 10, Lng: 0, VehicleCapacity: 4},
+		},
+	}
+
+	var calcIface distance.DistanceCalculator = calc
+	if err := prewarmRoutingDistances(context.Background(), calcIface, req, RouteModeDropoff); err != nil {
+		t.Fatalf("prewarmRoutingDistances() error = %v", err)
+	}
+	if calc.prewarmCacheCalls != 1 {
+		t.Fatalf("PrewarmCache calls = %d, want 1", calc.prewarmCacheCalls)
+	}
+}
+
+type cacheOnlyPrewarmCalculator struct {
+	stableDistanceCalculator
+	prewarmCacheCalls int
+}
+
+func (c *cacheOnlyPrewarmCalculator) PrewarmCache(ctx context.Context, points []models.Coordinates) error {
+	c.prewarmCacheCalls++
+	return nil
+}

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -337,7 +337,7 @@ func (rc routeContext) twoOptDistance(ctx context.Context, driver *models.Driver
 		return result.DistanceMeters
 	})
 	return twoOptByDelta(stops, func(candidate []*models.Participant, i, j int) (float64, error) {
-		return rc.twoOptDeltaFromScores(driver, candidate, i, j, scoreCache.score, false)
+		return rc.twoOptDeltaFromScores(driver, candidate, i, j, scoreCache.score, rc.objectiveIncludesTerminal())
 	})
 }
 

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -316,10 +316,10 @@ func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.D
 	}
 
 	blockStops := make([]*models.Participant, len(blocks))
-	blockByKey := make(map[string]*participantGroup, len(blocks))
+	blockByRep := make(map[*models.Participant]*participantGroup, len(blocks))
 	for i, block := range blocks {
 		blockStops[i] = block.members[0]
-		blockByKey[householdKey(block.members[0])] = block
+		blockByRep[block.members[0]] = block
 	}
 
 	optimizedStops, err := twoOptByDelta(blockStops, func(candidate []*models.Participant, i, j int) (float64, error) {
@@ -333,7 +333,7 @@ func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.D
 
 	orderedBlocks := make([]*participantGroup, 0, len(optimizedStops))
 	for _, rep := range optimizedStops {
-		block := blockByKey[householdKey(rep)]
+		block := blockByRep[rep]
 		if block == nil {
 			return nil, fmt.Errorf("optimized route lost household block")
 		}

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -305,7 +305,7 @@ func (rc routeContext) twoOptDistance(ctx context.Context, driver *models.Driver
 	return twoOptByDelta(stops, func(candidate []*models.Participant, i, j int) (float64, error) {
 		return rc.twoOptDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
 			return result.DistanceMeters
-		})
+		}, false)
 	})
 }
 
@@ -315,39 +315,35 @@ func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.D
 		return stops, nil
 	}
 
-	currentBlocks := append([]*participantGroup(nil), blocks...)
-	currentStops := flattenParticipantGroups(currentBlocks)
-	currentScore, err := rc.totalDriveDuration(ctx, driver, currentStops)
+	blockStops := make([]*models.Participant, len(blocks))
+	blockByKey := make(map[string]*participantGroup, len(blocks))
+	for i, block := range blocks {
+		blockStops[i] = block.members[0]
+		blockByKey[householdKey(block.members[0])] = block
+	}
+
+	optimizedStops, err := twoOptByDelta(blockStops, func(candidate []*models.Participant, i, j int) (float64, error) {
+		return rc.twoOptDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
+			return result.DurationSecs
+		}, true)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	improved := true
-	for improved {
-		improved = false
-		for i := 0; i < len(currentBlocks)-1; i++ {
-			for j := i + 2; j <= len(currentBlocks); j++ {
-				candidateBlocks := append([]*participantGroup(nil), currentBlocks...)
-				reverseGroups(candidateBlocks, i, j-1)
-				candidateStops := flattenParticipantGroups(candidateBlocks)
-				candidateScore, err := rc.totalDriveDuration(ctx, driver, candidateStops)
-				if err != nil {
-					return nil, err
-				}
-				if candidateScore < currentScore-scoreImprovementEpsilon {
-					currentBlocks = candidateBlocks
-					currentStops = candidateStops
-					currentScore = candidateScore
-					improved = true
-				}
-			}
+	orderedBlocks := make([]*participantGroup, 0, len(optimizedStops))
+	for _, rep := range optimizedStops {
+		block := blockByKey[householdKey(rep)]
+		if block == nil {
+			return nil, fmt.Errorf("optimized route lost household block")
 		}
+		orderedBlocks = append(orderedBlocks, block)
 	}
 
-	return currentStops, nil
+	return flattenParticipantGroups(orderedBlocks), nil
 }
 
-func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, stops []*models.Participant, i, j int, selector func(*distance.DistanceResult) float64) (float64, error) {
+func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, stops []*models.Participant, i, j int, selector func(*distance.DistanceResult) float64, includeTerminal bool) (float64, error) {
 	if driver == nil {
 		return 0, fmt.Errorf("route driver is required")
 	}
@@ -381,7 +377,7 @@ func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, s
 		return delta, nil
 	}
 
-	if rc.objectiveIncludesTerminal() {
+	if includeTerminal {
 		destination := rc.destination(driver)
 		currentTerminal, err := rc.distanceCalc.GetDistance(ctx, stops[j-1].GetCoords(), destination)
 		if err != nil {
@@ -398,7 +394,7 @@ func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, s
 }
 
 func twoOptByDelta(stops []*models.Participant, deltaFn func([]*models.Participant, int, int) (float64, error)) ([]*models.Participant, error) {
-	if len(stops) < 3 {
+	if len(stops) < 2 {
 		return stops, nil
 	}
 

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -315,15 +315,8 @@ func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.D
 		return stops, nil
 	}
 
-	blockStops := make([]*models.Participant, len(blocks))
-	blockByRep := make(map[*models.Participant]*participantGroup, len(blocks))
-	for i, block := range blocks {
-		blockStops[i] = block.members[0]
-		blockByRep[block.members[0]] = block
-	}
-
-	optimizedStops, err := twoOptByDelta(blockStops, func(candidate []*models.Participant, i, j int) (float64, error) {
-		return rc.twoOptDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
+	optimizedBlocks, err := twoOptBlocksByDelta(blocks, func(candidate []*participantGroup, i, j int) (float64, error) {
+		return rc.twoOptBlockDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
 			return result.DurationSecs
 		}, true)
 	})
@@ -331,16 +324,94 @@ func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.D
 		return nil, err
 	}
 
-	orderedBlocks := make([]*participantGroup, 0, len(optimizedStops))
-	for _, rep := range optimizedStops {
-		block := blockByRep[rep]
-		if block == nil {
-			return nil, fmt.Errorf("optimized route lost household block")
-		}
-		orderedBlocks = append(orderedBlocks, block)
+	return flattenParticipantGroups(optimizedBlocks), nil
+}
+
+func blockFirstMember(block *participantGroup) *models.Participant {
+	return block.members[0]
+}
+
+func blockLastMember(block *participantGroup) *models.Participant {
+	return block.members[len(block.members)-1]
+}
+
+func twoOptBlocksByDelta(blocks []*participantGroup, deltaFn func([]*participantGroup, int, int) (float64, error)) ([]*participantGroup, error) {
+	if len(blocks) < 2 {
+		return blocks, nil
 	}
 
-	return flattenParticipantGroups(orderedBlocks), nil
+	current := append([]*participantGroup(nil), blocks...)
+	improved := true
+	for improved {
+		improved = false
+		for i := 0; i < len(current)-1; i++ {
+			for j := i + 2; j <= len(current); j++ {
+				delta, err := deltaFn(current, i, j)
+				if err != nil {
+					return nil, err
+				}
+				if delta < 0 {
+					reverseParticipantGroups(current, i, j-1)
+					improved = true
+				}
+			}
+		}
+	}
+
+	return current, nil
+}
+
+func (rc routeContext) twoOptBlockDelta(ctx context.Context, driver *models.Driver, blocks []*participantGroup, i, j int, selector func(*distance.DistanceResult) float64, includeTerminal bool) (float64, error) {
+	if driver == nil {
+		return 0, fmt.Errorf("route driver is required")
+	}
+
+	beforeI := rc.origin(driver)
+	if i > 0 {
+		beforeI = blockLastMember(blocks[i-1]).GetCoords()
+	}
+
+	entryI := blockFirstMember(blocks[i]).GetCoords()
+	exitJM1 := blockLastMember(blocks[j-1]).GetCoords()
+
+	currentFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, entryI)
+	if err != nil {
+		return 0, err
+	}
+	newFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, exitJM1)
+	if err != nil {
+		return 0, err
+	}
+
+	delta := selector(newFirst) - selector(currentFirst)
+	if j < len(blocks) {
+		afterJ := blockFirstMember(blocks[j]).GetCoords()
+		currentSecond, err := rc.distanceCalc.GetDistance(ctx, exitJM1, afterJ)
+		if err != nil {
+			return 0, err
+		}
+		newSecond, err := rc.distanceCalc.GetDistance(ctx, entryI, afterJ)
+		if err != nil {
+			return 0, err
+		}
+		delta += selector(newSecond) - selector(currentSecond)
+		return delta, nil
+	}
+
+	if includeTerminal {
+		destination := rc.destination(driver)
+		currentTerminal, err := rc.distanceCalc.GetDistance(ctx, exitJM1, destination)
+		if err != nil {
+			return 0, err
+		}
+		newTerminal, err := rc.distanceCalc.GetDistance(ctx, entryI, destination)
+		if err != nil {
+			return 0, err
+		}
+		delta += selector(newTerminal) - selector(currentTerminal)
+	}
+
+	return delta, nil
 }
 
 func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, stops []*models.Participant, i, j int, selector func(*distance.DistanceResult) float64, includeTerminal bool) (float64, error) {

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -32,6 +32,37 @@ type routeMetrics struct {
 	DetourSecs              float64
 }
 
+type edgeScoreCache struct {
+	ctx          context.Context
+	distanceCalc distance.DistanceCalculator
+	selector     func(*distance.DistanceResult) float64
+	values       map[string]float64
+}
+
+func newEdgeScoreCache(ctx context.Context, distanceCalc distance.DistanceCalculator, selector func(*distance.DistanceResult) float64) *edgeScoreCache {
+	return &edgeScoreCache{
+		ctx:          ctx,
+		distanceCalc: distanceCalc,
+		selector:     selector,
+		values:       make(map[string]float64),
+	}
+}
+
+func (c *edgeScoreCache) score(origin, dest models.Coordinates) (float64, error) {
+	key := distance.PairCacheKey(origin, dest)
+	if value, ok := c.values[key]; ok {
+		return value, nil
+	}
+
+	result, err := c.distanceCalc.GetDistance(c.ctx, origin, dest)
+	if err != nil {
+		return 0, err
+	}
+	value := c.selector(result)
+	c.values[key] = value
+	return value, nil
+}
+
 func newRouteContext(distanceCalc distance.DistanceCalculator, instituteCoords models.Coordinates, mode RouteMode) routeContext {
 	if mode == "" {
 		mode = RouteModeDropoff
@@ -302,10 +333,11 @@ func OptimizeRouteOrder(ctx context.Context, distanceCalc distance.DistanceCalcu
 }
 
 func (rc routeContext) twoOptDistance(ctx context.Context, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
+	scoreCache := newEdgeScoreCache(ctx, rc.distanceCalc, func(result *distance.DistanceResult) float64 {
+		return result.DistanceMeters
+	})
 	return twoOptByDelta(stops, func(candidate []*models.Participant, i, j int) (float64, error) {
-		return rc.twoOptDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
-			return result.DistanceMeters
-		}, false)
+		return rc.twoOptDeltaFromScores(driver, candidate, i, j, scoreCache.score, false)
 	})
 }
 
@@ -315,10 +347,11 @@ func (rc routeContext) twoOptRouteDuration(ctx context.Context, driver *models.D
 		return stops, nil
 	}
 
+	scoreCache := newEdgeScoreCache(ctx, rc.distanceCalc, func(result *distance.DistanceResult) float64 {
+		return result.DurationSecs
+	})
 	optimizedBlocks, err := twoOptBlocksByDelta(blocks, func(candidate []*participantGroup, i, j int) (float64, error) {
-		return rc.twoOptBlockDelta(ctx, driver, candidate, i, j, func(result *distance.DistanceResult) float64 {
-			return result.DurationSecs
-		}, true)
+		return rc.twoOptBlockDeltaFromScores(driver, candidate, i, j, scoreCache.score, true)
 	})
 	if err != nil {
 		return nil, err
@@ -350,7 +383,7 @@ func twoOptBlocksByDelta(blocks []*participantGroup, deltaFn func([]*participant
 				if err != nil {
 					return nil, err
 				}
-				if delta < 0 {
+				if delta < -scoreImprovementEpsilon {
 					reverseParticipantGroups(current, i, j-1)
 					improved = true
 				}
@@ -362,6 +395,11 @@ func twoOptBlocksByDelta(blocks []*participantGroup, deltaFn func([]*participant
 }
 
 func (rc routeContext) twoOptBlockDelta(ctx context.Context, driver *models.Driver, blocks []*participantGroup, i, j int, selector func(*distance.DistanceResult) float64, includeTerminal bool) (float64, error) {
+	scoreCache := newEdgeScoreCache(ctx, rc.distanceCalc, selector)
+	return rc.twoOptBlockDeltaFromScores(driver, blocks, i, j, scoreCache.score, includeTerminal)
+}
+
+func (rc routeContext) twoOptBlockDeltaFromScores(driver *models.Driver, blocks []*participantGroup, i, j int, score func(models.Coordinates, models.Coordinates) (float64, error), includeTerminal bool) (float64, error) {
 	if driver == nil {
 		return 0, fmt.Errorf("route driver is required")
 	}
@@ -371,50 +409,69 @@ func (rc routeContext) twoOptBlockDelta(ctx context.Context, driver *models.Driv
 		beforeI = blockLastMember(blocks[prev]).GetCoords()
 	}
 
-	entryI := blockFirstMember(blocks[i]).GetCoords()
-	exitJM1 := blockLastMember(blocks[j-1]).GetCoords()
+	firstI := blockFirstMember(blocks[i]).GetCoords()
+	lastI := blockLastMember(blocks[i]).GetCoords()
+	firstJM1 := blockFirstMember(blocks[j-1]).GetCoords()
+	lastJM1 := blockLastMember(blocks[j-1]).GetCoords()
 
-	currentFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, entryI)
+	currentFirst, err := score(beforeI, firstI)
 	if err != nil {
 		return 0, err
 	}
-	newFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, exitJM1)
+	newFirst, err := score(beforeI, firstJM1)
 	if err != nil {
 		return 0, err
 	}
 
-	delta := selector(newFirst) - selector(currentFirst)
+	delta := newFirst - currentFirst
+	for k := i; k < j-1; k++ {
+		currentEdge, err := score(blockLastMember(blocks[k]).GetCoords(), blockFirstMember(blocks[k+1]).GetCoords())
+		if err != nil {
+			return 0, err
+		}
+		newEdge, err := score(blockLastMember(blocks[k+1]).GetCoords(), blockFirstMember(blocks[k]).GetCoords())
+		if err != nil {
+			return 0, err
+		}
+		delta += newEdge - currentEdge
+	}
+
 	if j < len(blocks) {
 		afterJ := blockFirstMember(blocks[j]).GetCoords()
-		currentSecond, err := rc.distanceCalc.GetDistance(ctx, exitJM1, afterJ)
+		currentSecond, err := score(lastJM1, afterJ)
 		if err != nil {
 			return 0, err
 		}
-		newSecond, err := rc.distanceCalc.GetDistance(ctx, entryI, afterJ)
+		newSecond, err := score(lastI, afterJ)
 		if err != nil {
 			return 0, err
 		}
-		delta += selector(newSecond) - selector(currentSecond)
+		delta += newSecond - currentSecond
 		return delta, nil
 	}
 
 	if includeTerminal {
 		destination := rc.destination(driver)
-		currentTerminal, err := rc.distanceCalc.GetDistance(ctx, exitJM1, destination)
+		currentTerminal, err := score(lastJM1, destination)
 		if err != nil {
 			return 0, err
 		}
-		newTerminal, err := rc.distanceCalc.GetDistance(ctx, entryI, destination)
+		newTerminal, err := score(lastI, destination)
 		if err != nil {
 			return 0, err
 		}
-		delta += selector(newTerminal) - selector(currentTerminal)
+		delta += newTerminal - currentTerminal
 	}
 
 	return delta, nil
 }
 
 func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, stops []*models.Participant, i, j int, selector func(*distance.DistanceResult) float64, includeTerminal bool) (float64, error) {
+	scoreCache := newEdgeScoreCache(ctx, rc.distanceCalc, selector)
+	return rc.twoOptDeltaFromScores(driver, stops, i, j, scoreCache.score, includeTerminal)
+}
+
+func (rc routeContext) twoOptDeltaFromScores(driver *models.Driver, stops []*models.Participant, i, j int, score func(models.Coordinates, models.Coordinates) (float64, error), includeTerminal bool) (float64, error) {
 	if driver == nil {
 		return 0, fmt.Errorf("route driver is required")
 	}
@@ -424,48 +481,60 @@ func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, s
 		beforeI = stops[prev].GetCoords()
 	}
 
-	currentFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, stops[i].GetCoords())
+	currentFirst, err := score(beforeI, stops[i].GetCoords())
 	if err != nil {
 		return 0, err
 	}
-	newFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, stops[j-1].GetCoords())
+	newFirst, err := score(beforeI, stops[j-1].GetCoords())
 	if err != nil {
 		return 0, err
 	}
 
-	delta := selector(newFirst) - selector(currentFirst)
+	delta := newFirst - currentFirst
+	for k := i; k < j-1; k++ {
+		currentEdge, err := score(stops[k].GetCoords(), stops[k+1].GetCoords())
+		if err != nil {
+			return 0, err
+		}
+		newEdge, err := score(stops[k+1].GetCoords(), stops[k].GetCoords())
+		if err != nil {
+			return 0, err
+		}
+		delta += newEdge - currentEdge
+	}
+
 	if j < len(stops) {
 		afterJ := stops[j].GetCoords()
-		currentSecond, err := rc.distanceCalc.GetDistance(ctx, stops[j-1].GetCoords(), afterJ)
+		currentSecond, err := score(stops[j-1].GetCoords(), afterJ)
 		if err != nil {
 			return 0, err
 		}
-		newSecond, err := rc.distanceCalc.GetDistance(ctx, stops[i].GetCoords(), afterJ)
+		newSecond, err := score(stops[i].GetCoords(), afterJ)
 		if err != nil {
 			return 0, err
 		}
-		delta += selector(newSecond) - selector(currentSecond)
+		delta += newSecond - currentSecond
 		return delta, nil
 	}
 
 	if includeTerminal {
 		destination := rc.destination(driver)
-		currentTerminal, err := rc.distanceCalc.GetDistance(ctx, stops[j-1].GetCoords(), destination)
+		currentTerminal, err := score(stops[j-1].GetCoords(), destination)
 		if err != nil {
 			return 0, err
 		}
-		newTerminal, err := rc.distanceCalc.GetDistance(ctx, stops[i].GetCoords(), destination)
+		newTerminal, err := score(stops[i].GetCoords(), destination)
 		if err != nil {
 			return 0, err
 		}
-		delta += selector(newTerminal) - selector(currentTerminal)
+		delta += newTerminal - currentTerminal
 	}
 
 	return delta, nil
 }
 
 func twoOptByDelta(stops []*models.Participant, deltaFn func([]*models.Participant, int, int) (float64, error)) ([]*models.Participant, error) {
-	if len(stops) < 2 {
+	if len(stops) < 3 {
 		return stops, nil
 	}
 
@@ -479,7 +548,7 @@ func twoOptByDelta(stops []*models.Participant, deltaFn func([]*models.Participa
 				if err != nil {
 					return nil, err
 				}
-				if delta < 0 {
+				if delta < -scoreImprovementEpsilon {
 					reverse(current, i, j-1)
 					improved = true
 				}

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -367,8 +367,8 @@ func (rc routeContext) twoOptBlockDelta(ctx context.Context, driver *models.Driv
 	}
 
 	beforeI := rc.origin(driver)
-	if i > 0 {
-		beforeI = blockLastMember(blocks[i-1]).GetCoords()
+	if prev := i - 1; prev >= 0 && prev < len(blocks) {
+		beforeI = blockLastMember(blocks[prev]).GetCoords()
 	}
 
 	entryI := blockFirstMember(blocks[i]).GetCoords()
@@ -420,8 +420,8 @@ func (rc routeContext) twoOptDelta(ctx context.Context, driver *models.Driver, s
 	}
 
 	beforeI := rc.origin(driver)
-	if i > 0 {
-		beforeI = stops[i-1].GetCoords()
+	if prev := i - 1; prev >= 0 && prev < len(stops) {
+		beforeI = stops[prev].GetCoords()
 	}
 
 	currentFirst, err := rc.distanceCalc.GetDistance(ctx, beforeI, stops[i].GetCoords())

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -409,3 +409,33 @@ func TestTwoOptRouteDuration_UsesLocalEdgeDeltaEvaluation(t *testing.T) {
 		t.Fatalf("twoOptRouteDuration() made %d distance calls, want <= 100 for local-edge evaluation", calc.calls)
 	}
 }
+
+func TestTwoOptRouteDuration_SplitHouseholdBlocksPreservesAllParticipants(t *testing.T) {
+	calc := &countingDistanceCalculator{}
+	rc := newRouteContext(calc, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
+	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0}
+	householdLat, householdLng := 1.0, 0.0
+	stops := []*models.Participant{
+		{ID: 1, Name: "H1", Lat: householdLat, Lng: householdLng},
+		{ID: 2, Name: "Other", Lat: 5, Lng: 0},
+		{ID: 3, Name: "H2", Lat: householdLat, Lng: householdLng},
+	}
+
+	optimized, err := rc.twoOptRouteDuration(context.Background(), driver, stops)
+	if err != nil {
+		t.Fatalf("twoOptRouteDuration() error = %v", err)
+	}
+	if len(optimized) != len(stops) {
+		t.Fatalf("optimized stop count = %d, want %d", len(optimized), len(stops))
+	}
+
+	seen := make(map[int64]struct{}, len(stops))
+	for _, stop := range optimized {
+		seen[stop.ID] = struct{}{}
+	}
+	for _, stop := range stops {
+		if _, ok := seen[stop.ID]; !ok {
+			t.Fatalf("optimized route lost participant %d", stop.ID)
+		}
+	}
+}

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
@@ -410,6 +411,72 @@ func TestTwoOptRouteDuration_UsesLocalEdgeDeltaEvaluation(t *testing.T) {
 	}
 }
 
+func TestTwoOptRouteDurationMatchesLegacyFullScoreForDirectedDistances(t *testing.T) {
+	for _, mode := range []RouteMode{RouteModeDropoff, RouteModePickup} {
+		t.Run(string(mode), func(t *testing.T) {
+			calc := newOverrideDistanceAdapter(100)
+			institute := models.Coordinates{Lat: 0, Lng: 0}
+			driver := &models.Driver{ID: 1, Name: "Driver", Lat: 4, Lng: 0}
+			stops := []*models.Participant{
+				{ID: 1, Name: "A", Lat: 1, Lng: 0},
+				{ID: 2, Name: "B", Lat: 2, Lng: 0},
+				{ID: 3, Name: "C", Lat: 3, Lng: 0},
+			}
+			rc := newRouteContext(calc, institute, mode)
+			origin := rc.origin(driver)
+			destination := rc.destination(driver)
+
+			calc.setDuration(origin, stops[0].GetCoords(), 100)
+			calc.setDuration(stops[0].GetCoords(), stops[1].GetCoords(), 10)
+			calc.setDuration(stops[1].GetCoords(), stops[2].GetCoords(), 100)
+			calc.setDuration(stops[2].GetCoords(), destination, 100)
+			calc.setDuration(origin, stops[1].GetCoords(), 10)
+			calc.setDuration(stops[1].GetCoords(), stops[0].GetCoords(), 500)
+			calc.setDuration(stops[0].GetCoords(), stops[2].GetCoords(), 10)
+
+			want, err := legacyTwoOptRouteDurationForTest(context.Background(), rc, driver, stops)
+			if err != nil {
+				t.Fatalf("legacy two-opt error = %v", err)
+			}
+			got, err := rc.twoOptRouteDuration(context.Background(), driver, stops)
+			if err != nil {
+				t.Fatalf("twoOptRouteDuration() error = %v", err)
+			}
+
+			if gotIDs, wantIDs := participantIDs(got), participantIDs(want); gotIDs != wantIDs {
+				t.Fatalf("optimized order = %s, want legacy full-score order %s", gotIDs, wantIDs)
+			}
+			if gotIDs := participantIDs(got); gotIDs != "1,2,3" {
+				t.Fatalf("directed internal edge costs should keep original order, got %s", gotIDs)
+			}
+		})
+	}
+}
+
+func TestTwoOptByDeltaRequiresLegacyImprovementEpsilon(t *testing.T) {
+	stops := []*models.Participant{
+		{ID: 1, Name: "A"},
+		{ID: 2, Name: "B"},
+		{ID: 3, Name: "C"},
+	}
+	calls := 0
+
+	got, err := twoOptByDelta(stops, func(candidate []*models.Participant, i, j int) (float64, error) {
+		calls++
+		if calls == 1 {
+			return -scoreImprovementEpsilon / 2, nil
+		}
+		return 0, nil
+	})
+	if err != nil {
+		t.Fatalf("twoOptByDelta() error = %v", err)
+	}
+
+	if gotIDs := participantIDs(got); gotIDs != "1,2,3" {
+		t.Fatalf("sub-epsilon gain changed order to %s", gotIDs)
+	}
+}
+
 func TestTwoOptBlockDelta_UsesLastMemberOfPreviousBlock(t *testing.T) {
 	rc := newRouteContext(stableDistanceCalculator{}, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
 	driver := &models.Driver{ID: 1, Lat: 10, Lng: 0}
@@ -438,6 +505,55 @@ func TestTwoOptBlockDelta_UsesLastMemberOfPreviousBlock(t *testing.T) {
 	if blockDelta == repDelta {
 		t.Fatalf("block delta %.0f should differ from first-member rep delta %.0f", blockDelta, repDelta)
 	}
+}
+
+func legacyTwoOptRouteDurationForTest(ctx context.Context, rc routeContext, driver *models.Driver, stops []*models.Participant) ([]*models.Participant, error) {
+	blocks := routeHouseholdBlocks(stops)
+	if len(blocks) < 2 {
+		return stops, nil
+	}
+
+	currentBlocks := append([]*participantGroup(nil), blocks...)
+	currentStops := flattenParticipantGroups(currentBlocks)
+	currentScore, err := rc.totalDriveDuration(ctx, driver, currentStops)
+	if err != nil {
+		return nil, err
+	}
+
+	improved := true
+	for improved {
+		improved = false
+		for i := 0; i < len(currentBlocks)-1; i++ {
+			for j := i + 2; j <= len(currentBlocks); j++ {
+				candidateBlocks := append([]*participantGroup(nil), currentBlocks...)
+				reverseParticipantGroups(candidateBlocks, i, j-1)
+				candidateStops := flattenParticipantGroups(candidateBlocks)
+				candidateScore, err := rc.totalDriveDuration(ctx, driver, candidateStops)
+				if err != nil {
+					return nil, err
+				}
+				if candidateScore < currentScore-scoreImprovementEpsilon {
+					currentBlocks = candidateBlocks
+					currentStops = candidateStops
+					currentScore = candidateScore
+					improved = true
+				}
+			}
+		}
+	}
+
+	return currentStops, nil
+}
+
+func participantIDs(stops []*models.Participant) string {
+	ids := ""
+	for i, stop := range stops {
+		if i > 0 {
+			ids += ","
+		}
+		ids += fmt.Sprintf("%d", stop.ID)
+	}
+	return ids
 }
 
 func TestTwoOptRouteDuration_SplitHouseholdBlocksPreservesAllParticipants(t *testing.T) {

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -384,3 +384,28 @@ func TestTwoOptDistance_UsesLocalEdgeDeltaEvaluation(t *testing.T) {
 		t.Fatalf("twoOptDistance() made %d distance calls, want <= 100 for local-edge evaluation", calc.calls)
 	}
 }
+
+func TestTwoOptRouteDuration_UsesLocalEdgeDeltaEvaluation(t *testing.T) {
+	calc := &countingDistanceCalculator{}
+	rc := newRouteContext(calc, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
+	driver := &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0}
+	stops := []*models.Participant{
+		{ID: 1, Name: "P1", Lat: 1, Lng: 0},
+		{ID: 2, Name: "P2", Lat: 2, Lng: 0},
+		{ID: 3, Name: "P3", Lat: 3, Lng: 0},
+		{ID: 4, Name: "P4", Lat: 4, Lng: 0},
+		{ID: 5, Name: "P5", Lat: 5, Lng: 0},
+		{ID: 6, Name: "P6", Lat: 6, Lng: 0},
+	}
+
+	optimized, err := rc.twoOptRouteDuration(context.Background(), driver, stops)
+	if err != nil {
+		t.Fatalf("twoOptRouteDuration() error = %v", err)
+	}
+	if len(optimized) != len(stops) {
+		t.Fatalf("optimized stop count = %d, want %d", len(optimized), len(stops))
+	}
+	if calc.calls > 100 {
+		t.Fatalf("twoOptRouteDuration() made %d distance calls, want <= 100 for local-edge evaluation", calc.calls)
+	}
+}

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -410,6 +410,36 @@ func TestTwoOptRouteDuration_UsesLocalEdgeDeltaEvaluation(t *testing.T) {
 	}
 }
 
+func TestTwoOptBlockDelta_UsesLastMemberOfPreviousBlock(t *testing.T) {
+	rc := newRouteContext(stableDistanceCalculator{}, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)
+	driver := &models.Driver{ID: 1, Lat: 10, Lng: 0}
+	memberFirst := &models.Participant{ID: 1, Lat: 1.000001, Lng: 0}
+	memberLast := &models.Participant{ID: 2, Lat: 1.000002, Lng: 0}
+	blockA := &participantGroup{members: []*models.Participant{memberFirst, memberLast}}
+	blockB := &participantGroup{members: []*models.Participant{{ID: 3, Lat: 3, Lng: 0}}}
+	blockC := &participantGroup{members: []*models.Participant{{ID: 4, Lat: 5, Lng: 0}}}
+	blocks := []*participantGroup{blockA, blockB, blockC}
+
+	blockDelta, err := rc.twoOptBlockDelta(context.Background(), driver, blocks, 1, 3, func(r *distance.DistanceResult) float64 {
+		return r.DurationSecs
+	}, true)
+	if err != nil {
+		t.Fatalf("twoOptBlockDelta() error = %v", err)
+	}
+
+	repStops := []*models.Participant{memberFirst, blockB.members[0], blockC.members[0]}
+	repDelta, err := rc.twoOptDelta(context.Background(), driver, repStops, 1, 3, func(r *distance.DistanceResult) float64 {
+		return r.DurationSecs
+	}, true)
+	if err != nil {
+		t.Fatalf("twoOptDelta() error = %v", err)
+	}
+
+	if blockDelta == repDelta {
+		t.Fatalf("block delta %.0f should differ from first-member rep delta %.0f", blockDelta, repDelta)
+	}
+}
+
 func TestTwoOptRouteDuration_SplitHouseholdBlocksPreservesAllParticipants(t *testing.T) {
 	calc := &countingDistanceCalculator{}
 	rc := newRouteContext(calc, models.Coordinates{Lat: 0, Lng: 0}, RouteModeDropoff)

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -2,10 +2,11 @@ package routing
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -546,14 +547,11 @@ func legacyTwoOptRouteDurationForTest(ctx context.Context, rc routeContext, driv
 }
 
 func participantIDs(stops []*models.Participant) string {
-	ids := ""
+	ids := make([]string, len(stops))
 	for i, stop := range stops {
-		if i > 0 {
-			ids += ","
-		}
-		ids += fmt.Sprintf("%d", stop.ID)
+		ids[i] = strconv.FormatInt(stop.ID, 10)
 	}
-	return ids
+	return strings.Join(ids, ",")
 }
 
 func TestTwoOptRouteDuration_SplitHouseholdBlocksPreservesAllParticipants(t *testing.T) {

--- a/internal/sqlite/distance_cache.go
+++ b/internal/sqlite/distance_cache.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
-
 	"ride-home-router/internal/database"
 	"ride-home-router/internal/models"
+	"strings"
 )
 
 type distanceCacheRepository struct {
@@ -15,7 +14,8 @@ type distanceCacheRepository struct {
 }
 
 func makeCacheKey(origin, dest models.Coordinates) string {
-	return fmt.Sprintf("%.5f,%.5f->%.5f,%.5f",
+	return fmt.Sprintf(
+		"%.5f,%.5f->%.5f,%.5f",
 		models.RoundCoordinate(origin.Lat),
 		models.RoundCoordinate(origin.Lng),
 		models.RoundCoordinate(dest.Lat),
@@ -83,29 +83,31 @@ func (r *distanceCacheRepository) GetBatch(ctx context.Context, pairs []struct{ 
 		chunk := uniquePairs[start:end]
 
 		query, args := buildDistanceCacheBatchQuery(chunk)
-		rows, err := r.store.db.QueryContext(ctx, query, args...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query batch entries: %w", err)
-		}
-
-		for rows.Next() {
-			var entry models.DistanceCacheEntry
-			if err := rows.Scan(
-				&entry.Origin.Lat, &entry.Origin.Lng,
-				&entry.Destination.Lat, &entry.Destination.Lng,
-				&entry.DistanceMeters, &entry.DurationSecs,
-			); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("failed to scan batch entry: %w", err)
+		if err := func() error {
+			rows, err := r.store.db.QueryContext(ctx, query, args...)
+			if err != nil {
+				return fmt.Errorf("failed to query batch entries: %w", err)
 			}
-			key := makeCacheKey(entry.Origin, entry.Destination)
-			result[key] = &entry
-		}
-		if err := rows.Close(); err != nil {
-			return nil, fmt.Errorf("failed to close batch rows: %w", err)
-		}
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("failed to iterate batch entries: %w", err)
+			defer func() { _ = rows.Close() }()
+
+			for rows.Next() {
+				var entry models.DistanceCacheEntry
+				if err := rows.Scan(
+					&entry.Origin.Lat, &entry.Origin.Lng,
+					&entry.Destination.Lat, &entry.Destination.Lng,
+					&entry.DistanceMeters, &entry.DurationSecs,
+				); err != nil {
+					return fmt.Errorf("failed to scan batch entry: %w", err)
+				}
+				key := makeCacheKey(entry.Origin, entry.Destination)
+				result[key] = &entry
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("failed to iterate batch entries: %w", err)
+			}
+			return nil
+		}(); err != nil {
+			return nil, err
 		}
 	}
 
@@ -117,7 +119,8 @@ func buildDistanceCacheBatchQuery(pairs []struct{ Origin, Dest models.Coordinate
 	args := make([]any, 0, len(pairs)*4)
 	for i, pair := range pairs {
 		valuePlaceholders[i] = "(?, ?, ?, ?)"
-		args = append(args,
+		args = append(
+			args,
 			models.RoundCoordinate(pair.Origin.Lat),
 			models.RoundCoordinate(pair.Origin.Lng),
 			models.RoundCoordinate(pair.Dest.Lat),
@@ -153,7 +156,8 @@ func (r *distanceCacheRepository) Set(ctx context.Context, entry *models.Distanc
 	destLat := models.RoundCoordinate(entry.Destination.Lat)
 	destLng := models.RoundCoordinate(entry.Destination.Lng)
 
-	_, err := r.store.db.ExecContext(ctx, query,
+	_, err := r.store.db.ExecContext(
+		ctx, query,
 		originLat, originLng, destLat, destLng,
 		entry.DistanceMeters, entry.DurationSecs,
 	)

--- a/internal/sqlite/distance_cache.go
+++ b/internal/sqlite/distance_cache.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+
 	"ride-home-router/internal/database"
 	"ride-home-router/internal/models"
 )
@@ -51,53 +53,91 @@ func (r *distanceCacheRepository) Get(ctx context.Context, origin, dest models.C
 	return &entry, nil
 }
 
+const distanceCacheBatchSize = 200
+
 func (r *distanceCacheRepository) GetBatch(ctx context.Context, pairs []struct{ Origin, Dest models.Coordinates }) (map[string]*models.DistanceCacheEntry, error) {
 	if len(pairs) == 0 {
 		return make(map[string]*models.DistanceCacheEntry), nil
 	}
 
+	uniquePairs := make([]struct{ Origin, Dest models.Coordinates }, 0, len(pairs))
+	seen := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		key := makeCacheKey(pair.Origin, pair.Dest)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniquePairs = append(uniquePairs, struct{ Origin, Dest models.Coordinates }{
+			Origin: pair.Origin,
+			Dest:   pair.Dest,
+		})
+	}
+
 	r.store.mu.RLock()
 	defer r.store.mu.RUnlock()
 
-	result := make(map[string]*models.DistanceCacheEntry)
+	result := make(map[string]*models.DistanceCacheEntry, len(uniquePairs))
+	for start := 0; start < len(uniquePairs); start += distanceCacheBatchSize {
+		end := min(start+distanceCacheBatchSize, len(uniquePairs))
+		chunk := uniquePairs[start:end]
 
-	// SQLite doesn't support tuple comparisons well, so we query each pair
-	// For large batches, this could be optimized with a temporary table
-	query := `SELECT origin_lat, origin_lng, dest_lat, dest_lng, distance_meters, duration_secs
-	          FROM distance_cache
-	          WHERE origin_lat = ? AND origin_lng = ? AND dest_lat = ? AND dest_lng = ?`
-
-	stmt, err := r.store.db.PrepareContext(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare batch query: %w", err)
-	}
-	defer func() { _ = stmt.Close() }()
-
-	for _, pair := range pairs {
-		originLat := models.RoundCoordinate(pair.Origin.Lat)
-		originLng := models.RoundCoordinate(pair.Origin.Lng)
-		destLat := models.RoundCoordinate(pair.Dest.Lat)
-		destLng := models.RoundCoordinate(pair.Dest.Lng)
-
-		var entry models.DistanceCacheEntry
-		err := stmt.QueryRowContext(ctx, originLat, originLng, destLat, destLng).Scan(
-			&entry.Origin.Lat, &entry.Origin.Lng,
-			&entry.Destination.Lat, &entry.Destination.Lng,
-			&entry.DistanceMeters, &entry.DurationSecs,
-		)
-
-		if err == sql.ErrNoRows {
-			continue
-		}
+		query, args := buildDistanceCacheBatchQuery(chunk)
+		rows, err := r.store.db.QueryContext(ctx, query, args...)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query batch entry: %w", err)
+			return nil, fmt.Errorf("failed to query batch entries: %w", err)
 		}
 
-		key := makeCacheKey(pair.Origin, pair.Dest)
-		result[key] = &entry
+		for rows.Next() {
+			var entry models.DistanceCacheEntry
+			if err := rows.Scan(
+				&entry.Origin.Lat, &entry.Origin.Lng,
+				&entry.Destination.Lat, &entry.Destination.Lng,
+				&entry.DistanceMeters, &entry.DurationSecs,
+			); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("failed to scan batch entry: %w", err)
+			}
+			key := makeCacheKey(entry.Origin, entry.Destination)
+			result[key] = &entry
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close batch rows: %w", err)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("failed to iterate batch entries: %w", err)
+		}
 	}
 
 	return result, nil
+}
+
+func buildDistanceCacheBatchQuery(pairs []struct{ Origin, Dest models.Coordinates }) (string, []any) {
+	valuePlaceholders := make([]string, len(pairs))
+	args := make([]any, 0, len(pairs)*4)
+	for i, pair := range pairs {
+		valuePlaceholders[i] = "(?, ?, ?, ?)"
+		args = append(args,
+			models.RoundCoordinate(pair.Origin.Lat),
+			models.RoundCoordinate(pair.Origin.Lng),
+			models.RoundCoordinate(pair.Dest.Lat),
+			models.RoundCoordinate(pair.Dest.Lng),
+		)
+	}
+
+	query := fmt.Sprintf(`WITH requested(origin_lat, origin_lng, dest_lat, dest_lng) AS (
+		VALUES %s
+	)
+	SELECT dc.origin_lat, dc.origin_lng, dc.dest_lat, dc.dest_lng,
+	       dc.distance_meters, dc.duration_secs
+	FROM requested r
+	JOIN distance_cache dc
+	  ON dc.origin_lat = r.origin_lat
+	 AND dc.origin_lng = r.origin_lng
+	 AND dc.dest_lat = r.dest_lat
+	 AND dc.dest_lng = r.dest_lng`, strings.Join(valuePlaceholders, ", "))
+
+	return query, args
 }
 
 func (r *distanceCacheRepository) Set(ctx context.Context, entry *models.DistanceCacheEntry) error {

--- a/internal/sqlite/distance_cache_test.go
+++ b/internal/sqlite/distance_cache_test.go
@@ -3,9 +3,8 @@ package sqlite
 import (
 	"context"
 	"path/filepath"
-	"testing"
-
 	"ride-home-router/internal/models"
+	"testing"
 )
 
 func TestDistanceCacheGetBatch_HitsMissesAndDuplicates(t *testing.T) {

--- a/internal/sqlite/distance_cache_test.go
+++ b/internal/sqlite/distance_cache_test.go
@@ -1,0 +1,92 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"ride-home-router/internal/models"
+)
+
+func TestDistanceCacheGetBatch_HitsMissesAndDuplicates(t *testing.T) {
+	store, err := New(filepath.Join(t.TempDir(), "distance-cache.db"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	origin := models.Coordinates{Lat: 40.12345, Lng: -74.12345}
+	destHit := models.Coordinates{Lat: 40.23456, Lng: -74.23456}
+	destMiss := models.Coordinates{Lat: 40.34567, Lng: -74.34567}
+
+	if err := store.DistanceCache().Set(ctx, &models.DistanceCacheEntry{
+		Origin:         origin,
+		Destination:    destHit,
+		DistanceMeters: 1500,
+		DurationSecs:   180,
+	}); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	pairs := []struct{ Origin, Dest models.Coordinates }{
+		{Origin: origin, Dest: destHit},
+		{Origin: origin, Dest: destHit},
+		{Origin: origin, Dest: destMiss},
+	}
+
+	result, err := store.DistanceCache().GetBatch(ctx, pairs)
+	if err != nil {
+		t.Fatalf("GetBatch() error = %v", err)
+	}
+
+	hitKey := makeCacheKey(origin, destHit)
+	missKey := makeCacheKey(origin, destMiss)
+	if result[hitKey] == nil {
+		t.Fatalf("expected cache hit for key %s", hitKey)
+	}
+	if result[missKey] != nil {
+		t.Fatalf("did not expect cache entry for miss key %s", missKey)
+	}
+	if result[hitKey].DistanceMeters != 1500 {
+		t.Fatalf("hit distance = %.0f, want 1500", result[hitKey].DistanceMeters)
+	}
+}
+
+func TestDistanceCacheGetBatch_NoHits(t *testing.T) {
+	store, err := New(filepath.Join(t.TempDir(), "distance-cache-miss.db"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	origin := models.Coordinates{Lat: 40.11111, Lng: -74.11111}
+	dest := models.Coordinates{Lat: 40.22222, Lng: -74.22222}
+	pairs := []struct{ Origin, Dest models.Coordinates }{
+		{Origin: origin, Dest: dest},
+	}
+
+	result, err := store.DistanceCache().GetBatch(context.Background(), pairs)
+	if err != nil {
+		t.Fatalf("GetBatch() error = %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected empty result map, got %d entries", len(result))
+	}
+}
+
+func TestDistanceCacheGetBatch_EmptyInput(t *testing.T) {
+	store, err := New(filepath.Join(t.TempDir(), "distance-cache-empty.db"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	result, err := store.DistanceCache().GetBatch(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetBatch() error = %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected empty result map, got %d entries", len(result))
+	}
+}

--- a/internal/testutil/mock_distance.go
+++ b/internal/testutil/mock_distance.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-
 	"ride-home-router/internal/database"
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"

--- a/internal/testutil/mock_distance.go
+++ b/internal/testutil/mock_distance.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
+
 	"ride-home-router/internal/database"
+	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
 )
 
@@ -119,6 +121,11 @@ func (m *MockDistanceCalculator) GetDistancesFromPoint(ctx context.Context, orig
 
 // PrewarmCache is a no-op for the mock
 func (m *MockDistanceCalculator) PrewarmCache(ctx context.Context, points []models.Coordinates) error {
+	return nil
+}
+
+// PrewarmPairs is a no-op for the mock
+func (m *MockDistanceCalculator) PrewarmPairs(ctx context.Context, pairs []distance.DistancePair) error {
 	return nil
 }
 

--- a/web/static/js/route-copy.js
+++ b/web/static/js/route-copy.js
@@ -188,6 +188,7 @@ async function flushQueuedParticipantMoves() {
             movesToRetry = null;
         }
     } catch (err) {
+        movesToRetry = null;
         console.error('Failed to move participant:', err);
         showRouteError('Failed to move participant: ' + err.message);
     } finally {

--- a/web/static/js/route-copy.js
+++ b/web/static/js/route-copy.js
@@ -127,6 +127,8 @@ function getSessionId() {
 let pendingMoveParticipantTimeout = null;
 let pendingMoveParticipantQueue = [];
 let isMoveParticipantFlushInProgress = false;
+let moveParticipantFlushPromise = null;
+const MOVE_PARTICIPANT_BATCH_LIMIT = 64;
 
 function scheduleMoveParticipantFlush() {
     if (pendingMoveParticipantTimeout) {
@@ -136,20 +138,58 @@ function scheduleMoveParticipantFlush() {
 }
 
 async function flushQueuedParticipantMoves() {
-    pendingMoveParticipantTimeout = null;
+    if (pendingMoveParticipantTimeout) {
+        clearTimeout(pendingMoveParticipantTimeout);
+        pendingMoveParticipantTimeout = null;
+    }
+
+    if (moveParticipantFlushPromise) {
+        return moveParticipantFlushPromise;
+    }
+
+    moveParticipantFlushPromise = runQueuedParticipantMoves();
+    try {
+        return await moveParticipantFlushPromise;
+    } finally {
+        moveParticipantFlushPromise = null;
+    }
+}
+
+function takeNextParticipantMoveBatch() {
+    const firstMove = pendingMoveParticipantQueue[0];
+    const sessionId = firstMove?.session_id;
+    if (!sessionId) {
+        pendingMoveParticipantQueue.shift();
+        return { sessionId: null, moves: [] };
+    }
+
+    const moves = [];
+    while (
+        pendingMoveParticipantQueue.length > 0 &&
+        moves.length < MOVE_PARTICIPANT_BATCH_LIMIT &&
+        pendingMoveParticipantQueue[0]?.session_id === sessionId
+    ) {
+        moves.push(pendingMoveParticipantQueue.shift());
+    }
+
+    return { sessionId, moves };
+}
+
+async function runQueuedParticipantMoves() {
     if (isMoveParticipantFlushInProgress) {
-        return;
+        return true;
     }
 
     isMoveParticipantFlushInProgress = true;
     let movesToRetry = null;
+    let flushSucceeded = true;
     try {
         while (pendingMoveParticipantQueue.length > 0) {
-            const moves = pendingMoveParticipantQueue.splice(0, pendingMoveParticipantQueue.length);
+            const { sessionId, moves } = takeNextParticipantMoveBatch();
             movesToRetry = moves;
-            const sessionId = moves[0]?.session_id;
-            if (!sessionId) {
+            if (!sessionId || moves.length === 0) {
                 movesToRetry = null;
+                flushSucceeded = false;
                 break;
             }
 
@@ -179,16 +219,20 @@ async function flushQueuedParticipantMoves() {
             if (routeResults) {
                 if (!response.ok) {
                     movesToRetry = null;
+                    flushSucceeded = false;
                     showRouteError(html);
                     break;
                 }
-                routeResults.innerHTML = html;
-                populateStopEtas();
+                if (getSessionId() === sessionId) {
+                    routeResults.innerHTML = html;
+                    populateStopEtas();
+                }
             }
             movesToRetry = null;
         }
     } catch (err) {
         movesToRetry = null;
+        flushSucceeded = false;
         console.error('Failed to move participant:', err);
         showRouteError('Failed to move participant: ' + err.message);
     } finally {
@@ -200,6 +244,8 @@ async function flushQueuedParticipantMoves() {
             scheduleMoveParticipantFlush();
         }
     }
+
+    return flushSucceeded && pendingMoveParticipantQueue.length === 0;
 }
 
 async function moveParticipant(participantId, fromRouteIndex, toRouteIndex) {
@@ -220,6 +266,40 @@ async function moveParticipant(participantId, fromRouteIndex, toRouteIndex) {
     });
     scheduleMoveParticipantFlush();
 }
+
+function hasQueuedParticipantMoves() {
+    return pendingMoveParticipantQueue.length > 0 || Boolean(pendingMoveParticipantTimeout) || isMoveParticipantFlushInProgress;
+}
+
+function isSaveEventForm(form) {
+    return form instanceof HTMLFormElement && form.getAttribute('hx-post') === '/api/v1/events';
+}
+
+document.addEventListener('submit', async function(evt) {
+    const form = evt.target;
+    if (!isSaveEventForm(form) || !hasQueuedParticipantMoves() || form.dataset.pendingMoveFlush === 'true') {
+        return;
+    }
+
+    evt.preventDefault();
+    evt.stopImmediatePropagation();
+    form.dataset.pendingMoveFlush = 'true';
+
+    const flushed = await flushQueuedParticipantMoves();
+    delete form.dataset.pendingMoveFlush;
+    if (!flushed) {
+        return;
+    }
+
+    if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit(evt.submitter || undefined);
+    } else {
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        if (form.dispatchEvent(submitEvent)) {
+            form.submit();
+        }
+    }
+}, true);
 
 /**
  * Swaps drivers between two routes

--- a/web/static/js/route-copy.js
+++ b/web/static/js/route-copy.js
@@ -144,7 +144,24 @@ async function flushQueuedParticipantMoves() {
     isMoveParticipantFlushInProgress = true;
     try {
         while (pendingMoveParticipantQueue.length > 0) {
-            const payload = pendingMoveParticipantQueue.shift();
+            const moves = pendingMoveParticipantQueue.splice(0, pendingMoveParticipantQueue.length);
+            const sessionId = moves[0]?.session_id;
+            if (!sessionId) {
+                break;
+            }
+
+            const payload = moves.length === 1
+                ? moves[0]
+                : {
+                    session_id: sessionId,
+                    moves: moves.map(move => ({
+                        participant_id: move.participant_id,
+                        from_route_index: move.from_route_index,
+                        to_route_index: move.to_route_index,
+                        insert_at_position: move.insert_at_position
+                    }))
+                };
+
             const response = await fetch('/api/v1/routes/edit/move-participant', {
                 method: 'POST',
                 headers: {

--- a/web/static/js/route-copy.js
+++ b/web/static/js/route-copy.js
@@ -142,11 +142,14 @@ async function flushQueuedParticipantMoves() {
     }
 
     isMoveParticipantFlushInProgress = true;
+    let movesToRetry = null;
     try {
         while (pendingMoveParticipantQueue.length > 0) {
             const moves = pendingMoveParticipantQueue.splice(0, pendingMoveParticipantQueue.length);
+            movesToRetry = moves;
             const sessionId = moves[0]?.session_id;
             if (!sessionId) {
+                movesToRetry = null;
                 break;
             }
 
@@ -175,18 +178,21 @@ async function flushQueuedParticipantMoves() {
             const routeResults = document.getElementById('results-section');
             if (routeResults) {
                 if (!response.ok) {
-                    // Show error inline above routes
                     showRouteError(html);
                     break;
                 }
                 routeResults.innerHTML = html;
                 populateStopEtas();
             }
+            movesToRetry = null;
         }
     } catch (err) {
         console.error('Failed to move participant:', err);
         showRouteError('Failed to move participant: ' + err.message);
     } finally {
+        if (movesToRetry) {
+            pendingMoveParticipantQueue.unshift(...movesToRetry);
+        }
         isMoveParticipantFlushInProgress = false;
         if (pendingMoveParticipantQueue.length > 0 && !pendingMoveParticipantTimeout) {
             scheduleMoveParticipantFlush();

--- a/web/static/js/route-copy.js
+++ b/web/static/js/route-copy.js
@@ -178,6 +178,7 @@ async function flushQueuedParticipantMoves() {
             const routeResults = document.getElementById('results-section');
             if (routeResults) {
                 if (!response.ok) {
+                    movesToRetry = null;
                     showRouteError(html);
                     break;
                 }

--- a/web/templates/partials/route_results.html
+++ b/web/templates/partials/route_results.html
@@ -255,8 +255,10 @@
         <form {{if not .IsOutOfBalance}}hx-post="/api/v1/events"{{end}}
               hx-target="#save-result"
               hx-indicator="#save-loading">
-            <input type="hidden" name="routes_json" value="{{toJSON .RoutingPayload}}">
             <input type="hidden" name="session_id" value="{{.SessionID}}">
+            {{if not .SessionID}}
+            <input type="hidden" name="routes_json" value="{{toJSON .RoutingPayload}}">
+            {{end}}
 
             <div class="form-group">
                 <label class="form-label">Event Date</label>


### PR DESCRIPTION
### Problem
Route generation and route editing were spending extra time on broad distance prewarm, per-pair cache lookups, full-route recomputation in optimization loops, and per-move request chatter.

### Changes
- Add routing pair-based prewarm set generation with provider fallback to full matrix prewarm.
- Add `DistancePair` + `PairPrewarmedDistanceCalculator`; wire Google/OSRM to prewarm only required directed pairs.
- Rewrite SQLite distance cache batch lookup to chunked CTE + VALUES SQL.
- Switch route-duration 2-opt and min-max candidate scoring to delta evaluation patterns to cut redundant distance calls.
- Cache min-max route durations and optimize only affected routes.
- Add batched participant move API payload support and frontend debounce queueing.
- Load session-based save routes from server state and omit `routes_json` for session save forms.
- Add/expand regression tests for new behavior and performance-critical paths.

### Decisions
- Kept all existing route quality logic and session validation contracts intact where possible.
- Kept legacy single-move payload format supported for compatibility alongside new batched request shape.

### Testing
- `go test ./...`
- `go test ./internal/routing -run 'Test.*TwoOpt|Test.*MinMax|Test.*Prewarm|Test.*Move' -count=1`
- `go test ./internal/distance ./internal/sqlite ./internal/handlers -count=1`
- `go test ./internal/routing -bench BenchmarkCollectRoutingPrewarmPairs -run '^$'`

<details>
<summary>Agent Context</summary>

- Targeted file set: `internal/routing`, `internal/distance`, `internal/sqlite`, `internal/handlers`, `web/static/js/route-copy.js`, `web/templates/partials/route_results.html`.
- Spec used: `_scratch/performance.md` (cursor-style implementation target).
- Additional validation performed against session save and move-batch behavior with request/response tests.

</details>
