### PR TITLE
refactor(no-ticket): deepen template rendering

### DIFF
--- a/internal/handlers/activity_locations_org_vehicles_test.go
+++ b/internal/handlers/activity_locations_org_vehicles_test.go
@@ -40,8 +40,8 @@ func newTestManagementHandler(t *testing.T) (*Handler, *sqlite.Store) {
 	}
 
 	handler := &Handler{
-		DB:        store,
-		Templates: loadEmbeddedTemplates(t),
+		DB:       store,
+		Renderer: loadEmbeddedTemplates(t),
 		Geocoder: stubGeocoder{
 			result: &geocoding.GeocodingResult{
 				Coords: models.Coordinates{Lat: 41.25, Lng: -72.75},

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -13,10 +13,12 @@ import (
 	"path/filepath"
 	"ride-home-router/internal/models"
 	"ride-home-router/internal/sqlite"
+	"ride-home-router/internal/templates"
 	"ride-home-router/web"
 	"strconv"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -671,7 +673,7 @@ func newTestEventHandler(t *testing.T, withLegacyHistory bool) (*Handler, *sqlit
 
 	handler := &Handler{
 		DB:           store,
-		Templates:    newTestTemplates(t),
+		Renderer:     newTestTemplates(t),
 		RouteSession: NewRouteSessionStore(),
 	}
 
@@ -685,18 +687,26 @@ func newTestEventHandler(t *testing.T, withLegacyHistory bool) (*Handler, *sqlit
 	return handler, store
 }
 
-func newTestTemplates(t *testing.T) *TemplateSet {
+func newTestTemplates(t *testing.T) *templates.Renderer {
 	t.Helper()
 
-	base, err := template.New("test").Parse(testEventTemplates)
+	templatesFS := fstest.MapFS{
+		"templates/layout.html":             {Data: []byte(`{{template "content" .}}`)},
+		"templates/partials/events.html":    {Data: []byte(testEventTemplates)},
+		"templates/index.html":              {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/participants.html":       {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/drivers.html":            {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/labels.html":             {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/activity_locations.html": {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/vans.html":               {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/settings.html":           {Data: []byte(`{{define "content"}}test{{end}}`)},
+		"templates/history.html":            {Data: []byte(`{{define "content"}}test{{end}}`)},
+	}
+	renderer, err := templates.New(templatesFS)
 	if err != nil {
-		t.Fatalf("parse test templates: %v", err)
+		t.Fatalf("load test templates: %v", err)
 	}
-
-	return &TemplateSet{
-		Base:  base,
-		Pages: map[string]string{},
-	}
+	return renderer
 }
 
 func createTestEvent(t *testing.T, store *sqlite.Store, eventDate, notes string) *models.Event {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"html/template"
 	"log"
 	"net/http"
 	"ride-home-router/internal/database"
@@ -13,14 +12,8 @@ import (
 	"ride-home-router/internal/geocoding"
 	"ride-home-router/internal/httpx"
 	"ride-home-router/internal/routing"
+	"ride-home-router/internal/templates"
 )
-
-// TemplateSet holds base templates and page templates separately
-type TemplateSet struct {
-	Base  *template.Template
-	Pages map[string]string
-	Funcs template.FuncMap
-}
 
 // Handler provides common handler utilities and dependencies
 type Handler struct {
@@ -28,7 +21,7 @@ type Handler struct {
 	Geocoder     geocoding.Geocoder
 	DistanceCalc distance.DistanceCalculator
 	Router       routing.Router
-	Templates    *TemplateSet
+	Renderer     *templates.Renderer
 	RouteSession *RouteSessionStore
 }
 
@@ -210,35 +203,8 @@ func (h *Handler) checkNotFound(err error) bool {
 func (h *Handler) renderTemplate(w http.ResponseWriter, name string, data any) {
 	w.Header().Set(httpx.HeaderContentType, httpx.MediaTypeHTML)
 
-	// Always clone to avoid "cannot Clone after executed" error
-	tmpl, err := h.Templates.Base.Clone()
-	if err != nil {
-		log.Printf("[ERROR] Template clone error: template=%s err=%v", name, err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
-	// Check if this is a page template (has content in Pages map)
-	if pageContent, ok := h.Templates.Pages[name]; ok {
-		// Parse the page template (which defines "content")
-		_, err = tmpl.New(name).Parse(pageContent)
-		if err != nil {
-			log.Printf("[ERROR] Template parse error: template=%s err=%v", name, err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			return
-		}
-
-		// Execute layout.html (which includes {{template "content" .}})
-		if err := tmpl.ExecuteTemplate(w, "layout.html", data); err != nil {
-			log.Printf("[ERROR] Template execute error: template=%s err=%v", name, err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		}
-		return
-	}
-
-	// For partials, execute from the cloned template
-	if err := tmpl.ExecuteTemplate(w, name, data); err != nil {
-		log.Printf("[ERROR] Template partial error: template=%s err=%v", name, err)
+	if err := h.Renderer.Render(w, name, data); err != nil {
+		log.Printf("[ERROR] Template render error: template=%s err=%v", name, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 }

--- a/internal/handlers/pages_test.go
+++ b/internal/handlers/pages_test.go
@@ -350,7 +350,7 @@ func newTestPageHandler(t *testing.T) (*Handler, *sqlite.Store) {
 
 	handler := &Handler{
 		DB:           store,
-		Templates:    loadEmbeddedTemplates(t),
+		Renderer:     loadEmbeddedTemplates(t),
 		RouteSession: NewRouteSessionStore(),
 	}
 

--- a/internal/handlers/routes_test.go
+++ b/internal/handlers/routes_test.go
@@ -1175,7 +1175,7 @@ func newTestRouteHandler(t *testing.T) (*Handler, *sqlite.Store) {
 
 	handler := &Handler{
 		DB:           store,
-		Templates:    loadEmbeddedTemplates(t),
+		Renderer:     loadEmbeddedTemplates(t),
 		RouteSession: NewRouteSessionStore(),
 	}
 

--- a/internal/handlers/template_helpers_test.go
+++ b/internal/handlers/template_helpers_test.go
@@ -1,57 +1,17 @@
 package handlers
 
 import (
-	"html/template"
-	"io/fs"
-	"ride-home-router/internal/templateutil"
+	"ride-home-router/internal/templates"
 	"ride-home-router/web"
-	"strings"
 	"testing"
 )
 
-func loadEmbeddedTemplates(t *testing.T) *TemplateSet {
+func loadEmbeddedTemplates(t *testing.T) *templates.Renderer {
 	t.Helper()
 
-	funcs := templateutil.FuncMap()
-
-	base := template.New("").Funcs(funcs)
-
-	layoutContent, err := fs.ReadFile(web.Templates, "templates/layout.html")
+	renderer, err := templates.New(web.Templates)
 	if err != nil {
-		t.Fatalf("read layout template: %v", err)
+		t.Fatalf("load embedded templates: %v", err)
 	}
-	if _, err := base.New("layout.html").Parse(string(layoutContent)); err != nil {
-		t.Fatalf("parse layout template: %v", err)
-	}
-
-	partialFiles, err := fs.Glob(web.Templates, "templates/partials/*.html")
-	if err != nil {
-		t.Fatalf("glob partial templates: %v", err)
-	}
-	for _, file := range partialFiles {
-		content, err := fs.ReadFile(web.Templates, file)
-		if err != nil {
-			t.Fatalf("read partial template %s: %v", file, err)
-		}
-		name := strings.TrimPrefix(file, "templates/partials/")
-		if _, err := base.New(name).Parse(string(content)); err != nil {
-			t.Fatalf("parse partial template %s: %v", file, err)
-		}
-	}
-
-	pages := make(map[string]string)
-	pageFiles := []string{"index.html", "participants.html", "drivers.html", "labels.html", "activity_locations.html", "vans.html", "settings.html", "history.html"}
-	for _, name := range pageFiles {
-		content, err := fs.ReadFile(web.Templates, "templates/"+name)
-		if err != nil {
-			t.Fatalf("read page template %s: %v", name, err)
-		}
-		pages[name] = string(content)
-	}
-
-	return &TemplateSet{
-		Base:  base,
-		Pages: pages,
-		Funcs: funcs,
-	}
+	return renderer
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io/fs"
 	"log"
 	"net"
@@ -18,7 +17,7 @@ import (
 	"ride-home-router/internal/logutil"
 	"ride-home-router/internal/routing"
 	"ride-home-router/internal/sqlite"
-	"ride-home-router/internal/templateutil"
+	"ride-home-router/internal/templates"
 	"ride-home-router/web"
 	"strings"
 	"time"
@@ -74,7 +73,7 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	log.Printf("Loading templates...")
-	templates, err := loadTemplates(web.Templates)
+	renderer, err := templates.New(web.Templates)
 	if err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to load templates: %w", err)
@@ -96,7 +95,7 @@ func New(cfg Config) (*Server, error) {
 		Geocoder:     geocoder,
 		DistanceCalc: distanceCalc,
 		Router:       router,
-		Templates:    templates,
+		Renderer:     renderer,
 		RouteSession: routeSession,
 	}
 
@@ -154,58 +153,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return err
 	}
 	return s.db.Close()
-}
-
-// loadTemplates loads all templates from the embedded filesystem
-func loadTemplates(templatesFS fs.FS) (*handlers.TemplateSet, error) {
-	funcs := templateutil.FuncMap()
-	base := template.New("").Funcs(funcs)
-
-	// Load layout.html
-	layoutContent, err := fs.ReadFile(templatesFS, "templates/layout.html")
-	if err != nil {
-		return nil, fmt.Errorf("failed to read layout: %w", err)
-	}
-	_, err = base.New("layout.html").Parse(string(layoutContent))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse layout: %w", err)
-	}
-
-	// Load partials
-	partialFiles, err := fs.Glob(templatesFS, "templates/partials/*.html")
-	if err != nil {
-		return nil, fmt.Errorf("failed to glob partials: %w", err)
-	}
-
-	for _, file := range partialFiles {
-		content, err := fs.ReadFile(templatesFS, file)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read partial %s: %w", file, err)
-		}
-		// Extract just the filename from the path
-		name := file[len("templates/partials/"):]
-		_, err = base.New(name).Parse(string(content))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse partial %s: %w", file, err)
-		}
-	}
-
-	// Load page templates as strings (don't parse into base)
-	pages := make(map[string]string)
-	pageFiles := []string{"index.html", "participants.html", "drivers.html", "labels.html", "activity_locations.html", "vans.html", "settings.html", "history.html"}
-	for _, name := range pageFiles {
-		content, err := fs.ReadFile(templatesFS, "templates/"+name)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read page %s: %w", name, err)
-		}
-		pages[name] = string(content)
-	}
-
-	return &handlers.TemplateSet{
-		Base:  base,
-		Pages: pages,
-		Funcs: funcs,
-	}, nil
 }
 
 func writeMethodNotAllowed(w http.ResponseWriter) {

--- a/internal/templates/renderer.go
+++ b/internal/templates/renderer.go
@@ -1,0 +1,84 @@
+package templates
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"io/fs"
+	"path"
+	"ride-home-router/internal/templateutil"
+)
+
+var pageNames = []string{
+	"index.html",
+	"participants.html",
+	"drivers.html",
+	"labels.html",
+	"activity_locations.html",
+	"vans.html",
+	"settings.html",
+	"history.html",
+}
+
+// Renderer loads and executes the application's page and partial templates.
+type Renderer struct {
+	partials *template.Template
+	pages    map[string]*template.Template
+}
+
+// New loads and precompiles all required templates from templatesFS.
+func New(templatesFS fs.FS) (*Renderer, error) {
+	base := template.New("").Funcs(templateutil.FuncMap())
+
+	layout, err := fs.ReadFile(templatesFS, "templates/layout.html")
+	if err != nil {
+		return nil, fmt.Errorf("read layout: %w", err)
+	}
+	if _, err := base.New("layout.html").Parse(string(layout)); err != nil {
+		return nil, fmt.Errorf("parse layout: %w", err)
+	}
+
+	partialFiles, err := fs.Glob(templatesFS, "templates/partials/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("glob partials: %w", err)
+	}
+	for _, file := range partialFiles {
+		content, err := fs.ReadFile(templatesFS, file)
+		if err != nil {
+			return nil, fmt.Errorf("read partial %s: %w", file, err)
+		}
+		if _, err := base.New(path.Base(file)).Parse(string(content)); err != nil {
+			return nil, fmt.Errorf("parse partial %s: %w", file, err)
+		}
+	}
+
+	renderer := &Renderer{
+		partials: base,
+		pages:    make(map[string]*template.Template, len(pageNames)),
+	}
+	for _, name := range pageNames {
+		content, err := fs.ReadFile(templatesFS, "templates/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("read page %s: %w", name, err)
+		}
+
+		page, err := base.Clone()
+		if err != nil {
+			return nil, fmt.Errorf("clone templates for page %s: %w", name, err)
+		}
+		if _, err := page.New(name).Parse(string(content)); err != nil {
+			return nil, fmt.Errorf("parse page %s: %w", name, err)
+		}
+		renderer.pages[name] = page
+	}
+
+	return renderer, nil
+}
+
+// Render executes name with data into w.
+func (r *Renderer) Render(w io.Writer, name string, data any) error {
+	if page, ok := r.pages[name]; ok {
+		return page.ExecuteTemplate(w, "layout.html", data)
+	}
+	return r.partials.ExecuteTemplate(w, name, data)
+}

--- a/internal/templates/renderer_test.go
+++ b/internal/templates/renderer_test.go
@@ -1,0 +1,158 @@
+package templates_test
+
+import (
+	"bytes"
+	"fmt"
+	"ride-home-router/internal/templates"
+	"strings"
+	"sync"
+	"testing"
+	"testing/fstest"
+)
+
+var pageNames = []string{
+	"index.html",
+	"participants.html",
+	"drivers.html",
+	"labels.html",
+	"activity_locations.html",
+	"vans.html",
+	"settings.html",
+	"history.html",
+}
+
+func validTemplatesFS() fstest.MapFS {
+	templatesFS := fstest.MapFS{
+		"templates/layout.html":                       {Data: []byte(`<header>Ride Home Router</header><main>{{template "content" .}}</main>`)},
+		"templates/partials/badge.html":               {Data: []byte(`{{define "badge"}}<strong>{{.}}</strong>{{end}}`)},
+		"templates/partials/address_suggestions.html": {Data: []byte(`address: {{.}}`)},
+	}
+	for _, name := range pageNames {
+		templatesFS["templates/"+name] = &fstest.MapFile{Data: []byte(`{{define "content"}}page{{end}}`)}
+	}
+	templatesFS["templates/index.html"] = &fstest.MapFile{Data: []byte(`{{define "content"}}Welcome, {{template "badge" .}}{{end}}`)}
+	return templatesFS
+}
+
+func TestRendererRendersPageWithLayoutAndPartials(t *testing.T) {
+	renderer, err := templates.New(validTemplatesFS())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	var output bytes.Buffer
+	if err := renderer.Render(&output, "index.html", "Ar"); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	const want = `<header>Ride Home Router</header><main>Welcome, <strong>Ar</strong></main>`
+	if got := output.String(); got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRendererRendersPartialsWithoutLayout(t *testing.T) {
+	renderer, err := templates.New(validTemplatesFS())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "badge", want: "<strong>Ar</strong>"},
+		{name: "address_suggestions.html", want: "address: Ar"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := renderer.Render(&output, test.name, "Ar"); err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+			if got := output.String(); got != test.want {
+				t.Fatalf("Render() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNewFailsForMissingOrInvalidRequiredTemplates(t *testing.T) {
+	t.Run("missing layout", func(t *testing.T) {
+		templatesFS := validTemplatesFS()
+		delete(templatesFS, "templates/layout.html")
+
+		if _, err := templates.New(templatesFS); err == nil {
+			t.Fatal("New() error = nil, want missing layout error")
+		}
+	})
+
+	t.Run("invalid page", func(t *testing.T) {
+		templatesFS := validTemplatesFS()
+		templatesFS["templates/index.html"] = &fstest.MapFile{Data: []byte(`{{define "content"}}`)}
+
+		if _, err := templates.New(templatesFS); err == nil {
+			t.Fatal("New() error = nil, want invalid page error")
+		}
+	})
+}
+
+func TestRendererReturnsErrorForUnknownName(t *testing.T) {
+	renderer, err := templates.New(validTemplatesFS())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	var output bytes.Buffer
+	err = renderer.Render(&output, "unknown", nil)
+	if err == nil {
+		t.Fatal("Render() error = nil, want unknown template error")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("Render() error = %q, want template name", err)
+	}
+}
+
+func TestRendererSupportsConcurrentPageAndPartialRendering(t *testing.T) {
+	renderer, err := templates.New(validTemplatesFS())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	const renders = 50
+	var wg sync.WaitGroup
+	errors := make(chan error, renders*2)
+	for range renders {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			var output bytes.Buffer
+			if err := renderer.Render(&output, "index.html", "Ar"); err != nil {
+				errors <- err
+				return
+			}
+			const want = `<header>Ride Home Router</header><main>Welcome, <strong>Ar</strong></main>`
+			if got := output.String(); got != want {
+				errors <- fmt.Errorf("Render() = %q, want %q", got, want)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			var output bytes.Buffer
+			if err := renderer.Render(&output, "address_suggestions.html", "Ar"); err != nil {
+				errors <- err
+				return
+			}
+			const want = "address: Ar"
+			if got := output.String(); got != want {
+				errors <- fmt.Errorf("Render() = %q, want %q", got, want)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
### Problem

Template rendering behavior was split across `internal/server` and `internal/handlers`. The server loaded raw page strings into an exposed `TemplateSet`, handlers cloned and parsed templates on every request, and tests duplicated the production loader.

### Changes

- Added a concrete `internal/templates.Renderer` that owns loading, page composition, partial lookup, precompilation, and concurrent reuse.
- Precompiled the existing eight page templates during construction while preserving direct rendering for defined and filename-style partials.
- Replaced `handlers.TemplateSet` and `server.loadTemplates` with the renderer.
- Reused the production constructor in embedded-template tests and moved focused event fixtures to `fstest.MapFS`.

### Decisions

- Kept HTTP concerns in handlers: content type and render-error-to-500 behavior are unchanged.
- Kept page detection as explicit membership in the existing page set so filename-style partials such as `address_suggestions.html` remain partials.
- Used the concrete renderer directly; no single-adapter interface or options surface was added.
- Left template helper behavior and template markup unchanged.

### Testing

- `go test -race ./...`
- `golangci-lint run`
- `git diff --check`

<details>
<summary>Agent Context</summary>

This no-ticket refactor was selected from an architecture review as a module-deepening opportunity. Before the change, `server.loadTemplates` owned filesystem reads and initial parsing, `handlers.TemplateSet` exposed `Base`, `Pages`, and an unused `Funcs` field, and `Handler.renderTemplate` owned per-request clone/parse/execute behavior. Tests in `template_helpers_test.go` duplicated the loader because there was no production rendering constructor available at the real seam.

The implementation was developed test-first through the renderer's public seam: `templates.New(fs.FS)` and `Renderer.Render(io.Writer, name, data)`. Page rendering, defined partials, filename-style partials, construction errors, unknown names, and concurrent reuse all have focused behavior coverage. Page templates clone the parsed base during construction and define their own `content`; after construction all parsed templates are immutable and safe for concurrent execution.

An external Cursor critique (`cursor-grok-4.5-high-fast`) reviewed alignment, test seam, behavior contracts, package placement, TDD slices, and plan risks before implementation. Its key correction was to retain explicit page membership rather than infer pages from the `.html` suffix, because `address_suggestions.html` is a direct partial. The critique verdict was `READY`.

No template markup, helper semantics, endpoint behavior, or user-facing output was intentionally changed.

</details>
