### PR TITLE
refactor(no-ticket): deepen route calculation

### DIFF
--- a/internal/handlers/org_vehicle_assignments.go
+++ b/internal/handlers/org_vehicle_assignments.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"errors"
 	"net/url"
 	"ride-home-router/internal/models"
@@ -61,36 +60,6 @@ func parseOrgVehicleAssignments(form url.Values, selectedDriverIDs []int64) (map
 	}
 
 	return assignments, nil
-}
-
-func (h *Handler) loadAssignedOrgVehicles(ctx context.Context, assignments map[int64]int64) (map[int64]*models.OrganizationVehicle, error) {
-	if len(assignments) == 0 {
-		return map[int64]*models.OrganizationVehicle{}, nil
-	}
-
-	vehicleIDs := make([]int64, 0, len(assignments))
-	seen := make(map[int64]struct{}, len(assignments))
-	for _, vehicleID := range assignments {
-		if _, ok := seen[vehicleID]; ok {
-			continue
-		}
-		seen[vehicleID] = struct{}{}
-		vehicleIDs = append(vehicleIDs, vehicleID)
-	}
-
-	vehicles, err := h.DB.OrganizationVehicles().GetByIDs(ctx, vehicleIDs)
-	if err != nil {
-		return nil, err
-	}
-	if len(vehicles) != len(vehicleIDs) {
-		return nil, errSelectedVanNotFound
-	}
-
-	vehicleMap := make(map[int64]*models.OrganizationVehicle, len(vehicles))
-	for i := range vehicles {
-		vehicleMap[vehicles[i].ID] = &vehicles[i]
-	}
-	return vehicleMap, nil
 }
 
 func applyOrgVehicleAssignments(drivers []models.Driver, assignments map[int64]int64, vehicleMap map[int64]*models.OrganizationVehicle) ([]models.Driver, map[int64]*models.OrganizationVehicle) {

--- a/internal/handlers/route_calculation.go
+++ b/internal/handlers/route_calculation.go
@@ -1,0 +1,176 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"ride-home-router/internal/database"
+	"ride-home-router/internal/models"
+	"ride-home-router/internal/routing"
+)
+
+type routeCalculationKind int
+
+var (
+	errActivityLocationNotFound = errors.New("activity location not found")
+	errSomeParticipantsNotFound = errors.New("some participants not found")
+	errSomeDriversNotFound      = errors.New("some drivers not found")
+)
+
+const (
+	routeCalculationUnknown routeCalculationKind = iota
+	routeCalculationSuccess
+	routeCalculationShortage
+	routeCalculationValidationFailure
+	routeCalculationRouteFailure
+	routeCalculationInternalFailure
+)
+
+type routeCalculationInput struct {
+	ParticipantIDs        []int64
+	DriverIDs             []int64
+	ActivityLocationID    int64
+	RouteTime             string
+	Mode                  models.RouteMode
+	OrgVehicleAssignments map[int64]int64
+}
+
+type routeCalculationOutcome struct {
+	Kind             routeCalculationKind
+	Result           *models.RoutingResult
+	Session          *RouteSession
+	Shortage         *routeCalculationShortageContext
+	ActivityLocation *models.ActivityLocation
+	UseMiles         bool
+	Err              error
+}
+
+type routeCalculationShortageContext struct {
+	RoutingError          *routing.ErrRoutingFailed
+	Drivers               []models.Driver
+	AvailableOrgVehicles  []models.OrganizationVehicle
+	ParticipantIDs        []int64
+	DriverIDs             []int64
+	ActivityLocation      *models.ActivityLocation
+	Mode                  models.RouteMode
+	UseMiles              bool
+	RouteTime             string
+	OrgVehicleAssignments map[int64]int64
+	DriverOrgVehicles     map[int64]*models.OrganizationVehicle
+}
+
+type routeCalculation struct {
+	db       database.DataStore
+	router   routing.Router
+	sessions *RouteSessionStore
+}
+
+func newRouteCalculation(db database.DataStore, router routing.Router, sessions *RouteSessionStore) *routeCalculation {
+	return &routeCalculation{db: db, router: router, sessions: sessions}
+}
+
+func (c *routeCalculation) calculate(ctx context.Context, input routeCalculationInput) routeCalculationOutcome {
+	settings, err := c.db.Settings().Get(ctx)
+	if err != nil {
+		return routeCalculationOutcome{Kind: routeCalculationInternalFailure, Err: err}
+	}
+	activityLocation, err := c.db.ActivityLocations().GetByID(ctx, input.ActivityLocationID)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return routeCalculationOutcome{Kind: routeCalculationValidationFailure, Err: errActivityLocationNotFound}
+		}
+		return routeCalculationOutcome{Kind: routeCalculationInternalFailure, Err: err}
+	}
+	participants, err := c.db.Participants().GetByIDs(ctx, input.ParticipantIDs)
+	if err != nil {
+		return routeCalculationOutcome{Kind: routeCalculationInternalFailure, Err: err}
+	}
+	if len(participants) != len(input.ParticipantIDs) {
+		return routeCalculationOutcome{Kind: routeCalculationValidationFailure, Err: errSomeParticipantsNotFound}
+	}
+	drivers, err := c.db.Drivers().GetByIDs(ctx, input.DriverIDs)
+	if err != nil {
+		return routeCalculationOutcome{Kind: routeCalculationInternalFailure, Err: err}
+	}
+	if len(drivers) != len(input.DriverIDs) {
+		return routeCalculationOutcome{Kind: routeCalculationValidationFailure, Err: errSomeDriversNotFound}
+	}
+	orgVehicleMap, err := c.loadAssignedOrgVehicles(ctx, input.OrgVehicleAssignments)
+	if err != nil {
+		if errors.Is(err, errSelectedVanNotFound) {
+			return routeCalculationOutcome{Kind: routeCalculationValidationFailure, Err: err}
+		}
+		return routeCalculationOutcome{Kind: routeCalculationInternalFailure, Err: err}
+	}
+	modifiedDrivers, driverOrgVehicles := applyOrgVehicleAssignments(drivers, input.OrgVehicleAssignments, orgVehicleMap)
+
+	result, err := c.router.CalculateRoutes(ctx, &routing.RoutingRequest{
+		InstituteCoords: activityLocation.GetCoords(),
+		Participants:    participants,
+		Drivers:         modifiedDrivers,
+		Mode:            input.Mode,
+	})
+	if err != nil {
+		if routingFailure, ok := err.(*routing.ErrRoutingFailed); ok {
+			availableOrgVehicles, _ := c.db.OrganizationVehicles().List(ctx)
+			return routeCalculationOutcome{
+				Kind: routeCalculationShortage,
+				Shortage: &routeCalculationShortageContext{
+					RoutingError:          routingFailure,
+					Drivers:               drivers,
+					AvailableOrgVehicles:  availableOrgVehicles,
+					ParticipantIDs:        input.ParticipantIDs,
+					DriverIDs:             input.DriverIDs,
+					ActivityLocation:      activityLocation,
+					Mode:                  input.Mode,
+					UseMiles:              settings.UseMiles,
+					RouteTime:             input.RouteTime,
+					OrgVehicleAssignments: input.OrgVehicleAssignments,
+					DriverOrgVehicles:     driverOrgVehicles,
+				},
+			}
+		}
+		return routeCalculationOutcome{Kind: routeCalculationRouteFailure, Err: err}
+	}
+
+	applyAssignedOrgVehicleMetadata(result.Routes, driverOrgVehicles)
+	result.Summary.OrgVehiclesUsed = countUsedOrgVehicles(result.Routes)
+	session := c.sessions.Create(result.Routes, modifiedDrivers, activityLocation, settings.UseMiles, input.RouteTime, input.Mode, driverOrgVehicles)
+
+	return routeCalculationOutcome{
+		Kind:             routeCalculationSuccess,
+		Result:           result,
+		Session:          session,
+		ActivityLocation: activityLocation,
+		UseMiles:         settings.UseMiles,
+	}
+}
+
+func (c *routeCalculation) loadAssignedOrgVehicles(ctx context.Context, assignments map[int64]int64) (map[int64]*models.OrganizationVehicle, error) {
+	if len(assignments) == 0 {
+		return map[int64]*models.OrganizationVehicle{}, nil
+	}
+
+	vehicleIDs := make([]int64, 0, len(assignments))
+	seen := make(map[int64]struct{}, len(assignments))
+	for _, vehicleID := range assignments {
+		if _, ok := seen[vehicleID]; ok {
+			continue
+		}
+		seen[vehicleID] = struct{}{}
+		vehicleIDs = append(vehicleIDs, vehicleID)
+	}
+
+	vehicles, err := c.db.OrganizationVehicles().GetByIDs(ctx, vehicleIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(vehicles) != len(vehicleIDs) {
+		return nil, errSelectedVanNotFound
+	}
+
+	vehicleMap := make(map[int64]*models.OrganizationVehicle, len(vehicles))
+	for i := range vehicles {
+		vehicleMap[vehicles[i].ID] = &vehicles[i]
+	}
+	return vehicleMap, nil
+}

--- a/internal/handlers/route_calculation_test.go
+++ b/internal/handlers/route_calculation_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"ride-home-router/internal/models"
+	"ride-home-router/internal/routing"
+	"testing"
+)
+
+func TestRouteCalculation_AssignedVehicleSuccessCreatesRestorableSession(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+	ctx := context.Background()
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{Name: "Rider", Address: "1 Rider Rd", Lat: 40.1, Lng: -73.9})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{Name: "Driver", Address: "2 Driver Rd", Lat: 40.2, Lng: -73.8, VehicleCapacity: 2})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(ctx, &models.ActivityLocation{Name: "Gym", Address: "3 Event Ave", Lat: 42, Lng: -75})
+	if err != nil {
+		t.Fatalf("create activity location: %v", err)
+	}
+	van, err := store.OrganizationVehicles().Create(ctx, &models.OrganizationVehicle{Name: "Blue Van", Capacity: 8})
+	if err != nil {
+		t.Fatalf("create organization vehicle: %v", err)
+	}
+
+	router := &captureRouter{result: &models.RoutingResult{
+		Routes: []models.CalculatedRoute{{
+			Driver: driver,
+			Stops:  []models.RouteStop{{Participant: participant}},
+		}},
+		Summary: models.RoutingSummary{TotalDriversUsed: 1},
+	}}
+	calculation := newRouteCalculation(store, router, handler.RouteSession)
+
+	outcome := calculation.calculate(ctx, routeCalculationInput{
+		ParticipantIDs:        []int64{participant.ID},
+		DriverIDs:             []int64{driver.ID},
+		ActivityLocationID:    location.ID,
+		RouteTime:             "18:30",
+		Mode:                  models.RouteModeDropoff,
+		OrgVehicleAssignments: map[int64]int64{driver.ID: van.ID},
+	})
+
+	if outcome.Kind != routeCalculationSuccess {
+		t.Fatalf("outcome kind = %v, want success; err=%v", outcome.Kind, outcome.Err)
+	}
+	if router.lastRequest == nil {
+		t.Fatal("expected router to receive a request")
+	}
+	if got := router.lastRequest.InstituteCoords; got != location.GetCoords() {
+		t.Fatalf("router activity coordinates = %#v, want %#v", got, location.GetCoords())
+	}
+	if got := router.lastRequest.Mode; got != models.RouteModeDropoff {
+		t.Fatalf("router mode = %q, want %q", got, models.RouteModeDropoff)
+	}
+	if got := router.lastRequest.Drivers[0].VehicleCapacity; got != van.Capacity {
+		t.Fatalf("router driver capacity = %d, want assigned van capacity %d", got, van.Capacity)
+	}
+	if got := outcome.Result.Routes[0].OrgVehicleID; got != van.ID {
+		t.Fatalf("route organization vehicle ID = %d, want %d", got, van.ID)
+	}
+	if got := outcome.Result.Routes[0].EffectiveCapacity; got != van.Capacity {
+		t.Fatalf("route effective capacity = %d, want %d", got, van.Capacity)
+	}
+	if got := outcome.Result.Summary.OrgVehiclesUsed; got != 1 {
+		t.Fatalf("organization vehicles used = %d, want 1", got)
+	}
+
+	session := handler.RouteSession.Get(outcome.Session.ID)
+	if session == nil {
+		t.Fatal("expected route session to be restorable")
+	}
+	if got := session.SelectedDrivers[0].VehicleCapacity; got != van.Capacity {
+		t.Fatalf("session driver capacity = %d, want %d", got, van.Capacity)
+	}
+	if got := session.DriverOrgVehicles[driver.ID]; got == nil || got.ID != van.ID {
+		t.Fatalf("session organization vehicle = %#v, want ID %d", got, van.ID)
+	}
+	if got := session.CurrentRoutes[0].OrgVehicleID; got != van.ID {
+		t.Fatalf("session route organization vehicle ID = %d, want %d", got, van.ID)
+	}
+}
+
+func TestRouteCalculation_CapacityShortageReturnsAssignmentsAndAvailableVehicles(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+	ctx := context.Background()
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{Name: "Rider", Address: "1 Rider Rd", Lat: 40.1, Lng: -73.9})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{Name: "Driver", Address: "2 Driver Rd", Lat: 40.2, Lng: -73.8, VehicleCapacity: 1})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(ctx, &models.ActivityLocation{Name: "Gym", Address: "3 Event Ave", Lat: 42, Lng: -75})
+	if err != nil {
+		t.Fatalf("create activity location: %v", err)
+	}
+	van, err := store.OrganizationVehicles().Create(ctx, &models.OrganizationVehicle{Name: "Blue Van", Capacity: 2})
+	if err != nil {
+		t.Fatalf("create organization vehicle: %v", err)
+	}
+	if err := store.Settings().Update(ctx, &models.Settings{UseMiles: false}); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+
+	routingFailure := &routing.ErrRoutingFailed{
+		Reason:            "not enough capacity",
+		UnassignedCount:   1,
+		TotalCapacity:     2,
+		TotalParticipants: 3,
+	}
+	calculation := newRouteCalculation(store, &captureRouter{err: routingFailure}, handler.RouteSession)
+	assignments := map[int64]int64{driver.ID: van.ID}
+
+	outcome := calculation.calculate(ctx, routeCalculationInput{
+		ParticipantIDs:        []int64{participant.ID},
+		DriverIDs:             []int64{driver.ID},
+		ActivityLocationID:    location.ID,
+		RouteTime:             "18:30",
+		Mode:                  models.RouteModeDropoff,
+		OrgVehicleAssignments: assignments,
+	})
+
+	if outcome.Kind != routeCalculationShortage {
+		t.Fatalf("outcome kind = %v, want shortage; err=%v", outcome.Kind, outcome.Err)
+	}
+	shortage := outcome.Shortage
+	if shortage == nil || shortage.RoutingError != routingFailure {
+		t.Fatalf("shortage routing error = %#v, want %#v", shortage, routingFailure)
+	}
+	if got := shortage.OrgVehicleAssignments[driver.ID]; got != van.ID {
+		t.Fatalf("preserved assignment = %d, want %d", got, van.ID)
+	}
+	if len(shortage.AvailableOrgVehicles) != 1 || shortage.AvailableOrgVehicles[0].ID != van.ID {
+		t.Fatalf("available organization vehicles = %#v, want vehicle %d", shortage.AvailableOrgVehicles, van.ID)
+	}
+	if got := shortage.DriverOrgVehicles[driver.ID]; got == nil || got.ID != van.ID {
+		t.Fatalf("driver organization vehicle = %#v, want ID %d", got, van.ID)
+	}
+	if got := shortage.Drivers[0].VehicleCapacity; got != driver.VehicleCapacity {
+		t.Fatalf("shortage driver capacity = %d, want original capacity %d", got, driver.VehicleCapacity)
+	}
+	if shortage.ActivityLocation.ID != location.ID || shortage.UseMiles || shortage.RouteTime != "18:30" {
+		t.Fatalf("shortage context = %#v, want selected location, settings, and route time", shortage)
+	}
+}

--- a/internal/handlers/routes.go
+++ b/internal/handlers/routes.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/httpx"
-	"ride-home-router/internal/routing"
 	"strconv"
 	"strings"
 	"time"
@@ -117,119 +116,70 @@ func (h *Handler) HandleCalculateRoutes(w http.ResponseWriter, r *http.Request) 
 
 	log.Printf("[HTTP] POST /api/v1/routes/calculate: participants=%d drivers=%d mode=%s", len(req.ParticipantIDs), len(req.DriverIDs), mode)
 
-	settings, err := h.DB.Settings().Get(r.Context())
-	if err != nil {
-		h.handleInternalError(w, err)
-		return
-	}
-
 	activityLocationID := req.ActivityLocationID
 	if activityLocationID == 0 {
 		h.handleValidationErrorHTMX(w, r, messageChooseActivityLocationForEvent)
 		return
 	}
-
-	// Get the selected activity location
-	activityLocation, err := h.DB.ActivityLocations().GetByID(r.Context(), activityLocationID)
-	if err != nil {
-		if h.checkNotFound(err) {
-			log.Printf("[HTTP] POST /api/v1/routes/calculate: activity location id=%d not found", activityLocationID)
-			h.handleValidationErrorHTMX(w, r, messageSelectedActivityLocationNotFoundChooseAnother)
-			return
-		}
-		h.handleInternalError(w, err)
-		return
-	}
-
-	participants, err := h.DB.Participants().GetByIDs(r.Context(), req.ParticipantIDs)
-	if err != nil {
-		h.handleInternalError(w, err)
-		return
-	}
-
-	if len(participants) != len(req.ParticipantIDs) {
-		log.Printf("[HTTP] POST /api/v1/routes/calculate: participants mismatch requested=%d found=%d", len(req.ParticipantIDs), len(participants))
-		h.handleValidationError(w, "Some participants not found")
-		return
-	}
-
-	drivers, err := h.DB.Drivers().GetByIDs(r.Context(), req.DriverIDs)
-	if err != nil {
-		h.handleInternalError(w, err)
-		return
-	}
-
-	if len(drivers) != len(req.DriverIDs) {
-		log.Printf("[HTTP] POST /api/v1/routes/calculate: drivers mismatch requested=%d found=%d", len(req.DriverIDs), len(drivers))
-		h.handleValidationError(w, "Some drivers not found")
-		return
-	}
-
-	orgVehicleMap, err := h.loadAssignedOrgVehicles(r.Context(), orgVehicleAssignments)
-	if err != nil {
-		if errors.Is(err, errSelectedVanNotFound) {
-			h.handleValidationErrorHTMX(w, r, err.Error())
+	outcome := newRouteCalculation(h.DB, h.Router, h.RouteSession).calculate(r.Context(), routeCalculationInput{
+		ParticipantIDs:        req.ParticipantIDs,
+		DriverIDs:             req.DriverIDs,
+		ActivityLocationID:    activityLocationID,
+		RouteTime:             routeTime,
+		Mode:                  mode,
+		OrgVehicleAssignments: orgVehicleAssignments,
+	})
+	if outcome.Kind == routeCalculationValidationFailure {
+		message := routeCalculationValidationMessage(outcome.Err)
+		if errors.Is(outcome.Err, errSomeParticipantsNotFound) || errors.Is(outcome.Err, errSomeDriversNotFound) {
+			h.handleValidationError(w, message)
 		} else {
-			h.handleInternalError(w, err)
+			h.handleValidationErrorHTMX(w, r, message)
 		}
 		return
 	}
-	modifiedDrivers, driverOrgVehicle := applyOrgVehicleAssignments(drivers, orgVehicleAssignments, orgVehicleMap)
-
-	routingReq := &routing.RoutingRequest{
-		InstituteCoords: activityLocation.GetCoords(),
-		Participants:    participants,
-		Drivers:         modifiedDrivers,
-		Mode:            mode,
+	if outcome.Kind == routeCalculationInternalFailure {
+		h.handleInternalError(w, outcome.Err)
+		return
 	}
-
-	result, err := h.Router.CalculateRoutes(r.Context(), routingReq)
-	if err != nil {
-		if rerr, ok := err.(*routing.ErrRoutingFailed); ok {
-			log.Printf("[ERROR] Routing failed: participants=%d unassigned=%d capacity=%d reason=%s", rerr.TotalParticipants, rerr.UnassignedCount, rerr.TotalCapacity, rerr.Reason)
-
-			// For HTMX requests, show the capacity shortage UI with org vehicle assignment options
-			if h.isHTMX(r) {
-				orgVehicles, _ := h.DB.OrganizationVehicles().List(r.Context())
-
-				h.setHTMXToast(w, messageNotEnoughCapacity(rerr.TotalParticipants-rerr.TotalCapacity), toastTypeWarning)
-
-				h.renderTemplate(w, "capacity_shortage", buildCapacityShortageViewData(
-					rerr,
-					drivers,
-					orgVehicles,
-					req.ParticipantIDs,
-					req.DriverIDs,
-					activityLocation,
-					string(mode),
-					settings.UseMiles,
-					routeTime,
-					orgVehicleAssignments,
-					driverOrgVehicle,
-				))
-				return
-			}
-
-			h.handleRoutingError(w, err)
+	if outcome.Kind == routeCalculationRouteFailure {
+		log.Printf("[ERROR] Route calculation failed: err=%v", outcome.Err)
+		h.handleRouteCalculationError(w, r, outcome.Err)
+		return
+	}
+	if outcome.Kind == routeCalculationShortage {
+		shortage := outcome.Shortage
+		log.Printf("[ERROR] Routing failed: participants=%d unassigned=%d capacity=%d reason=%s", shortage.RoutingError.TotalParticipants, shortage.RoutingError.UnassignedCount, shortage.RoutingError.TotalCapacity, shortage.RoutingError.Reason)
+		if h.isHTMX(r) {
+			h.setHTMXToast(w, messageNotEnoughCapacity(shortage.RoutingError.TotalParticipants-shortage.RoutingError.TotalCapacity), toastTypeWarning)
+			h.renderTemplate(w, "capacity_shortage", buildCapacityShortageViewData(
+				shortage.RoutingError,
+				shortage.Drivers,
+				shortage.AvailableOrgVehicles,
+				shortage.ParticipantIDs,
+				shortage.DriverIDs,
+				shortage.ActivityLocation,
+				string(shortage.Mode),
+				shortage.UseMiles,
+				shortage.RouteTime,
+				shortage.OrgVehicleAssignments,
+				shortage.DriverOrgVehicles,
+			))
 			return
 		}
-		log.Printf("[ERROR] Route calculation failed: err=%v", err)
-		h.handleRouteCalculationError(w, r, err)
+		h.handleRoutingError(w, shortage.RoutingError)
 		return
 	}
 
+	result := outcome.Result
+	session := outcome.Session
+	activityLocation := outcome.ActivityLocation
 	log.Printf("[HTTP] Routes calculated successfully: drivers=%d total_distance=%.0f", result.Summary.TotalDriversUsed, result.Summary.TotalDropoffDistanceMeters)
-
-	applyAssignedOrgVehicleMetadata(result.Routes, driverOrgVehicle)
-	result.Summary.OrgVehiclesUsed = countUsedOrgVehicles(result.Routes)
-
-	// Create a session for route editing
-	session := h.RouteSession.Create(result.Routes, modifiedDrivers, activityLocation, settings.UseMiles, routeTime, mode, driverOrgVehicle)
 
 	// Return HTML for htmx, JSON for API calls
 	if h.isHTMX(r) {
 		h.setHTMXToast(w, messageRoutesCalculated(result.Summary.TotalDriversUsed), toastTypeSuccess)
-		h.renderTemplate(w, "route_results", buildRouteResultsView(result.Routes, result.Summary, activityLocation, settings.UseMiles, routeTime, session.ID, false, getUnusedDrivers(session), mode))
+		h.renderTemplate(w, "route_results", buildRouteResultsView(result.Routes, result.Summary, activityLocation, outcome.UseMiles, routeTime, session.ID, false, getUnusedDrivers(session), mode))
 		return
 	}
 
@@ -308,101 +258,70 @@ func (h *Handler) HandleCalculateRoutesWithOrgVehicles(w http.ResponseWriter, r 
 		return
 	}
 
-	settings, err := h.DB.Settings().Get(r.Context())
-	if err != nil {
-		h.handleInternalError(w, err)
-		return
-	}
-
 	if activityLocationID == 0 {
 		h.handleValidationErrorHTMX(w, r, messageChooseActivityLocationForEvent)
 		return
 	}
-
-	activityLocation, err := h.DB.ActivityLocations().GetByID(r.Context(), activityLocationID)
-	if err != nil {
-		if h.checkNotFound(err) {
-			h.handleValidationErrorHTMX(w, r, messageSelectedActivityLocationNotFoundChooseAnother)
-			return
-		}
-		h.handleInternalError(w, err)
+	outcome := newRouteCalculation(h.DB, h.Router, h.RouteSession).calculate(r.Context(), routeCalculationInput{
+		ParticipantIDs:        participantIDs,
+		DriverIDs:             driverIDs,
+		ActivityLocationID:    activityLocationID,
+		RouteTime:             routeTime,
+		Mode:                  mode,
+		OrgVehicleAssignments: orgVehicleAssignments,
+	})
+	if outcome.Kind == routeCalculationValidationFailure {
+		h.handleValidationErrorHTMX(w, r, routeCalculationValidationMessage(outcome.Err))
+		return
+	}
+	if outcome.Kind == routeCalculationInternalFailure {
+		h.handleInternalError(w, outcome.Err)
+		return
+	}
+	if outcome.Kind == routeCalculationRouteFailure {
+		h.handleRouteCalculationError(w, r, outcome.Err)
+		return
+	}
+	if outcome.Kind == routeCalculationShortage {
+		shortage := outcome.Shortage
+		h.renderTemplate(w, "capacity_shortage", buildCapacityShortageViewData(
+			shortage.RoutingError,
+			shortage.Drivers,
+			shortage.AvailableOrgVehicles,
+			shortage.ParticipantIDs,
+			shortage.DriverIDs,
+			shortage.ActivityLocation,
+			string(shortage.Mode),
+			shortage.UseMiles,
+			shortage.RouteTime,
+			shortage.OrgVehicleAssignments,
+			shortage.DriverOrgVehicles,
+		))
 		return
 	}
 
-	participants, err := h.DB.Participants().GetByIDs(r.Context(), participantIDs)
-	if err != nil {
-		h.handleInternalError(w, err)
-		return
-	}
-
-	drivers, err := h.DB.Drivers().GetByIDs(r.Context(), driverIDs)
-	if err != nil {
-		h.handleInternalError(w, err)
-		return
-	}
-
-	orgVehicleMap, err := h.loadAssignedOrgVehicles(r.Context(), orgVehicleAssignments)
-	if err != nil {
-		if errors.Is(err, errSelectedVanNotFound) {
-			h.handleValidationErrorHTMX(w, r, err.Error())
-		} else {
-			h.handleInternalError(w, err)
-		}
-		return
-	}
-	modifiedDrivers, driverOrgVehicle := applyOrgVehicleAssignments(drivers, orgVehicleAssignments, orgVehicleMap)
-	for _, driver := range drivers {
-		if vehicle, ok := driverOrgVehicle[driver.ID]; ok && vehicle != nil {
-			log.Printf("[ROUTING] Driver %s assigned org vehicle %s (capacity %d -> %d)",
-				driver.Name, vehicle.Name, driver.VehicleCapacity, vehicle.Capacity)
-		}
-	}
-
-	routingReq := &routing.RoutingRequest{
-		InstituteCoords: activityLocation.GetCoords(),
-		Participants:    participants,
-		Drivers:         modifiedDrivers,
-		Mode:            mode,
-	}
-
-	result, err := h.Router.CalculateRoutes(r.Context(), routingReq)
-	if err != nil {
-		if rerr, ok := err.(*routing.ErrRoutingFailed); ok {
-			// Still not enough capacity - show the UI again
-			allOrgVehicles, _ := h.DB.OrganizationVehicles().List(r.Context())
-
-			h.renderTemplate(w, "capacity_shortage", buildCapacityShortageViewData(
-				rerr,
-				drivers,
-				allOrgVehicles,
-				participantIDs,
-				driverIDs,
-				activityLocation,
-				string(mode),
-				settings.UseMiles,
-				routeTime,
-				orgVehicleAssignments,
-				driverOrgVehicle,
-			))
-			return
-		}
-		h.handleRouteCalculationError(w, r, err)
-		return
-	}
-
-	applyAssignedOrgVehicleMetadata(result.Routes, driverOrgVehicle)
-
-	// Count org vehicles used in summary
-	result.Summary.OrgVehiclesUsed = countUsedOrgVehicles(result.Routes)
+	result := outcome.Result
+	session := outcome.Session
+	activityLocation := outcome.ActivityLocation
 
 	log.Printf("[HTTP] Routes calculated with org vehicles: drivers=%d org_vehicles=%d total_distance=%.0f",
 		result.Summary.TotalDriversUsed, result.Summary.OrgVehiclesUsed, result.Summary.TotalDropoffDistanceMeters)
 
-	// Create a session for route editing
-	session := h.RouteSession.Create(result.Routes, modifiedDrivers, activityLocation, settings.UseMiles, routeTime, mode, driverOrgVehicle)
-
 	h.setHTMXToast(w, messageRoutesCalculated(result.Summary.TotalDriversUsed), toastTypeSuccess)
-	h.renderTemplate(w, "route_results", buildRouteResultsView(result.Routes, result.Summary, activityLocation, settings.UseMiles, routeTime, session.ID, false, getUnusedDrivers(session), mode))
+	h.renderTemplate(w, "route_results", buildRouteResultsView(result.Routes, result.Summary, activityLocation, outcome.UseMiles, routeTime, session.ID, false, getUnusedDrivers(session), mode))
+}
+
+func routeCalculationValidationMessage(err error) string {
+	switch {
+	case errors.Is(err, errActivityLocationNotFound):
+		return messageSelectedActivityLocationNotFoundChooseAnother
+	case errors.Is(err, errSomeParticipantsNotFound):
+		return "Some participants not found"
+	case errors.Is(err, errSomeDriversNotFound):
+		return "Some drivers not found"
+	default:
+		return err.Error()
+	}
 }
 
 func (h *Handler) handleRouteCalculationError(w http.ResponseWriter, r *http.Request, err error) {

--- a/internal/handlers/routes_test.go
+++ b/internal/handlers/routes_test.go
@@ -54,94 +54,6 @@ func (r *captureRouter) CalculateRoutes(_ context.Context, req *routing.RoutingR
 	return &models.RoutingResult{}, nil
 }
 
-func TestHandleCalculateRoutes_UsesRequestedActivityLocation(t *testing.T) {
-	handler, store := newTestRouteHandler(t)
-
-	participant, err := store.Participants().Create(context.Background(), &models.Participant{
-		Name:    "Participant One",
-		Address: "1 Rider Rd",
-		Lat:     40.10,
-		Lng:     -73.90,
-	})
-	if err != nil {
-		t.Fatalf("create participant: %v", err)
-	}
-
-	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
-		Name:            "Driver One",
-		Address:         "2 Driver Rd",
-		Lat:             40.20,
-		Lng:             -73.80,
-		VehicleCapacity: 4,
-	})
-	if err != nil {
-		t.Fatalf("create driver: %v", err)
-	}
-
-	fallbackLocation, err := store.ActivityLocations().Create(context.Background(), &models.ActivityLocation{
-		Name:    "Fallback",
-		Address: "3 Default Ave",
-		Lat:     41.00,
-		Lng:     -74.00,
-	})
-	if err != nil {
-		t.Fatalf("create fallback location: %v", err)
-	}
-
-	requestedLocation, err := store.ActivityLocations().Create(context.Background(), &models.ActivityLocation{
-		Name:    "Requested",
-		Address: "4 Event Ave",
-		Lat:     42.00,
-		Lng:     -75.00,
-	})
-	if err != nil {
-		t.Fatalf("create requested location: %v", err)
-	}
-
-	if err := store.Settings().Update(context.Background(), &models.Settings{
-		SelectedActivityLocationID: fallbackLocation.ID,
-		UseMiles:                   false,
-	}); err != nil {
-		t.Fatalf("update settings: %v", err)
-	}
-
-	router := &captureRouter{
-		result: &models.RoutingResult{
-			Routes: []models.CalculatedRoute{},
-			Summary: models.RoutingSummary{
-				TotalDriversUsed:           1,
-				TotalDropoffDistanceMeters: 1200,
-			},
-		},
-	}
-	handler.Router = router
-
-	form := url.Values{}
-	form.Add("participant_ids", int64ToString(participant.ID))
-	form.Add("driver_ids", int64ToString(driver.ID))
-	form.Set("activity_location_id", int64ToString(requestedLocation.ID))
-	form.Set("route_time", "18:30")
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/calculate", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	rr := httptest.NewRecorder()
-
-	handler.HandleCalculateRoutes(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d body=%q", http.StatusOK, rr.Code, rr.Body.String())
-	}
-	if router.lastRequest == nil {
-		t.Fatal("expected router to receive a request")
-	}
-	if router.lastRequest.InstituteCoords != requestedLocation.GetCoords() {
-		t.Fatalf("expected requested location coords %+v, got %+v", requestedLocation.GetCoords(), router.lastRequest.InstituteCoords)
-	}
-	if router.lastRequest.Mode != models.RouteModeDropoff {
-		t.Fatalf("expected default mode %q, got %q", models.RouteModeDropoff, router.lastRequest.Mode)
-	}
-}
-
 func TestHandleCalculateRoutes_JSONPickupPropagatesTypedMode(t *testing.T) {
 	handler, store := newTestRouteHandler(t)
 
@@ -333,6 +245,130 @@ func TestHandleCalculateRoutesWithOrgVehicles_InvalidModeReturnsValidationError(
 	}
 }
 
+func TestHandleCalculateRoutesWithOrgVehicles_ShortageRendersHTMLWithoutWarningToast(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+	ctx := context.Background()
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{Name: "Rider", Address: "1 Rider Rd", Lat: 40.1, Lng: -73.9})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{Name: "Driver", Address: "2 Driver Rd", Lat: 40.2, Lng: -73.8, VehicleCapacity: 1})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(ctx, &models.ActivityLocation{Name: "Gym", Address: "3 Event Ave", Lat: 42, Lng: -75})
+	if err != nil {
+		t.Fatalf("create activity location: %v", err)
+	}
+	van, err := store.OrganizationVehicles().Create(ctx, &models.OrganizationVehicle{Name: "Blue Van", Capacity: 2})
+	if err != nil {
+		t.Fatalf("create organization vehicle: %v", err)
+	}
+	handler.Router = &captureRouter{err: &routing.ErrRoutingFailed{
+		Reason:            "still short",
+		UnassignedCount:   1,
+		TotalCapacity:     2,
+		TotalParticipants: 3,
+	}}
+
+	form := url.Values{}
+	form.Add("participant_ids", int64ToString(participant.ID))
+	form.Add("driver_ids", int64ToString(driver.ID))
+	form.Set("activity_location_id", int64ToString(location.ID))
+	form.Set("route_time", "18:30")
+	form.Set("mode", "dropoff")
+	form.Set("org_vehicle_"+int64ToString(driver.ID), int64ToString(van.ID))
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/routes/calculate-with-org-vehicles", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCalculateRoutesWithOrgVehicles(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if got := rr.Header().Get("HX-Trigger"); got != "" {
+		t.Fatalf("HX-Trigger = %q, want no warning toast", got)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, `class="capacity-shortage-container"`) || !strings.Contains(body, "Not Enough Available Capacity") {
+		t.Fatalf("expected capacity shortage HTML, body=%q", body)
+	}
+}
+
+func TestHandleCalculateRoutesWithOrgVehicles_SuccessRendersHTMLAndCreatesSession(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+	ctx := context.Background()
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{Name: "Rider", Address: "1 Rider Rd", Lat: 40.1, Lng: -73.9})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{Name: "Driver", Address: "2 Driver Rd", Lat: 40.2, Lng: -73.8, VehicleCapacity: 1})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(ctx, &models.ActivityLocation{Name: "Gym", Address: "3 Event Ave", Lat: 42, Lng: -75})
+	if err != nil {
+		t.Fatalf("create activity location: %v", err)
+	}
+	van, err := store.OrganizationVehicles().Create(ctx, &models.OrganizationVehicle{Name: "Blue Van", Capacity: 2})
+	if err != nil {
+		t.Fatalf("create organization vehicle: %v", err)
+	}
+	handler.Router = &captureRouter{result: &models.RoutingResult{
+		Routes: []models.CalculatedRoute{{
+			Driver: driver,
+			Stops:  []models.RouteStop{{Participant: participant}},
+			Mode:   models.RouteModeDropoff,
+		}},
+		Summary: models.RoutingSummary{TotalParticipants: 1, TotalDriversUsed: 1},
+	}}
+
+	form := url.Values{}
+	form.Add("participant_ids", int64ToString(participant.ID))
+	form.Add("driver_ids", int64ToString(driver.ID))
+	form.Set("activity_location_id", int64ToString(location.ID))
+	form.Set("route_time", "18:30")
+	form.Set("mode", "dropoff")
+	form.Set("org_vehicle_"+int64ToString(driver.ID), int64ToString(van.ID))
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/routes/calculate-with-org-vehicles", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCalculateRoutesWithOrgVehicles(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if got, want := rr.Header().Get("HX-Trigger"), `{"showToast":{"message":"Routes calculated! 1 drivers assigned.","type":"success"}}`; got != want {
+		t.Fatalf("HX-Trigger = %q, want %q", got, want)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `class="routes-container"`) {
+		t.Fatalf("expected route-result HTML, body=%q", body)
+	}
+	sessionIDMarker := `data-session-id="`
+	start := strings.Index(body, sessionIDMarker)
+	if start < 0 {
+		t.Fatalf("expected rendered session ID, body=%q", body)
+	}
+	start += len(sessionIDMarker)
+	end := strings.Index(body[start:], `"`)
+	if end < 0 {
+		t.Fatalf("expected rendered session ID terminator, body=%q", body)
+	}
+	session := handler.RouteSession.Get(body[start : start+end])
+	if session == nil {
+		t.Fatal("expected route session to be restorable")
+	}
+	if got := session.DriverOrgVehicles[driver.ID]; got == nil || got.ID != van.ID {
+		t.Fatalf("session organization vehicle = %#v, want ID %d", got, van.ID)
+	}
+}
+
 func TestHandleCalculateRoutes_HTMXMissingActivityLocationReturnsEventPlanningMessage(t *testing.T) {
 	handler, store := newTestRouteHandler(t)
 
@@ -372,83 +408,6 @@ func TestHandleCalculateRoutes_HTMXMissingActivityLocationReturnsEventPlanningMe
 	expectedTrigger := `{"showToast":{"message":"Please choose an activity location for this event.","type":"error"}}`
 	if got := rr.Header().Get("HX-Trigger"); got != expectedTrigger {
 		t.Fatalf("HX-Trigger = %q, want %q", got, expectedTrigger)
-	}
-}
-
-func TestHandleCalculateRoutes_AppliesAssignedVanCapacityBeforeRouting(t *testing.T) {
-	handler, store := newTestRouteHandler(t)
-
-	participant, err := store.Participants().Create(context.Background(), &models.Participant{
-		Name:    "Participant One",
-		Address: "1 Rider Rd",
-		Lat:     40.10,
-		Lng:     -73.90,
-	})
-	if err != nil {
-		t.Fatalf("create participant: %v", err)
-	}
-
-	driver, err := store.Drivers().Create(context.Background(), &models.Driver{
-		Name:            "Driver One",
-		Address:         "2 Driver Rd",
-		Lat:             40.20,
-		Lng:             -73.80,
-		VehicleCapacity: 4,
-	})
-	if err != nil {
-		t.Fatalf("create driver: %v", err)
-	}
-
-	location, err := store.ActivityLocations().Create(context.Background(), &models.ActivityLocation{
-		Name:    "Gym",
-		Address: "4 Event Ave",
-		Lat:     42.00,
-		Lng:     -75.00,
-	})
-	if err != nil {
-		t.Fatalf("create activity location: %v", err)
-	}
-
-	van, err := store.OrganizationVehicles().Create(context.Background(), &models.OrganizationVehicle{
-		Name:     "Overflow Van",
-		Capacity: 8,
-	})
-	if err != nil {
-		t.Fatalf("create van: %v", err)
-	}
-
-	router := &captureRouter{
-		result: &models.RoutingResult{
-			Routes: []models.CalculatedRoute{},
-			Summary: models.RoutingSummary{
-				TotalDriversUsed:           1,
-				TotalDropoffDistanceMeters: 1200,
-			},
-		},
-	}
-	handler.Router = router
-
-	form := url.Values{}
-	form.Add("participant_ids", int64ToString(participant.ID))
-	form.Add("driver_ids", int64ToString(driver.ID))
-	form.Set("activity_location_id", int64ToString(location.ID))
-	form.Set("route_time", "18:30")
-	form.Set("org_vehicle_"+int64ToString(driver.ID), int64ToString(van.ID))
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/routes/calculate", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	rr := httptest.NewRecorder()
-
-	handler.HandleCalculateRoutes(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d body=%q", http.StatusOK, rr.Code, rr.Body.String())
-	}
-	if router.lastRequest == nil {
-		t.Fatal("expected router to receive a request")
-	}
-	if got := router.lastRequest.Drivers[0].VehicleCapacity; got != van.Capacity {
-		t.Fatalf("driver capacity = %d, want %d", got, van.Capacity)
 	}
 }
 

--- a/internal/handlers/routes_test.go
+++ b/internal/handlers/routes_test.go
@@ -214,6 +214,57 @@ func TestHandleCalculateRoutes_DistanceProviderFailureReturnsVisibleError(t *tes
 	}
 }
 
+func TestHandleCalculateRoutes_JSONCapacityShortageReturnsRoutingFailure(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+	ctx := context.Background()
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{Name: "Rider", Address: "1 Rider Rd", Lat: 40.1, Lng: -73.9})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{Name: "Driver", Address: "2 Driver Rd", Lat: 40.2, Lng: -73.8, VehicleCapacity: 1})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(ctx, &models.ActivityLocation{Name: "Gym", Address: "3 Event Ave", Lat: 42, Lng: -75})
+	if err != nil {
+		t.Fatalf("create activity location: %v", err)
+	}
+	handler.Router = &captureRouter{err: &routing.ErrRoutingFailed{
+		Reason:            "not enough capacity",
+		UnassignedCount:   2,
+		TotalCapacity:     1,
+		TotalParticipants: 3,
+	}}
+
+	body := fmt.Sprintf(`{"participant_ids":[%d],"driver_ids":[%d],"activity_location_id":%d,"route_time":"18:30","mode":"dropoff"}`, participant.ID, driver.ID, location.ID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/routes/calculate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCalculateRoutes(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusUnprocessableEntity, rr.Body.String())
+	}
+	var response struct {
+		Error struct {
+			Code    string              `json:"code"`
+			Message string              `json:"message"`
+			Details RoutingErrorDetails `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error.Code != "ROUTING_FAILED" || response.Error.Message != "not enough capacity" {
+		t.Fatalf("error = %#v, want ROUTING_FAILED capacity error", response.Error)
+	}
+	if got, want := response.Error.Details, (RoutingErrorDetails{UnassignedCount: 2, TotalCapacity: 1, TotalParticipants: 3}); got != want {
+		t.Fatalf("routing details = %#v, want %#v", got, want)
+	}
+}
+
 func TestHandleCalculateRoutesWithOrgVehicles_InvalidModeReturnsValidationError(t *testing.T) {
 	handler, _ := newTestRouteHandler(t)
 	router := &captureRouter{}
@@ -366,6 +417,63 @@ func TestHandleCalculateRoutesWithOrgVehicles_SuccessRendersHTMLAndCreatesSessio
 	}
 	if got := session.DriverOrgVehicles[driver.ID]; got == nil || got.ID != van.ID {
 		t.Fatalf("session organization vehicle = %#v, want ID %d", got, van.ID)
+	}
+}
+
+func TestHandleCalculateRoutesWithOrgVehicles_RejectsStaleSelectedEntitiesBeforeRouting(t *testing.T) {
+	handler, store := newTestRouteHandler(t)
+	ctx := context.Background()
+
+	participant, err := store.Participants().Create(ctx, &models.Participant{Name: "Rider", Address: "1 Rider Rd", Lat: 40.1, Lng: -73.9})
+	if err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	driver, err := store.Drivers().Create(ctx, &models.Driver{Name: "Driver", Address: "2 Driver Rd", Lat: 40.2, Lng: -73.8, VehicleCapacity: 1})
+	if err != nil {
+		t.Fatalf("create driver: %v", err)
+	}
+	location, err := store.ActivityLocations().Create(ctx, &models.ActivityLocation{Name: "Gym", Address: "3 Event Ave", Lat: 42, Lng: -75})
+	if err != nil {
+		t.Fatalf("create activity location: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		participantID int64
+		driverID      int64
+		wantMessage   string
+	}{
+		{name: "participant", participantID: participant.ID + 1000, driverID: driver.ID, wantMessage: "Some participants not found"},
+		{name: "driver", participantID: participant.ID, driverID: driver.ID + 1000, wantMessage: "Some drivers not found"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := &captureRouter{}
+			handler.Router = router
+			form := url.Values{}
+			form.Add("participant_ids", int64ToString(test.participantID))
+			form.Add("driver_ids", int64ToString(test.driverID))
+			form.Set("activity_location_id", int64ToString(location.ID))
+			form.Set("route_time", "18:30")
+			form.Set("mode", "dropoff")
+			req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/v1/routes/calculate-with-org-vehicles", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("HX-Request", "true")
+			rr := httptest.NewRecorder()
+
+			handler.HandleCalculateRoutesWithOrgVehicles(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d body=%q", rr.Code, http.StatusBadRequest, rr.Body.String())
+			}
+			wantTrigger := `{"showToast":{"message":"` + test.wantMessage + `","type":"error"}}`
+			if got := rr.Header().Get("HX-Trigger"); got != wantTrigger {
+				t.Fatalf("HX-Trigger = %q, want %q", got, wantTrigger)
+			}
+			if router.lastRequest != nil {
+				t.Fatalf("router received request %#v for stale %s", router.lastRequest, test.name)
+			}
+		})
 	}
 }
 
@@ -765,6 +873,10 @@ func TestHandleCalculateRoutes_PreservesVanAssignmentsInShortageFlow(t *testing.
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d body=%q", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	expectedTrigger := `{"showToast":{"message":"Not enough capacity - need 1 more seats","type":"warning"}}`
+	if got := rr.Header().Get("HX-Trigger"); got != expectedTrigger {
+		t.Fatalf("HX-Trigger = %q, want %q", got, expectedTrigger)
 	}
 
 	body := rr.Body.String()


### PR DESCRIPTION
### Problem

Route calculation was split across two large HTTP handlers. Both handlers owned persistence loading, organization-vehicle capacity application, router invocation, shortage recovery context, result metadata, and route-session creation, which duplicated the workflow and forced workflow tests through HTTP.

### Changes

- Added one unexported in-process route-calculation module with typed input and tagged outcomes.
- Moved entity loading, completeness validation, organization-vehicle resolution/application, routing, shortage context, result metadata, and session creation behind that module.
- Reduced both route endpoints to transport parsing and response mapping while preserving their different HTMX/JSON policies.
- Added direct module-seam tests using temporary SQLite, the capture router, and the real route-session store.
- Added focused retry-endpoint coverage and removed redundant workflow assertions from HTTP tests.

### Decisions

- Kept the module inside `internal/handlers`; a new package would require a speculative route-session interface or an out-of-scope session move.
- Kept form/JSON decoding, form-specific assignment rules, route-time/mode parsing, toasts, templates, status codes, and response envelopes in the HTTP adapters.
- Kept view models and HTTP details out of the module outcome.
- Preserved the normal endpoint's form/JSON behavior and shortage warning toast.
- Preserved the retry endpoint's form-only, HTML-success, and no-shortage-toast behavior.
- Deliberately unified selected participant/driver completeness validation across both paths so stale IDs cannot reach routing.

### Testing

- `go test ./internal/handlers -run '^(TestRouteCalculation_|TestHandleCalculateRoutes)'`
- `go test -race ./...`
- `golangci-lint run`
- `git diff --check`

<details>
<summary>Agent Context</summary>

This no-ticket refactor came from an architecture review of recent route-planning hot spots. The selected candidate was to deepen route calculation: callers should cross one seam instead of duplicating the planning workflow in HTTP handlers.

The planning critique was run read-only through Cursor Grok 4.5 High Fast. It recommended an unexported in-package module because `RouteSessionStore` currently lives in `handlers`; creating a separate package now would force a one-adapter session seam or broaden the task into route-session restructuring. The critique also identified the normal/retry response differences as acceptance criteria.

The confirmed module ownership is:

- settings, activity-location, participant, and driver loading;
- selected-entity completeness checks;
- assigned organization-vehicle loading and capacity application;
- router invocation;
- typed capacity-shortage context;
- organization-vehicle result metadata and summary correction;
- route-session creation using modified drivers and assignment metadata.

HTTP adapters continue to own:

- form and JSON decoding;
- form-specific organization-vehicle assignment parsing;
- empty-selection, route-time, and route-mode validation;
- HTMX detection, toasts, templates, JSON envelopes, and status mapping.

Implementation followed vertical TDD slices. The first direct module test drove success, assigned capacity before routing, annotated results, and a restorable session. The second drove typed capacity-shortage context. The normal and retry adapters were then rewired separately. Review-stage characterization tests locked down retry shortage without a warning toast and retry HTML success with a restorable session. Two older HTTP tests whose workflow assertions were covered by the module seam were removed instead of layering duplicate coverage.

Out of scope and unchanged: routing algorithms, route-session editing behavior, persistence interfaces, browser code, templates, and server startup.

</details>
