### PR TITLE
feat(no-ticket): redesign balanced routing for driver utilization and corridor coherence

### DIFF
--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -10,6 +10,7 @@ import (
 	"ride-home-router/internal/models"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -88,11 +89,28 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 	// Phase 1: Build a feasible rider-score seed. The complete lexicographic
 	// objective is applied by the ordering and assignment phases below.
 	phase1Start := time.Now()
-	unassigned, err = roundRobinInsertion(ctx, rc, routes, driverIDs, unassigned)
-	if err != nil {
-		return nil, err
+	seedName := "bearing-sweep"
+	if r.bearingSweepInsertion(req.InstituteCoords, routes, driverIDs, unassigned) {
+		unassigned = nil
+	} else {
+		seedName = "round-robin fallback"
+		fallbackUnassigned, err := roundRobinInsertion(ctx, rc, routes, driverIDs, unassigned)
+		if err != nil {
+			return nil, err
+		}
+		unassigned = fallbackUnassigned
 	}
-	log.Printf("[TIMING] Phase 1 (round-robin): %v", time.Since(phase1Start))
+	if len(unassigned) == 0 {
+		repairs, err := r.maximizeNonemptyRoutes(ctx, rc, routes, driverIDs)
+		if err != nil {
+			return nil, err
+		}
+		if repairs > 0 {
+			log.Printf("[BALANCED] Phase 1 filled %d additional driver routes", repairs)
+		}
+	}
+	log.Printf("[BALANCED] Phase 1 seed: %s", seedName)
+	log.Printf("[TIMING] Phase 1 (%s): %v", seedName, time.Since(phase1Start))
 
 	// Phase 2: Improve route order in the context of the complete solution.
 	phase2Start := time.Now()
@@ -141,6 +159,279 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 type balancedRoute struct {
 	driver *models.Driver
 	stops  []*models.Participant
+}
+
+// bearingSweepInsertion partitions household groups into contiguous bearing
+// arcs and matches each arc to the unused driver whose home bearing is nearest.
+// It commits assignments only when the entire sweep succeeds.
+func (r *BalancedRouter) bearingSweepInsertion(institute models.Coordinates, routes map[int64]*balancedRoute, driverIDs []int64, unassigned []*models.Participant) bool {
+	if len(unassigned) == 0 {
+		return true
+	}
+	if len(driverIDs) == 0 {
+		return false
+	}
+
+	groups := bearingSweepGroups(institute, unassigned)
+	workingRoutes := cloneBalancedRoutes(routes, driverIDs)
+	if len(workingRoutes) != len(driverIDs) {
+		return false
+	}
+
+	orderedDriverIDs := slices.Clone(driverIDs)
+	slices.Sort(orderedDriverIDs)
+	usedDrivers := make(map[int64]struct{}, len(orderedDriverIDs))
+	driversWithGroups := make(map[int64]struct{}, len(orderedDriverIDs))
+	rejectedForGroup := make(map[int64]struct{}, len(orderedDriverIDs))
+	reserveEveryDriver := len(groups) >= len(orderedDriverIDs)
+
+	maxVehicleCapacity := maxRouteVehicleCapacity(workingRoutes)
+	splittableHouseholds := make(map[string]struct{})
+	for _, group := range groups {
+		if len(group.members) > maxVehicleCapacity {
+			splittableHouseholds[participantGroupKey(group)] = struct{}{}
+		}
+	}
+
+	for len(groups) > 0 {
+		driverID, ok := closestUnusedDriverByBearing(institute, groups[0], workingRoutes, orderedDriverIDs, usedDrivers, rejectedForGroup)
+		if !ok {
+			return false
+		}
+		route := workingRoutes[driverID]
+		arcHasGroup := false
+
+		for len(groups) > 0 {
+			group := groups[0]
+			remainingCapacity := route.driver.VehicleCapacity - len(route.stops)
+			if remainingCapacity <= 0 {
+				break
+			}
+
+			assignedCount := len(group.members)
+			if assignedCount > remainingCapacity {
+				if _, splittable := splittableHouseholds[participantGroupKey(group)]; !splittable {
+					break
+				}
+				assignedCount = 1
+			}
+
+			remainingGroupCount := len(groups)
+			if assignedCount == len(group.members) {
+				remainingGroupCount--
+			}
+			remainingUnusedDrivers := len(orderedDriverIDs) - len(usedDrivers)
+			if arcHasGroup && remainingGroupCount < remainingUnusedDrivers {
+				break
+			}
+			if !assignmentPreservesCapacityFeasibility(workingRoutes, driverID, groups, 0, assignedCount, splittableHouseholds) {
+				break
+			}
+
+			route.stops = append(route.stops, group.members[:assignedCount]...)
+			usedDrivers[driverID] = struct{}{}
+			driversWithGroups[driverID] = struct{}{}
+			arcHasGroup = true
+			if assignedCount == len(group.members) {
+				groups = groups[1:]
+			} else {
+				group.members = group.members[assignedCount:]
+			}
+		}
+		if !arcHasGroup {
+			rejectedForGroup[driverID] = struct{}{}
+			continue
+		}
+		clear(rejectedForGroup)
+	}
+
+	if reserveEveryDriver && len(driversWithGroups) != len(orderedDriverIDs) {
+		return false
+	}
+	for _, driverID := range orderedDriverIDs {
+		routes[driverID].stops = workingRoutes[driverID].stops
+	}
+	return true
+}
+
+func bearingSweepGroups(institute models.Coordinates, participants []*models.Participant) []*participantGroup {
+	groups := groupParticipantsByAddress(participants)
+	sort.Slice(groups, func(i, j int) bool {
+		iBearing := bearingFromInstitute(institute, models.Coordinates{Lat: groups[i].lat, Lng: groups[i].lng})
+		jBearing := bearingFromInstitute(institute, models.Coordinates{Lat: groups[j].lat, Lng: groups[j].lng})
+		if iBearing != jBearing {
+			return iBearing < jBearing
+		}
+		return participantGroupKey(groups[i]) < participantGroupKey(groups[j])
+	})
+	if len(groups) <= 1 {
+		return groups
+	}
+
+	largestGap := -1.0
+	startIndex := 0
+	startKey := ""
+	for i, group := range groups {
+		nextIndex := (i + 1) % len(groups)
+		currentBearing := bearingFromInstitute(institute, models.Coordinates{Lat: group.lat, Lng: group.lng})
+		nextGroup := groups[nextIndex]
+		nextBearing := bearingFromInstitute(institute, models.Coordinates{Lat: nextGroup.lat, Lng: nextGroup.lng})
+		gap := math.Mod(nextBearing-currentBearing+360, 360)
+		nextKey := participantGroupKey(nextGroup)
+		if gap > largestGap || gap == largestGap && nextKey < startKey {
+			largestGap = gap
+			startIndex = nextIndex
+			startKey = nextKey
+		}
+	}
+
+	ordered := make([]*participantGroup, 0, len(groups))
+	ordered = append(ordered, groups[startIndex:]...)
+	ordered = append(ordered, groups[:startIndex]...)
+	return ordered
+}
+
+func cloneBalancedRoutes(routes map[int64]*balancedRoute, driverIDs []int64) map[int64]*balancedRoute {
+	cloned := make(map[int64]*balancedRoute, len(driverIDs))
+	for _, driverID := range driverIDs {
+		route, ok := routes[driverID]
+		if !ok || route == nil || route.driver == nil {
+			continue
+		}
+		cloned[driverID] = &balancedRoute{
+			driver: route.driver,
+			stops:  slices.Clone(route.stops),
+		}
+	}
+	return cloned
+}
+
+func closestUnusedDriverByBearing(institute models.Coordinates, group *participantGroup, routes map[int64]*balancedRoute, driverIDs []int64, used, rejected map[int64]struct{}) (int64, bool) {
+	groupBearing := bearingFromInstitute(institute, models.Coordinates{Lat: group.lat, Lng: group.lng})
+	bestDistance := math.Inf(1)
+	var bestDriverID int64
+	found := false
+	for _, driverID := range driverIDs {
+		if _, alreadyUsed := used[driverID]; alreadyUsed {
+			continue
+		}
+		if _, alreadyRejected := rejected[driverID]; alreadyRejected {
+			continue
+		}
+		route, ok := routes[driverID]
+		if !ok || route == nil || route.driver == nil {
+			continue
+		}
+		driverBearing := bearingFromInstitute(institute, route.driver.GetCoords())
+		distance := angularDistance(groupBearing, driverBearing)
+		if !found || distance < bestDistance || distance == bestDistance && driverID < bestDriverID {
+			bestDistance = distance
+			bestDriverID = driverID
+			found = true
+		}
+	}
+	return bestDriverID, found
+}
+
+func angularDistance(first, second float64) float64 {
+	difference := math.Abs(first - second)
+	return min(difference, 360-difference)
+}
+
+type nonemptyRouteRepair struct {
+	stops map[int64][]*models.Participant
+	score solutionScore
+	found bool
+}
+
+// maximizeNonemptyRoutes augments the seed through chains of household-block
+// relocations. A chain may temporarily transfer the empty route between
+// drivers, but every committed chain ends at a route with multiple blocks and
+// therefore increases the number of nonempty routes by one.
+func (r *BalancedRouter) maximizeNonemptyRoutes(ctx context.Context, rc routeContext, routes map[int64]*balancedRoute, driverIDs []int64) (int, error) {
+	orderedDriverIDs := slices.Clone(driverIDs)
+	slices.Sort(orderedDriverIDs)
+	repairs := 0
+
+	for {
+		baseStops := make(map[int64][]*models.Participant, len(orderedDriverIDs))
+		baseMetrics := make(map[int64]routeObjectiveMetrics, len(orderedDriverIDs))
+		for _, driverID := range orderedDriverIDs {
+			baseStops[driverID] = slices.Clone(routes[driverID].stops)
+			metrics, err := rc.evaluateRouteObjective(ctx, routes[driverID].driver, routes[driverID].stops)
+			if err != nil {
+				return repairs, err
+			}
+			baseMetrics[driverID] = metrics
+		}
+		currentScore := scoreSolution(baseMetrics, orderedDriverIDs)
+		best := nonemptyRouteRepair{score: currentScore}
+
+		var search func(int64, map[int64][]*models.Participant, map[int64]struct{}) error
+		search = func(emptyDriverID int64, workingStops map[int64][]*models.Participant, visited map[int64]struct{}) error {
+			for _, sourceDriverID := range orderedDriverIDs {
+				if sourceDriverID == emptyDriverID {
+					continue
+				}
+				if _, alreadyVisited := visited[sourceDriverID]; alreadyVisited {
+					continue
+				}
+
+				sourcePosition := 0
+				for _, sourceGroup := range routeHouseholdBlocks(workingStops[sourceDriverID]) {
+					groupSize := len(sourceGroup.members)
+					if groupSize > routes[emptyDriverID].driver.VehicleCapacity {
+						sourcePosition += groupSize
+						continue
+					}
+
+					candidateStops := maps.Clone(workingStops)
+					candidateStops[sourceDriverID] = removeRange(workingStops[sourceDriverID], sourcePosition, sourcePosition+groupSize)
+					candidateStops[emptyDriverID] = slices.Clone(sourceGroup.members)
+					if len(candidateStops[sourceDriverID]) == 0 {
+						candidateVisited := maps.Clone(visited)
+						candidateVisited[emptyDriverID] = struct{}{}
+						if err := search(sourceDriverID, candidateStops, candidateVisited); err != nil {
+							return err
+						}
+						sourcePosition += groupSize
+						continue
+					}
+
+					candidateMetrics := make(map[int64]routeObjectiveMetrics, len(orderedDriverIDs))
+					for _, driverID := range orderedDriverIDs {
+						metrics, err := rc.evaluateRouteObjective(ctx, routes[driverID].driver, candidateStops[driverID])
+						if err != nil {
+							return err
+						}
+						candidateMetrics[driverID] = metrics
+					}
+					candidateScore := scoreSolution(candidateMetrics, orderedDriverIDs)
+					if candidateScore.betterThan(currentScore) && (!best.found || candidateScore.betterThan(best.score)) {
+						best = nonemptyRouteRepair{stops: candidateStops, score: candidateScore, found: true}
+					}
+					sourcePosition += groupSize
+				}
+			}
+			return nil
+		}
+
+		for _, emptyDriverID := range orderedDriverIDs {
+			if len(baseStops[emptyDriverID]) != 0 {
+				continue
+			}
+			if err := search(emptyDriverID, baseStops, map[int64]struct{}{}); err != nil {
+				return repairs, err
+			}
+		}
+		if !best.found {
+			return repairs, nil
+		}
+		for _, driverID := range orderedDriverIDs {
+			routes[driverID].stops = best.stops[driverID]
+		}
+		repairs++
+	}
 }
 
 // roundRobinInsertion assigns participants by cycling through drivers
@@ -332,10 +623,12 @@ type routeObjectiveMetrics struct {
 	aggregateParticipantCompletion float64
 	driverDetour                   float64
 	driveDuration                  float64
+	corridorSpread                 int
 	used                           bool
 }
 
 type solutionScore struct {
+	corridorSpread                 int
 	latestParticipantCompletion    float64
 	maxDriverDetour                float64
 	aggregateParticipantCompletion float64
@@ -344,6 +637,13 @@ type solutionScore struct {
 }
 
 func (score solutionScore) betterThan(other solutionScore) bool {
+	if score.usedDrivers != other.usedDrivers {
+		return score.usedDrivers > other.usedDrivers
+	}
+	if score.corridorSpread != other.corridorSpread {
+		return score.corridorSpread < other.corridorSpread
+	}
+
 	for _, values := range [][2]float64{
 		{score.latestParticipantCompletion, other.latestParticipantCompletion},
 		{score.maxDriverDetour, other.maxDriverDetour},
@@ -358,7 +658,7 @@ func (score solutionScore) betterThan(other solutionScore) bool {
 		}
 	}
 
-	return score.usedDrivers > other.usedDrivers
+	return false
 }
 
 func (rc routeContext) evaluateRouteObjective(ctx context.Context, driver *models.Driver, stops []*models.Participant) (routeObjectiveMetrics, error) {
@@ -374,7 +674,10 @@ func (rc routeContext) evaluateRouteObjective(ctx context.Context, driver *model
 	result := routeObjectiveMetrics{
 		driverDetour:  metrics.DetourSecs,
 		driveDuration: metrics.RouteDurationSecs,
-		used:          true,
+		corridorSpread: int(math.Round(
+			routeCorridorSpread(rc.instituteCoords, stops) / 10.0,
+		)),
+		used: true,
 	}
 	if rc.mode == RouteModePickup {
 		result.latestParticipantCompletion = metrics.RouteDurationSecs
@@ -400,12 +703,39 @@ func scoreSolution(routeMetrics map[int64]routeObjectiveMetrics, driverIDs []int
 		result.maxDriverDetour = max(result.maxDriverDetour, metrics.driverDetour)
 		result.aggregateParticipantCompletion += metrics.aggregateParticipantCompletion
 		result.aggregateDriveDuration += metrics.driveDuration
+		result.corridorSpread += metrics.corridorSpread
 		result.usedDrivers++
 	}
 	if result.usedDrivers == 0 {
 		result.maxDriverDetour = 0
 	}
 	return result
+}
+
+func bearingFromInstitute(institute, coordinate models.Coordinates) float64 {
+	instituteLatitudeRadians := institute.Lat * math.Pi / 180
+	deltaLatitude := coordinate.Lat - institute.Lat
+	deltaLongitude := math.Remainder(coordinate.Lng-institute.Lng, 360)
+	bearing := math.Atan2(deltaLongitude*math.Cos(instituteLatitudeRadians), deltaLatitude) * 180 / math.Pi
+	return math.Mod(bearing+360, 360)
+}
+
+func routeCorridorSpread(institute models.Coordinates, stops []*models.Participant) float64 {
+	if len(stops) <= 1 {
+		return 0
+	}
+
+	bearings := make([]float64, len(stops))
+	for i, stop := range stops {
+		bearings[i] = bearingFromInstitute(institute, stop.GetCoords())
+	}
+	sort.Float64s(bearings)
+
+	largestGap := bearings[0] + 360 - bearings[len(bearings)-1]
+	for i := 1; i < len(bearings); i++ {
+		largestGap = max(largestGap, bearings[i]-bearings[i-1])
+	}
+	return 360 - largestGap
 }
 
 func (rc routeContext) optimizeRouteOrders(ctx context.Context, routes map[int64]*balancedRoute, driverIDs []int64) error {
@@ -535,12 +865,14 @@ func optimizeAssignments(ctx context.Context, rc routeContext, routes map[int64]
 		best := assignmentChange{}
 		budgetExhausted := false
 
-		consider := func(firstDriverID, secondDriverID int64, firstStops, secondStops []*models.Participant) error {
-			if candidateEvaluations >= maxAssignmentCandidateEvaluations {
-				budgetExhausted = true
-				return nil
+		consider := func(firstDriverID, secondDriverID int64, firstStops, secondStops []*models.Participant, countsTowardBudget bool) error {
+			if countsTowardBudget {
+				if candidateEvaluations >= maxAssignmentCandidateEvaluations {
+					budgetExhausted = true
+					return nil
+				}
+				candidateEvaluations++
 			}
-			candidateEvaluations++
 
 			optimizedStops, _, candidateScore, err := rc.optimizeStopsForSolution(
 				ctx,
@@ -570,73 +902,101 @@ func optimizeAssignments(ctx context.Context, rc routeContext, routes map[int64]
 			return nil
 		}
 
-	relocationSearch:
+		// These relocations necessarily increase usedDrivers. Evaluate them before
+		// the bounded lower-tier neighborhood so the candidate budget can never
+		// hide the objective's highest-priority improvement.
 		for _, sourceDriverID := range driverIDs {
 			sourceRoute := routes[sourceDriverID]
 			sourceBlocks := routeHouseholdBlocks(sourceRoute.stops)
+			if len(sourceBlocks) < 2 {
+				continue
+			}
 			sourcePosition := 0
 			for _, sourceGroup := range sourceBlocks {
 				groupSize := len(sourceGroup.members)
 				for _, destinationDriverID := range driverIDs {
-					if destinationDriverID == sourceDriverID {
-						continue
-					}
 					destinationRoute := routes[destinationDriverID]
-					if len(destinationRoute.stops)+groupSize > destinationRoute.driver.VehicleCapacity {
+					if len(destinationRoute.stops) != 0 || groupSize > destinationRoute.driver.VehicleCapacity {
 						continue
 					}
-
-					for _, destinationPosition := range householdBoundaryPositions(destinationRoute.stops) {
-						newSourceStops := removeRange(sourceRoute.stops, sourcePosition, sourcePosition+groupSize)
-						newDestinationStops := insertGroupAt(destinationRoute.stops, sourceGroup, destinationPosition)
-						if err := consider(sourceDriverID, destinationDriverID, newSourceStops, newDestinationStops); err != nil {
-							return iteration, err
-						}
-						if budgetExhausted {
-							break relocationSearch
-						}
+					newSourceStops := removeRange(sourceRoute.stops, sourcePosition, sourcePosition+groupSize)
+					newDestinationStops := slices.Clone(sourceGroup.members)
+					if err := consider(sourceDriverID, destinationDriverID, newSourceStops, newDestinationStops, false); err != nil {
+						return iteration, err
 					}
 				}
 				sourcePosition += groupSize
 			}
 		}
 
-	swapSearch:
-		for firstIndex, firstDriverID := range driverIDs {
-			if budgetExhausted {
-				break
-			}
-			firstRoute := routes[firstDriverID]
-			firstPosition := 0
-			for _, firstGroup := range routeHouseholdBlocks(firstRoute.stops) {
-				firstSize := len(firstGroup.members)
-				for _, secondDriverID := range driverIDs[firstIndex+1:] {
-					secondRoute := routes[secondDriverID]
-					secondPosition := 0
-					for _, secondGroup := range routeHouseholdBlocks(secondRoute.stops) {
-						secondSize := len(secondGroup.members)
-						if len(firstRoute.stops)-firstSize+secondSize <= firstRoute.driver.VehicleCapacity &&
-							len(secondRoute.stops)-secondSize+firstSize <= secondRoute.driver.VehicleCapacity {
-							newFirstStops := replaceRangeWithGroup(firstRoute.stops, firstPosition, firstPosition+firstSize, secondGroup)
-							newSecondStops := replaceRangeWithGroup(secondRoute.stops, secondPosition, secondPosition+secondSize, firstGroup)
-							if err := consider(firstDriverID, secondDriverID, newFirstStops, newSecondStops); err != nil {
+		if !best.found {
+		relocationSearch:
+			for _, sourceDriverID := range driverIDs {
+				sourceRoute := routes[sourceDriverID]
+				sourceBlocks := routeHouseholdBlocks(sourceRoute.stops)
+				sourcePosition := 0
+				for _, sourceGroup := range sourceBlocks {
+					groupSize := len(sourceGroup.members)
+					for _, destinationDriverID := range driverIDs {
+						if destinationDriverID == sourceDriverID {
+							continue
+						}
+						destinationRoute := routes[destinationDriverID]
+						if len(destinationRoute.stops)+groupSize > destinationRoute.driver.VehicleCapacity {
+							continue
+						}
+
+						for _, destinationPosition := range householdBoundaryPositions(destinationRoute.stops) {
+							newSourceStops := removeRange(sourceRoute.stops, sourcePosition, sourcePosition+groupSize)
+							newDestinationStops := insertGroupAt(destinationRoute.stops, sourceGroup, destinationPosition)
+							if err := consider(sourceDriverID, destinationDriverID, newSourceStops, newDestinationStops, true); err != nil {
 								return iteration, err
 							}
 							if budgetExhausted {
-								break swapSearch
+								break relocationSearch
 							}
 						}
-						secondPosition += secondSize
 					}
+					sourcePosition += groupSize
 				}
-				firstPosition += firstSize
+			}
+
+		swapSearch:
+			for firstIndex, firstDriverID := range driverIDs {
+				if budgetExhausted {
+					break
+				}
+				firstRoute := routes[firstDriverID]
+				firstPosition := 0
+				for _, firstGroup := range routeHouseholdBlocks(firstRoute.stops) {
+					firstSize := len(firstGroup.members)
+					for _, secondDriverID := range driverIDs[firstIndex+1:] {
+						secondRoute := routes[secondDriverID]
+						secondPosition := 0
+						for _, secondGroup := range routeHouseholdBlocks(secondRoute.stops) {
+							secondSize := len(secondGroup.members)
+							if len(firstRoute.stops)-firstSize+secondSize <= firstRoute.driver.VehicleCapacity &&
+								len(secondRoute.stops)-secondSize+firstSize <= secondRoute.driver.VehicleCapacity {
+								newFirstStops := replaceRangeWithGroup(firstRoute.stops, firstPosition, firstPosition+firstSize, secondGroup)
+								newSecondStops := replaceRangeWithGroup(secondRoute.stops, secondPosition, secondPosition+secondSize, firstGroup)
+								if err := consider(firstDriverID, secondDriverID, newFirstStops, newSecondStops, true); err != nil {
+									return iteration, err
+								}
+								if budgetExhausted {
+									break swapSearch
+								}
+							}
+							secondPosition += secondSize
+						}
+					}
+					firstPosition += firstSize
+				}
 			}
 		}
 
 		if !best.found {
 			return iteration, nil
 		}
-
 		firstRoute := routes[best.firstDriverID]
 		secondRoute := routes[best.secondDriverID]
 		firstRoute.stops = best.firstStops
@@ -744,27 +1104,26 @@ type participantGroup struct {
 	lng     float64
 }
 
-// groupParticipantsByAddress groups participants by their address coordinates
-// Participants with the same rounded lat/lng are considered to be from the same household
+// groupParticipantsByAddress groups participants by normalized address, falling
+// back to rounded coordinates when an address is unavailable.
 func groupParticipantsByAddress(participants []*models.Participant) []*participantGroup {
-	// Map address coordinates to group
-	addressMap := make(map[string]*participantGroup)
+	householdMap := make(map[string]*participantGroup)
 
 	for _, p := range participants {
 		key := householdKey(p)
 
-		if group, exists := addressMap[key]; exists {
+		if group, exists := householdMap[key]; exists {
 			// Add to existing group
 			group.members = append(group.members, p)
 		} else {
 			// Create new group
-			addressMap[key] = newParticipantGroup(p)
+			householdMap[key] = newParticipantGroup(p)
 		}
 	}
 
 	// Convert map to slice
-	groups := make([]*participantGroup, 0, len(addressMap))
-	for _, group := range addressMap {
+	groups := make([]*participantGroup, 0, len(householdMap))
+	for _, group := range householdMap {
 		groups = append(groups, group)
 	}
 
@@ -784,9 +1143,16 @@ func coordinateKey(lat, lng float64) string {
 	return fmt.Sprintf("%.5f,%.5f", lat, lng)
 }
 
+func normalizeAddress(address string) string {
+	return strings.ToLower(strings.Join(strings.Fields(address), " "))
+}
+
 func householdKey(participant *models.Participant) string {
 	if participant == nil {
 		return ""
+	}
+	if address := normalizeAddress(participant.Address); address != "" {
+		return "addr:" + address
 	}
 	return coordinateKey(models.RoundCoordinate(participant.Lat), models.RoundCoordinate(participant.Lng))
 }
@@ -794,6 +1160,12 @@ func householdKey(participant *models.Participant) string {
 func participantGroupKey(group *participantGroup) string {
 	if group == nil {
 		return ""
+	}
+	if len(group.members) > 0 {
+		return householdKey(group.members[0])
+	}
+	if address := normalizeAddress(group.address); address != "" {
+		return "addr:" + address
 	}
 	return coordinateKey(group.lat, group.lng)
 }

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -15,7 +15,8 @@ import (
 )
 
 // BalancedRouter assigns participants under vehicle and household constraints,
-// then improves the complete solution using the participant-first objective.
+// then improves the complete solution with driver utilization first, corridor
+// coherence second, and time tiers last.
 type BalancedRouter struct {
 	distanceCalc distance.SolveSource
 }
@@ -23,9 +24,11 @@ type BalancedRouter struct {
 const (
 	scoreImprovementEpsilon           = 0.001
 	maxAssignmentCandidateEvaluations = 10000
+	maxNonemptyRouteSearchNodes       = 10000
 )
 
-// NewBalancedRouter creates a participant-first bounded-search router.
+// NewBalancedRouter creates a bounded-search router that prioritizes driver
+// utilization first, corridor coherence second, and time tiers last.
 func NewBalancedRouter(distanceCalc distance.SolveSource) Router {
 	return &BalancedRouter{
 		distanceCalc: distanceCalc,
@@ -86,8 +89,8 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 		unassigned[i] = &req.Participants[i]
 	}
 
-	// Phase 1: Build a feasible rider-score seed. The complete lexicographic
-	// objective is applied by the ordering and assignment phases below.
+	// Phase 1: Build a feasible bearing-sweep seed. Later phases apply driver
+	// utilization first, corridor coherence second, and time tiers last.
 	phase1Start := time.Now()
 	seedName := "bearing-sweep"
 	if r.bearingSweepInsertion(req.InstituteCoords, routes, driverIDs, unassigned) {
@@ -352,12 +355,32 @@ func (r *BalancedRouter) maximizeNonemptyRoutes(ctx context.Context, rc routeCon
 	orderedDriverIDs := slices.Clone(driverIDs)
 	slices.Sort(orderedDriverIDs)
 	repairs := 0
+	searchNodes := 0
+	budgetExhausted := false
+
+	hasUnvisitedMultiBlockRoute := func(stops map[int64][]*models.Participant, visited map[int64]struct{}) bool {
+		for _, driverID := range orderedDriverIDs {
+			if _, alreadyVisited := visited[driverID]; alreadyVisited {
+				continue
+			}
+			if len(routeHouseholdBlocks(stops[driverID])) >= 2 {
+				return true
+			}
+		}
+		return false
+	}
 
 	for {
 		baseStops := make(map[int64][]*models.Participant, len(orderedDriverIDs))
-		baseMetrics := make(map[int64]routeObjectiveMetrics, len(orderedDriverIDs))
 		for _, driverID := range orderedDriverIDs {
 			baseStops[driverID] = slices.Clone(routes[driverID].stops)
+		}
+		if !hasUnvisitedMultiBlockRoute(baseStops, nil) {
+			return repairs, nil
+		}
+
+		baseMetrics := make(map[int64]routeObjectiveMetrics, len(orderedDriverIDs))
+		for _, driverID := range orderedDriverIDs {
 			metrics, err := rc.evaluateRouteObjective(ctx, routes[driverID].driver, routes[driverID].stops)
 			if err != nil {
 				return repairs, err
@@ -369,7 +392,16 @@ func (r *BalancedRouter) maximizeNonemptyRoutes(ctx context.Context, rc routeCon
 
 		var search func(int64, map[int64][]*models.Participant, map[int64]struct{}) error
 		search = func(emptyDriverID int64, workingStops map[int64][]*models.Participant, visited map[int64]struct{}) error {
+			if searchNodes >= maxNonemptyRouteSearchNodes {
+				budgetExhausted = true
+				return nil
+			}
+			searchNodes++
+
 			for _, sourceDriverID := range orderedDriverIDs {
+				if budgetExhausted {
+					return nil
+				}
 				if sourceDriverID == emptyDriverID {
 					continue
 				}
@@ -391,6 +423,10 @@ func (r *BalancedRouter) maximizeNonemptyRoutes(ctx context.Context, rc routeCon
 					if len(candidateStops[sourceDriverID]) == 0 {
 						candidateVisited := maps.Clone(visited)
 						candidateVisited[emptyDriverID] = struct{}{}
+						if !hasUnvisitedMultiBlockRoute(candidateStops, candidateVisited) {
+							sourcePosition += groupSize
+							continue
+						}
 						if err := search(sourceDriverID, candidateStops, candidateVisited); err != nil {
 							return err
 						}
@@ -420,8 +456,14 @@ func (r *BalancedRouter) maximizeNonemptyRoutes(ctx context.Context, rc routeCon
 			if len(baseStops[emptyDriverID]) != 0 {
 				continue
 			}
+			if !hasUnvisitedMultiBlockRoute(baseStops, nil) {
+				return repairs, nil
+			}
 			if err := search(emptyDriverID, baseStops, map[int64]struct{}{}); err != nil {
 				return repairs, err
+			}
+			if budgetExhausted {
+				break
 			}
 		}
 		if !best.found {
@@ -431,6 +473,9 @@ func (r *BalancedRouter) maximizeNonemptyRoutes(ctx context.Context, rc routeCon
 			routes[driverID].stops = best.stops[driverID]
 		}
 		repairs++
+		if budgetExhausted {
+			return repairs, nil
+		}
 	}
 }
 

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -8,6 +8,7 @@ import (
 	"ride-home-router/internal/models"
 	"slices"
 	"testing"
+	"time"
 )
 
 type countingSolveDistanceCalculator struct {
@@ -531,6 +532,44 @@ func TestMaximizeNonemptyRoutes_UsesAugmentingRelocationChain(t *testing.T) {
 				t.Fatalf("cap-2 driver household split: %q/%q", routes[2].stops[0].Address, routes[2].stops[1].Address)
 			}
 		})
+	}
+}
+
+func TestMaximizeNonemptyRoutes_AllSingletonRoutesReturnQuickly(t *testing.T) {
+	const singletonCount = 6
+
+	routes := make(map[int64]*balancedRoute, singletonCount+1)
+	driverIDs := make([]int64, 0, singletonCount+1)
+	for id := int64(1); id <= singletonCount+1; id++ {
+		driver := driverAtBearing(id, float64(id), 1)
+		route := &balancedRoute{driver: driver}
+		if id <= singletonCount {
+			route.stops = []*models.Participant{{
+				ID:      id,
+				Name:    fmt.Sprintf("Rider %d", id),
+				Address: fmt.Sprintf("Household %d", id),
+			}}
+		}
+		routes[id] = route
+		driverIDs = append(driverIDs, id)
+	}
+
+	started := time.Now()
+	repairs, err := (&BalancedRouter{}).maximizeNonemptyRoutes(
+		context.Background(),
+		newRouteContext(stableDistanceCalculator{}, models.Coordinates{}, RouteModeDropoff),
+		routes,
+		driverIDs,
+	)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("maximizeNonemptyRoutes() error = %v", err)
+	}
+	if repairs != 0 {
+		t.Fatalf("repair count = %d, want 0", repairs)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("maximizeNonemptyRoutes() took %v, want under 1s", elapsed)
 	}
 }
 

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -3,8 +3,10 @@ package routing
 import (
 	"context"
 	"fmt"
+	"math"
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
+	"slices"
 	"testing"
 )
 
@@ -81,6 +83,101 @@ func TestGroupParticipantsByAddress_SlightlyDifferentCoordinates(t *testing.T) {
 	// Charlie should be in a different group (rounds to 40.12355, -74.12355)
 	if len(groups) != 2 {
 		t.Errorf("expected 2 groups, got %d", len(groups))
+	}
+}
+
+func TestGroupParticipantsByAddress_SameNormalizedAddressWithDifferentCoordinates(t *testing.T) {
+	participants := []*models.Participant{
+		{ID: 1, Name: "Alice", Address: "123 Main St", Lat: 40.12345, Lng: -74.12345},
+		{ID: 2, Name: "Bob", Address: "123 Main St", Lat: 40.22345, Lng: -74.22345},
+	}
+
+	groups := groupParticipantsByAddress(participants)
+	if len(groups) != 1 {
+		t.Fatalf("group count = %d, want 1", len(groups))
+	}
+	if len(groups[0].members) != 2 {
+		t.Fatalf("group member count = %d, want 2", len(groups[0].members))
+	}
+	if groups[0].lat != models.RoundCoordinate(participants[0].Lat) || groups[0].lng != models.RoundCoordinate(participants[0].Lng) {
+		t.Fatalf("group coordinates = (%f, %f), want first member coordinates", groups[0].lat, groups[0].lng)
+	}
+
+	router := NewBalancedRouter(newMockDistanceAdapter())
+	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
+		InstituteCoords: models.Coordinates{},
+		Participants: []models.Participant{
+			*participants[0],
+			*participants[1],
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "Driver1", VehicleCapacity: 2},
+			{ID: 2, Name: "Driver2", VehicleCapacity: 2},
+		},
+		Mode: RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+
+	assignedDriver := make(map[int64]int64)
+	for _, route := range result.Routes {
+		for _, stop := range route.Stops {
+			assignedDriver[stop.Participant.ID] = route.Driver.ID
+		}
+	}
+	if assignedDriver[1] == 0 || assignedDriver[1] != assignedDriver[2] {
+		t.Fatalf("same-address participants assigned to drivers %d and %d, want one driver", assignedDriver[1], assignedDriver[2])
+	}
+}
+
+func TestGroupParticipantsByAddress_DifferentAddressesWithIdenticalCoordinates(t *testing.T) {
+	participants := []*models.Participant{
+		{ID: 1, Address: "Apartment 1", Lat: 40.12345, Lng: -74.12345},
+		{ID: 2, Address: "Apartment 2", Lat: 40.12345, Lng: -74.12345},
+	}
+
+	groups := groupParticipantsByAddress(participants)
+	if len(groups) != 2 {
+		t.Fatalf("group count = %d, want 2", len(groups))
+	}
+	if householdKey(participants[0]) == householdKey(participants[1]) {
+		t.Fatal("different non-blank addresses produced the same household key")
+	}
+}
+
+func TestGroupParticipantsByAddress_NormalizesAddressCaseAndWhitespace(t *testing.T) {
+	participants := []*models.Participant{
+		{ID: 1, Address: "  123  MAIN\tSt\n", Lat: 1, Lng: 1},
+		{ID: 2, Address: "123 main st", Lat: 2, Lng: 2},
+	}
+
+	groups := groupParticipantsByAddress(participants)
+	if len(groups) != 1 {
+		t.Fatalf("group count = %d, want 1", len(groups))
+	}
+	if got := householdKey(participants[0]); got != "addr:123 main st" {
+		t.Fatalf("household key = %q, want %q", got, "addr:123 main st")
+	}
+}
+
+func TestGroupParticipantsByAddress_EmptyAddressFallsBackToCoordinates(t *testing.T) {
+	participants := []*models.Participant{
+		{ID: 1, Address: "", Lat: 40.123450, Lng: -74.123450},
+		{ID: 2, Address: " \t\n", Lat: 40.123454, Lng: -74.123454},
+	}
+
+	groups := groupParticipantsByAddress(participants)
+	if len(groups) != 1 {
+		t.Fatalf("group count = %d, want 1", len(groups))
+	}
+	coordinateHouseholdKey := householdKey(participants[0])
+	if coordinateHouseholdKey != coordinateKey(40.12345, -74.12345) {
+		got := coordinateHouseholdKey
+		t.Fatalf("household key = %q, want coordinate fallback", got)
+	}
+	if householdKey(&models.Participant{Address: coordinateKey(40.12345, -74.12345)}) == coordinateHouseholdKey {
+		t.Fatal("address and coordinate household key spaces collided")
 	}
 }
 
@@ -286,6 +383,315 @@ func TestRoundRobinInsertion_ReservesOnlyFittingVehicleForHousehold(t *testing.T
 	}
 	if got := len(routes[smallDriver.ID].stops); got != 1 {
 		t.Fatalf("small driver stop count = %d, want solo rider", got)
+	}
+}
+
+func TestBearingSweepInsertion_AssignsClearBearingClustersToMatchingDrivers(t *testing.T) {
+	routes, participants := bearingSweepFixture(
+		[]float64{85, 95, 265, 275},
+		[]bearingSweepDriver{{id: 1, bearing: 90, capacity: 2}, {id: 2, bearing: 270, capacity: 2}},
+	)
+
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(models.Coordinates{}, routes, []int64{1, 2}, participants); !ok {
+		t.Fatal("bearingSweepInsertion() failed, want a complete sweep seed")
+	}
+	assertSweepRouteParticipantIDs(t, routes[1], 1, 2)
+	assertSweepRouteParticipantIDs(t, routes[2], 3, 4)
+}
+
+func TestBearingSweepInsertion_MatchesDriverByHomeBearingNotDriverOrder(t *testing.T) {
+	routes, participants := bearingSweepFixture(
+		[]float64{85, 95, 265, 275},
+		[]bearingSweepDriver{{id: 1, bearing: 270, capacity: 2}, {id: 2, bearing: 90, capacity: 2}},
+	)
+
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(models.Coordinates{}, routes, []int64{1, 2}, participants); !ok {
+		t.Fatal("bearingSweepInsertion() failed, want a complete sweep seed")
+	}
+	assertSweepRouteParticipantIDs(t, routes[2], 1, 2)
+	assertSweepRouteParticipantIDs(t, routes[1], 3, 4)
+}
+
+func TestBearingSweepInsertion_KeepsWraparoundClusterContiguous(t *testing.T) {
+	routes, participants := bearingSweepFixture(
+		[]float64{350, 355, 5, 10},
+		[]bearingSweepDriver{{id: 1, bearing: 355, capacity: 2}, {id: 2, bearing: 5, capacity: 2}},
+	)
+
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(models.Coordinates{}, routes, []int64{1, 2}, participants); !ok {
+		t.Fatal("bearingSweepInsertion() failed, want a complete sweep seed")
+	}
+	assertSweepRouteParticipantIDs(t, routes[1], 1, 2)
+	assertSweepRouteParticipantIDs(t, routes[2], 3, 4)
+}
+
+func TestBearingSweepInsertion_ReservesOneGroupPerRemainingDriver(t *testing.T) {
+	routes, participants := bearingSweepFixture(
+		[]float64{0, 10, 20},
+		[]bearingSweepDriver{{id: 1, bearing: 0, capacity: 3}, {id: 2, bearing: 10, capacity: 3}, {id: 3, bearing: 20, capacity: 3}},
+	)
+
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(models.Coordinates{}, routes, []int64{1, 2, 3}, participants); !ok {
+		t.Fatal("bearingSweepInsertion() failed, want a complete sweep seed")
+	}
+	for _, driverID := range []int64{1, 2, 3} {
+		if got := len(routes[driverID].stops); got != 1 {
+			t.Fatalf("driver %d stop count = %d, want 1", driverID, got)
+		}
+	}
+}
+
+func TestBearingSweepInsertion_DeterministicTieBreaks(t *testing.T) {
+	participants := participantsAtBearings(0, 90, 180, 270)
+	for i, participant := range participants {
+		participant.Address = fmt.Sprintf("Household %d", i+1)
+	}
+	groups := bearingSweepGroups(models.Coordinates{}, participants)
+	for i, group := range groups {
+		if got, want := group.members[0].ID, int64(i+1); got != want {
+			t.Fatalf("equal-gap sweep group %d ID = %d, want household-key order ID %d", i, got, want)
+		}
+	}
+
+	routes, oneGroup := bearingSweepFixture(
+		[]float64{0},
+		[]bearingSweepDriver{{id: 2, bearing: 0, capacity: 1}, {id: 1, bearing: 0, capacity: 1}},
+	)
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(models.Coordinates{}, routes, []int64{2, 1}, oneGroup); !ok {
+		t.Fatal("bearingSweepInsertion() failed, want a complete sweep seed")
+	}
+	assertSweepRouteParticipantIDs(t, routes[1], 1)
+}
+
+func TestBearingSweepInsertion_DoesNotBurnDriverOnUnfittingGroup(t *testing.T) {
+	institute := models.Coordinates{}
+	groupCoords := participantAtBearing(1, 0).GetCoords()
+	soloCoords := participantAtBearing(3, 10).GetCoords()
+	participants := []*models.Participant{
+		{ID: 1, Name: "Group 1", Address: "Shared", Lat: groupCoords.Lat, Lng: groupCoords.Lng},
+		{ID: 2, Name: "Group 2", Address: "Shared", Lat: groupCoords.Lat, Lng: groupCoords.Lng},
+		{ID: 3, Name: "Solo", Address: "Solo", Lat: soloCoords.Lat, Lng: soloCoords.Lng},
+	}
+	small := driverAtBearing(1, 0, 1)
+	large := driverAtBearing(2, 10, 2)
+	routes := map[int64]*balancedRoute{
+		small.ID: {driver: small},
+		large.ID: {driver: large},
+	}
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(institute, routes, []int64{small.ID, large.ID}, participants); !ok {
+		t.Fatal("bearingSweepInsertion() failed after the small driver rejected only the oversized group")
+	}
+	assertSweepRouteParticipantIDs(t, routes[small.ID], 3)
+	assertSweepRouteParticipantIDs(t, routes[large.ID], 1, 2)
+}
+
+func TestMaximizeNonemptyRoutes_UsesAugmentingRelocationChain(t *testing.T) {
+	for _, mode := range []RouteMode{RouteModeDropoff, RouteModePickup} {
+		t.Run(string(mode), func(t *testing.T) {
+			groupA := participantAtBearing(1, 0).GetCoords()
+			groupB := participantAtBearing(3, 10).GetCoords()
+			groupC := participantAtBearing(5, 20).GetCoords()
+			participants := []*models.Participant{
+				{ID: 1, Name: "A1", Address: "A", Lat: groupA.Lat, Lng: groupA.Lng},
+				{ID: 2, Name: "A2", Address: "A", Lat: groupA.Lat, Lng: groupA.Lng},
+				{ID: 3, Name: "B1", Address: "B", Lat: groupB.Lat, Lng: groupB.Lng},
+				{ID: 4, Name: "B2", Address: "B", Lat: groupB.Lat, Lng: groupB.Lng},
+				{ID: 5, Name: "C", Address: "C", Lat: groupC.Lat, Lng: groupC.Lng},
+			}
+			drivers := []*models.Driver{
+				driverAtBearing(1, 30, 4),
+				driverAtBearing(2, 20, 2),
+				driverAtBearing(3, 0, 1),
+			}
+			routes := map[int64]*balancedRoute{
+				1: {driver: drivers[0], stops: participants[:4]},
+				2: {driver: drivers[1], stops: participants[4:]},
+				3: {driver: drivers[2]},
+			}
+
+			repairs, err := (&BalancedRouter{}).maximizeNonemptyRoutes(
+				context.Background(),
+				newRouteContext(stableDistanceCalculator{}, models.Coordinates{}, mode),
+				routes,
+				[]int64{1, 2, 3},
+			)
+			if err != nil {
+				t.Fatalf("maximizeNonemptyRoutes() error = %v", err)
+			}
+			if repairs != 1 {
+				t.Fatalf("repair count = %d, want 1", repairs)
+			}
+			if len(routes[1].stops) != 2 || len(routes[2].stops) != 2 || len(routes[3].stops) != 1 {
+				t.Fatalf("route sizes = %d/%d/%d, want 2/2/1", len(routes[1].stops), len(routes[2].stops), len(routes[3].stops))
+			}
+			if routes[3].stops[0].Address != "C" {
+				t.Fatalf("cap-1 driver received household %q, want C", routes[3].stops[0].Address)
+			}
+			if routes[2].stops[0].Address != routes[2].stops[1].Address {
+				t.Fatalf("cap-2 driver household split: %q/%q", routes[2].stops[0].Address, routes[2].stops[1].Address)
+			}
+		})
+	}
+}
+
+func TestBalancedRouter_MaximizesDriversWithHeterogeneousCapacities(t *testing.T) {
+	for _, mode := range []RouteMode{RouteModeDropoff, RouteModePickup} {
+		t.Run(string(mode), func(t *testing.T) {
+			institute := models.Coordinates{}
+			groupA := participantAtBearing(1, 0).GetCoords()
+			groupB := participantAtBearing(3, 10).GetCoords()
+			groupC := participantAtBearing(5, 20).GetCoords()
+			drivers := []models.Driver{
+				*driverAtBearing(1, 30, 4),
+				*driverAtBearing(2, 20, 2),
+				*driverAtBearing(3, 0, 1),
+			}
+			distances := newOverrideDistanceAdapter(1000)
+			if mode == RouteModeDropoff {
+				distances.setDuration(institute, groupA, 1)
+				distances.setDuration(institute, groupB, 100)
+				distances.setDuration(institute, groupC, 3)
+			} else {
+				distances.setDuration(drivers[0].GetCoords(), groupA, 1)
+				distances.setDuration(drivers[0].GetCoords(), groupB, 100)
+				distances.setDuration(drivers[0].GetCoords(), groupC, 3)
+				distances.setDuration(drivers[1].GetCoords(), groupB, 100)
+				distances.setDuration(drivers[2].GetCoords(), groupC, 5000)
+				distances.setDuration(groupA, groupB, 1)
+				distances.setDuration(groupB, groupA, 1)
+				distances.setDuration(groupA, institute, 1)
+				distances.setDuration(groupB, institute, 1)
+				distances.setDuration(groupC, institute, 1)
+			}
+
+			result, err := NewBalancedRouter(distances).CalculateRoutes(context.Background(), &RoutingRequest{
+				InstituteCoords: institute,
+				Participants: []models.Participant{
+					{ID: 1, Name: "A1", Address: "A", Lat: groupA.Lat, Lng: groupA.Lng},
+					{ID: 2, Name: "A2", Address: "A", Lat: groupA.Lat, Lng: groupA.Lng},
+					{ID: 3, Name: "B1", Address: "B", Lat: groupB.Lat, Lng: groupB.Lng},
+					{ID: 4, Name: "B2", Address: "B", Lat: groupB.Lat, Lng: groupB.Lng},
+					{ID: 5, Name: "C", Address: "C", Lat: groupC.Lat, Lng: groupC.Lng},
+				},
+				Drivers: drivers,
+				Mode:    mode,
+			})
+			if err != nil {
+				t.Fatalf("CalculateRoutes() error = %v", err)
+			}
+
+			assertAllDriversUsedAndHouseholdsIntact(t, result, 3, map[string]int{"A": 2, "B": 2, "C": 1})
+		})
+	}
+}
+
+func TestBalancedRouter_HeterogeneousCapacityForcedFallbackUsesAllDrivers(t *testing.T) {
+	institute := models.Coordinates{}
+	groupA := participantAtBearing(1, 0).GetCoords()
+	groupB := participantAtBearing(3, 10).GetCoords()
+	groupC := participantAtBearing(5, 20).GetCoords()
+	participants := []*models.Participant{
+		{ID: 1, Name: "A1", Address: "A", Lat: groupA.Lat, Lng: groupA.Lng},
+		{ID: 2, Name: "A2", Address: "A", Lat: groupA.Lat, Lng: groupA.Lng},
+		{ID: 3, Name: "B1", Address: "B", Lat: groupB.Lat, Lng: groupB.Lng},
+		{ID: 4, Name: "B2", Address: "B", Lat: groupB.Lat, Lng: groupB.Lng},
+		{ID: 5, Name: "C", Address: "C", Lat: groupC.Lat, Lng: groupC.Lng},
+	}
+	drivers := []*models.Driver{
+		driverAtBearing(1, 0, 3),
+		driverAtBearing(2, 10, 2),
+	}
+	routes := map[int64]*balancedRoute{
+		drivers[0].ID: {driver: drivers[0]},
+		drivers[1].ID: {driver: drivers[1]},
+	}
+	if ok := (&BalancedRouter{}).bearingSweepInsertion(institute, routes, []int64{1, 2}, participants); ok {
+		t.Fatal("bearingSweepInsertion() succeeded, want a forced fallback for noncontiguous capacity packing")
+	}
+
+	result, err := NewBalancedRouter(stableDistanceCalculator{}).CalculateRoutes(context.Background(), &RoutingRequest{
+		InstituteCoords: institute,
+		Participants: []models.Participant{
+			*participants[0], *participants[1], *participants[2], *participants[3], *participants[4],
+		},
+		Drivers: []models.Driver{*drivers[0], *drivers[1]},
+		Mode:    RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+	assertAllDriversUsedAndHouseholdsIntact(t, result, 2, map[string]int{"A": 2, "B": 2, "C": 1})
+}
+
+func assertAllDriversUsedAndHouseholdsIntact(t *testing.T, result *models.RoutingResult, wantDrivers int, householdSizes map[string]int) {
+	t.Helper()
+	if result.Summary.TotalDriversUsed != wantDrivers {
+		t.Fatalf("drivers used = %d, want %d", result.Summary.TotalDriversUsed, wantDrivers)
+	}
+
+	householdDriver := make(map[string]int64, len(householdSizes))
+	householdCounts := make(map[string]int, len(householdSizes))
+	for _, route := range result.Routes {
+		if len(route.Stops) > route.Driver.VehicleCapacity {
+			t.Fatalf("driver %d has %d stops over capacity %d", route.Driver.ID, len(route.Stops), route.Driver.VehicleCapacity)
+		}
+		for _, stop := range route.Stops {
+			address := stop.Participant.Address
+			if previousDriver, seen := householdDriver[address]; seen && previousDriver != route.Driver.ID {
+				t.Fatalf("household %q split between drivers %d and %d", address, previousDriver, route.Driver.ID)
+			}
+			householdDriver[address] = route.Driver.ID
+			householdCounts[address]++
+		}
+	}
+	for address, want := range householdSizes {
+		if got := householdCounts[address]; got != want {
+			t.Fatalf("household %q assigned count = %d, want %d", address, got, want)
+		}
+	}
+}
+
+type bearingSweepDriver struct {
+	id       int64
+	bearing  float64
+	capacity int
+}
+
+func bearingSweepFixture(groupBearings []float64, drivers []bearingSweepDriver) (map[int64]*balancedRoute, []*models.Participant) {
+	participants := make([]*models.Participant, len(groupBearings))
+	for i, bearing := range groupBearings {
+		participant := participantAtBearing(int64(i+1), bearing)
+		participant.Address = fmt.Sprintf("Household %d", i+1)
+		participants[i] = participant
+	}
+
+	routes := make(map[int64]*balancedRoute, len(drivers))
+	for _, spec := range drivers {
+		driver := driverAtBearing(spec.id, spec.bearing, spec.capacity)
+		routes[spec.id] = &balancedRoute{driver: driver}
+	}
+	return routes, participants
+}
+
+func driverAtBearing(id int64, bearing float64, capacity int) *models.Driver {
+	radians := bearing * math.Pi / 180
+	return &models.Driver{
+		ID:              id,
+		Name:            fmt.Sprintf("Driver %d", id),
+		Lat:             math.Cos(radians),
+		Lng:             math.Sin(radians),
+		VehicleCapacity: capacity,
+	}
+}
+
+func assertSweepRouteParticipantIDs(t *testing.T, route *balancedRoute, want ...int64) {
+	t.Helper()
+	got := make([]int64, len(route.stops))
+	for i, stop := range route.stops {
+		got[i] = stop.ID
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("driver %d participant IDs = %v, want %v", route.driver.ID, got, want)
 	}
 }
 
@@ -499,7 +905,171 @@ func TestBalancedRouter_OrdersRoutesAgainstTheFullSolutionObjective(t *testing.T
 	}
 }
 
-func TestOptimizeAssignments_ReordersUntouchedPeerAfterGlobalMaximumChanges(t *testing.T) {
+func TestRouteCorridorSpread(t *testing.T) {
+	institute := models.Coordinates{}
+	tests := []struct {
+		name     string
+		bearings []float64
+		want     float64
+	}{
+		{name: "empty route", want: 0},
+		{name: "single stop", bearings: []float64{42}, want: 0},
+		{name: "wraparound", bearings: []float64{10, 350}, want: 20},
+		{name: "half circle", bearings: []float64{0, 90, 180}, want: 180},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stops := make([]*models.Participant, 0, len(tt.bearings))
+			for i, bearing := range tt.bearings {
+				stops = append(stops, participantAtBearing(int64(i+1), bearing))
+			}
+
+			got := routeCorridorSpread(institute, stops)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("routeCorridorSpread() = %.12f, want %.12f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBearingFromInstitute_NormalizesAntimeridianLongitudeDelta(t *testing.T) {
+	got := bearingFromInstitute(
+		models.Coordinates{Lat: 0, Lng: 179},
+		models.Coordinates{Lat: 1, Lng: -179},
+	)
+	const want = 63.43494882292201
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("bearingFromInstitute() = %.12f, want %.12f", got, want)
+	}
+}
+
+func TestRouteCorridorSpread_StraddlesAntimeridian(t *testing.T) {
+	institute := models.Coordinates{Lat: 0, Lng: 179}
+	stops := []*models.Participant{
+		{ID: 1, Address: "West", Lat: 1, Lng: 178.5},
+		{ID: 2, Address: "East", Lat: 1, Lng: -179.5},
+	}
+
+	got := routeCorridorSpread(institute, stops)
+	const want = 82.8749836510982
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("routeCorridorSpread() = %.12f, want %.12f", got, want)
+	}
+}
+
+func TestSolutionObjective_PrefersLowerCorridorSpreadOverFasterRoutes(t *testing.T) {
+	institute := models.Coordinates{}
+	participants := participantsAtBearings(0, 10, 90, 100)
+	driver1 := &models.Driver{ID: 1, Lat: -1, Lng: -1}
+	driver2 := &models.Driver{ID: 2, Lat: -2, Lng: -2}
+	distances := newOverrideDistanceAdapter(1)
+	distances.setDuration(participants[0].GetCoords(), participants[1].GetCoords(), 100)
+	distances.setDuration(participants[2].GetCoords(), participants[3].GetCoords(), 100)
+	rc := newRouteContext(distances, institute, RouteModeDropoff)
+
+	coherent := objectiveScoreForTest(t, rc,
+		objectiveTestRoute{driver: driver1, stops: participants[0:2]},
+		objectiveTestRoute{driver: driver2, stops: participants[2:4]},
+	)
+	zigzag := objectiveScoreForTest(t, rc,
+		objectiveTestRoute{driver: driver1, stops: []*models.Participant{participants[0], participants[2]}},
+		objectiveTestRoute{driver: driver2, stops: []*models.Participant{participants[1], participants[3]}},
+	)
+
+	if coherent.corridorSpread >= zigzag.corridorSpread {
+		t.Fatalf("coherent corridor spread = %d, want less than zigzag spread %d", coherent.corridorSpread, zigzag.corridorSpread)
+	}
+	if coherent.latestParticipantCompletion <= zigzag.latestParticipantCompletion {
+		t.Fatalf("coherent latest completion = %.0f, want slower than zigzag completion %.0f", coherent.latestParticipantCompletion, zigzag.latestParticipantCompletion)
+	}
+	if !coherent.betterThan(zigzag) {
+		t.Fatal("lower-spread solution did not beat faster zigzag solution")
+	}
+}
+
+func TestSolutionObjective_UsedDriversDominatesCorridorSpread(t *testing.T) {
+	institute := models.Coordinates{}
+	participants := participantsAtBearings(0, 10, 90, 100)
+	driver1 := &models.Driver{ID: 1, Lat: -1, Lng: -1}
+	driver2 := &models.Driver{ID: 2, Lat: -2, Lng: -2}
+	rc := newRouteContext(newOverrideDistanceAdapter(1), institute, RouteModeDropoff)
+
+	oneDriver := objectiveScoreForTest(t, rc,
+		objectiveTestRoute{driver: driver1, stops: participants},
+	)
+	twoDrivers := objectiveScoreForTest(t, rc,
+		objectiveTestRoute{driver: driver1, stops: []*models.Participant{participants[0], participants[2]}},
+		objectiveTestRoute{driver: driver2, stops: []*models.Participant{participants[1], participants[3]}},
+	)
+
+	if twoDrivers.corridorSpread <= oneDriver.corridorSpread {
+		t.Fatalf("two-driver corridor spread = %d, want greater than one-driver spread %d", twoDrivers.corridorSpread, oneDriver.corridorSpread)
+	}
+	if !twoDrivers.betterThan(oneDriver) {
+		t.Fatal("solution using more drivers did not win over its lower-spread alternative")
+	}
+}
+
+func TestSolutionObjective_SameCorridorBucketFallsThroughToTime(t *testing.T) {
+	institute := models.Coordinates{}
+	slowerStops := participantsAtBearings(0, 20)
+	fasterStops := participantsAtBearings(180, 204)
+	driver := &models.Driver{ID: 1, Lat: -1, Lng: -1}
+	distances := newOverrideDistanceAdapter(1)
+	distances.setDuration(slowerStops[0].GetCoords(), slowerStops[1].GetCoords(), 100)
+	rc := newRouteContext(distances, institute, RouteModeDropoff)
+
+	slower := objectiveScoreForTest(t, rc, objectiveTestRoute{driver: driver, stops: slowerStops})
+	faster := objectiveScoreForTest(t, rc, objectiveTestRoute{driver: driver, stops: fasterStops})
+
+	spreadDifference := routeCorridorSpread(institute, fasterStops) - routeCorridorSpread(institute, slowerStops)
+	if spreadDifference <= 0 || spreadDifference >= 10 {
+		t.Fatalf("raw spread difference = %.2f, want between 0 and 10 degrees", spreadDifference)
+	}
+	if slower.corridorSpread != faster.corridorSpread {
+		t.Fatalf("corridor buckets differ: slower = %d, faster = %d", slower.corridorSpread, faster.corridorSpread)
+	}
+	if !faster.betterThan(slower) {
+		t.Fatal("faster solution did not win after equal corridor buckets")
+	}
+}
+
+type objectiveTestRoute struct {
+	driver *models.Driver
+	stops  []*models.Participant
+}
+
+func objectiveScoreForTest(t *testing.T, rc routeContext, routes ...objectiveTestRoute) solutionScore {
+	t.Helper()
+
+	metrics := make(map[int64]routeObjectiveMetrics, len(routes))
+	driverIDs := make([]int64, 0, len(routes))
+	for _, route := range routes {
+		routeMetrics, err := rc.evaluateRouteObjective(context.Background(), route.driver, route.stops)
+		if err != nil {
+			t.Fatalf("evaluateRouteObjective() error = %v", err)
+		}
+		metrics[route.driver.ID] = routeMetrics
+		driverIDs = append(driverIDs, route.driver.ID)
+	}
+	return scoreSolution(metrics, driverIDs)
+}
+
+func participantsAtBearings(bearings ...float64) []*models.Participant {
+	participants := make([]*models.Participant, 0, len(bearings))
+	for i, bearing := range bearings {
+		participants = append(participants, participantAtBearing(int64(i+1), bearing))
+	}
+	return participants
+}
+
+func participantAtBearing(id int64, bearing float64) *models.Participant {
+	radians := bearing * math.Pi / 180
+	return &models.Participant{ID: id, Lat: math.Cos(radians), Lng: math.Sin(radians)}
+}
+
+func TestOptimizeAssignments_UsesTimeTieBreakerWhenDriverCountIsEqual(t *testing.T) {
 	ctx := context.Background()
 	activity := models.Coordinates{Lat: 0, Lng: 0}
 	x1 := &models.Participant{ID: 1, Name: "X1", Lat: 1, Lng: 0}
@@ -560,7 +1130,7 @@ func TestOptimizeAssignments_ReordersUntouchedPeerAfterGlobalMaximumChanges(t *t
 	}
 }
 
-func TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective(t *testing.T) {
+func TestBalancedRouter_UsesAllDriversEvenWhenConsolidationIsFaster(t *testing.T) {
 	activity := models.Coordinates{Lat: 0, Lng: 0}
 	first := models.Coordinates{Lat: 1, Lng: 0}
 	second := models.Coordinates{Lat: 2, Lng: 0}
@@ -582,8 +1152,8 @@ func TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective
 	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
 		InstituteCoords: activity,
 		Participants: []models.Participant{
-			{ID: 1, Name: "First", Lat: first.Lat, Lng: first.Lng},
-			{ID: 2, Name: "Second", Lat: second.Lat, Lng: second.Lng},
+			{ID: 1, Name: "First", Address: "1 First Street", Lat: first.Lat, Lng: first.Lng},
+			{ID: 2, Name: "Second", Address: "2 Second Street", Lat: second.Lat, Lng: second.Lng},
 		},
 		Drivers: []models.Driver{
 			{ID: 1, Name: "Nearby Driver", Lat: nearbyHome.Lat, Lng: nearbyHome.Lng, VehicleCapacity: 2},
@@ -595,35 +1165,49 @@ func TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective
 		t.Fatalf("CalculateRoutes() error = %v", err)
 	}
 
-	if result.Summary.TotalDriversUsed != 1 {
-		t.Fatalf("drivers used = %d, want 1 because an empty route removes the higher-priority detour", result.Summary.TotalDriversUsed)
+	if result.Summary.TotalDriversUsed != 2 {
+		t.Fatalf("drivers used = %d, want 2 despite the second driver's worse route", result.Summary.TotalDriversUsed)
 	}
-	if len(result.Routes) != 1 || result.Routes[0].Driver.ID != 1 {
-		t.Fatalf("routes = %+v, want only nearby driver 1", result.Routes)
+	if len(result.Routes) != 2 {
+		t.Fatalf("route count = %d, want 2", len(result.Routes))
 	}
-	if len(result.Routes[0].Stops) != 2 {
-		t.Fatalf("nearby driver stops = %d, want 2", len(result.Routes[0].Stops))
+	for _, route := range result.Routes {
+		if len(route.Stops) != 1 {
+			t.Fatalf("driver %d stops = %d, want exactly 1", route.Driver.ID, len(route.Stops))
+		}
 	}
-	if result.Summary.SumDetourSecs <= 0 {
-		t.Fatalf("sum detour = %.1f, want a nonzero fixture", result.Summary.SumDetourSecs)
-	}
-	if result.Summary.MaxDetourSecs != result.Summary.SumDetourSecs || result.Summary.AverageDetourSecs != result.Summary.SumDetourSecs {
-		t.Fatalf("unused driver affected detour summary divisor: %+v", result.Summary)
+	if result.Summary.MaxDetourSecs != 2 || result.Summary.SumDetourSecs != 4 || result.Summary.AverageDetourSecs != 2 {
+		t.Fatalf("detour summary = %+v, want max=2 sum=4 average=2", result.Summary)
 	}
 }
 
-func TestBalancedRouter_PrefersUsingMoreDriversOnlyAfterObjectiveTies(t *testing.T) {
-	router := NewBalancedRouter(newOverrideDistanceAdapter(0))
+func TestBalancedRouter_UsedDriversDominatesLatestCompletionAndDetour(t *testing.T) {
+	activity := models.Coordinates{Lat: 0, Lng: 0}
+	first := models.Coordinates{Lat: 1, Lng: 0}
+	second := models.Coordinates{Lat: 2, Lng: 0}
+	firstDriverHome := models.Coordinates{Lat: 10, Lng: 0}
+	secondDriverHome := models.Coordinates{Lat: 20, Lng: 0}
+	distances := newOverrideDistanceAdapter(1000)
+	distances.setDuration(activity, first, 1)
+	distances.setDuration(activity, second, 100)
+	distances.setDuration(first, second, 1)
+	distances.setDuration(second, first, 100)
+	distances.setDuration(activity, firstDriverHome, 10)
+	distances.setDuration(first, firstDriverHome, 9)
+	distances.setDuration(second, firstDriverHome, 8)
+	distances.setDuration(activity, secondDriverHome, 20)
+	distances.setDuration(second, secondDriverHome, 100)
+	router := NewBalancedRouter(distances)
 
 	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
-		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		InstituteCoords: activity,
 		Participants: []models.Participant{
-			{ID: 1, Name: "First", Lat: 1, Lng: 0},
-			{ID: 2, Name: "Second", Lat: 2, Lng: 0},
+			{ID: 1, Name: "First", Address: "1 First Street", Lat: first.Lat, Lng: first.Lng},
+			{ID: 2, Name: "Second", Address: "2 Second Street", Lat: second.Lat, Lng: second.Lng},
 		},
 		Drivers: []models.Driver{
-			{ID: 1, Name: "First Driver", Lat: 10, Lng: 0, VehicleCapacity: 2},
-			{ID: 2, Name: "Second Driver", Lat: 20, Lng: 0, VehicleCapacity: 2},
+			{ID: 1, Name: "First Driver", Lat: firstDriverHome.Lat, Lng: firstDriverHome.Lng, VehicleCapacity: 2},
+			{ID: 2, Name: "Second Driver", Lat: secondDriverHome.Lat, Lng: secondDriverHome.Lng, VehicleCapacity: 2},
 		},
 		Mode: RouteModeDropoff,
 	})
@@ -632,7 +1216,75 @@ func TestBalancedRouter_PrefersUsingMoreDriversOnlyAfterObjectiveTies(t *testing
 	}
 
 	if result.Summary.TotalDriversUsed != 2 {
-		t.Fatalf("drivers used = %d, want 2 when every higher-priority objective ties", result.Summary.TotalDriversUsed)
+		t.Fatalf("drivers used = %d, want 2 despite worse completion and detour", result.Summary.TotalDriversUsed)
+	}
+
+	latestCompletion := 0.0
+	maxDetour := 0.0
+	for _, route := range result.Routes {
+		for _, stop := range route.Stops {
+			latestCompletion = max(latestCompletion, stop.CumulativeDurationSecs)
+		}
+		maxDetour = max(maxDetour, route.DetourSecs)
+	}
+	if latestCompletion <= 2 {
+		t.Fatalf("latest completion = %.0f, want greater than consolidated completion 2", latestCompletion)
+	}
+	if maxDetour <= 0 {
+		t.Fatalf("max detour = %.0f, want greater than consolidated detour 0", maxDetour)
+	}
+}
+
+func TestBalancedRouter_SingleHouseholdUsesOnlyOneDriver(t *testing.T) {
+	router := NewBalancedRouter(stableDistanceCalculator{})
+
+	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
+		InstituteCoords: models.Coordinates{},
+		Participants: []models.Participant{
+			{ID: 1, Name: "First", Address: "1 Shared Street", Lat: 1},
+			{ID: 2, Name: "Second", Address: "1 Shared Street", Lat: 1},
+			{ID: 3, Name: "Third", Address: "1 Shared Street", Lat: 1},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "First Driver", Lat: 10, VehicleCapacity: 3},
+			{ID: 2, Name: "Second Driver", Lat: 20, VehicleCapacity: 3},
+		},
+		Mode: RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+
+	if result.Summary.TotalDriversUsed != 1 {
+		t.Fatalf("drivers used = %d, want 1 because the only household is atomic", result.Summary.TotalDriversUsed)
+	}
+	if len(result.Routes) != 1 || len(result.Routes[0].Stops) != 3 {
+		t.Fatalf("routes = %+v, want one route containing the whole household", result.Routes)
+	}
+}
+
+func TestBalancedRouter_ThreeHouseholdsUseBothDrivers(t *testing.T) {
+	router := NewBalancedRouter(stableDistanceCalculator{})
+
+	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
+		InstituteCoords: models.Coordinates{},
+		Participants: []models.Participant{
+			{ID: 1, Name: "First", Address: "1 First Street", Lat: 1},
+			{ID: 2, Name: "Second", Address: "2 Second Street", Lat: 2},
+			{ID: 3, Name: "Third", Address: "3 Third Street", Lat: 3},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "First Driver", Lat: 10, VehicleCapacity: 3},
+			{ID: 2, Name: "Second Driver", Lat: 20, VehicleCapacity: 3},
+		},
+		Mode: RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+
+	if result.Summary.TotalDriversUsed != 2 {
+		t.Fatalf("drivers used = %d, want 2 for three household groups", result.Summary.TotalDriversUsed)
 	}
 }
 


### PR DESCRIPTION
### Problem

The "balanced" router optimized a different set of goals than the ones we actually have. Households were inferred from lat/lng rounded to 5 decimals, so one address geocoded two ways split a family and unrelated neighbors merged. Used-driver count was the *last* lexicographic tie-breaker, so the optimizer deliberately consolidated riders and idled selected drivers (this was even pinned by tests). And nothing measured route shape, so drivers zigzagged between corridors whenever raw travel time scored well.

### Changes

- **Household identity**: `householdKey` now prefers `"addr:" + normalized(address)` (lowercased, whitespace-collapsed), falling back to rounded coordinates when the address is blank. All membership derivations (grouping, blocks, boundaries, coalescing) flow through the one function.
- **Objective reorder**: `betterThan` tiers are now usedDrivers (max) → corridorSpread (min) → latest participant completion → max driver detour → aggregate completion → aggregate duration.
- **Corridor spread**: per-route smallest circular arc containing stop bearings from the institute, quantized to 10° buckets, summed over used routes. Bearing math normalizes longitude deltas across the antimeridian.
- **Bearing-sweep seed**: phase 1 sorts household groups by bearing, starts after the largest circular gap, carves contiguous arcs matched to the unused driver with the nearest home bearing, and reserves ≥1 group per driver when groups ≥ drivers. Falls back to the retained round-robin seed on infeasibility, then a repair pass fills empty routes via chain relocations of household blocks.
- **Phase 3 budget fix**: usedDrivers-increasing relocations (multi-block route → empty route) are evaluated before the 10k-candidate budget, so consolidation can never hide the top-priority improvement.

### Decisions

- Ride time is deliberately subordinated: the owner accepted trading participant completion time for full driver utilization and corridor coherence.
- When there are fewer household groups than drivers, idling drivers is correct (households are atomic).
- Households larger than every selected vehicle keep the existing splitting behavior.
- Corridor spread uses 10° buckets so sub-bucket angular noise falls through to the time tiers.

### Testing

- `go build`, `go test -race ./internal/routing/ ./internal/handlers/`, and `go vet` green on this branch in isolation (routing coverage ~89.6%).
- Full `make test` (JS + Go) and `make lint` (0 issues) run by an independent review pass.
- An independent delegated review confirmed two defects (feasible all-driver assignment missed with capacities 4/2/1 and households 2/2/1; antimeridian bearing wrap); both are fixed here with permanent regression tests in dropoff and pickup modes.

<details>
<summary>Agent Context</summary>

This PR was produced via a lead/implementer delegation flow. Diagnosis first: an explorer pass mapped the old algorithm (round-robin greedy seed → block-reversal ordering → relocation/swap hill climbing, strict lexicographic objective) and ranked failure mechanisms per goal. Key diagnostic facts: usedDrivers was the 5th tie-breaker and empty routes contribute zero detour/duration, so consolidation dominated; no directional feature existed anywhere in the routing path; households had no identity beyond rounded coordinates.

Implementation was four sequential slices, each independently verified: (1) address-keyed households, (2) usedDrivers to tier 1, (3) corridorSpread metric at tier 2, (4) bearing-sweep seed with fallback. A fifth revision fixed the two review findings: the sweep previously "burned" a driver as used when its arc received no group (e.g. a 1-seat vehicle offered a 2-person household), and strict-improvement search could not recover because the recovery required a neutral intermediate move — hence the explicit `maximizeNonemptyRoutes` repair pass (chain relocations, cycle-protected, committed only when strictly better, which any nonempty-count increase is under the new tier order) and the pre-budget phase-3 pass.

Behavioral invariants worth preserving in future changes: a usedDrivers-increasing feasible relocation must always be accepted; fitting households are hard-atomic (no split penalty exists — splitting is prohibited, not scored); `TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective` was intentionally inverted to `UsesAllDriversEvenWhenConsolidationIsFaster`. The objective is lexicographic — there are no scalar weights to tune; changes to priorities mean reordering tiers.

Known limitations, deliberately out of scope: Google distance requests are `TRAFFIC_UNAWARE` (selected route time never affects scoring); phase 2/3 remain bounded strict-improvement local search (no plateau moves); corridor spread is measured from the institute, not along the road network.

Note for reviewers with local checkouts: an unrelated in-progress "AddressName" feature and a `critical-fixes` branch (defer ui.js) exist from a parallel session in the same working copy; they are intentionally excluded from this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZNQ2WAPpdsmDP3p5j1bS3
