### PR TITLE
fix(no-ticket): deepen browser Event Plan orchestration

### DIFF
--- a/web/static/js/event-planner.js
+++ b/web/static/js/event-planner.js
@@ -306,11 +306,13 @@
         }
 
         async function run() {
+            const sessionOutcomes = new Map();
             while (queue.length > 0) {
                 const moves = takeBatch();
-                if (moves.length === 0) return false;
+                if (moves.length === 0) return { succeeded: false, sessionOutcomes };
 
-                activeSessionId = moves[0].session_id;
+                const sessionId = moves[0].session_id;
+                activeSessionId = sessionId;
                 let succeeded;
                 try {
                     succeeded = await sendBatch(toPayload(moves));
@@ -320,12 +322,13 @@
                 } finally {
                     activeSessionId = null;
                 }
-                if (!succeeded) return false;
+                sessionOutcomes.set(sessionId, (sessionOutcomes.get(sessionId) ?? true) && succeeded);
+                if (!succeeded) return { succeeded: false, sessionOutcomes };
             }
-            return true;
+            return { succeeded: true, sessionOutcomes };
         }
 
-        async function flush() {
+        async function flushDetailed() {
             if (timeout !== null) {
                 cancel(timeout);
                 timeout = null;
@@ -341,6 +344,11 @@
             }
         }
 
+        async function flush() {
+            const result = await flushDetailed();
+            return result.succeeded;
+        }
+
         function hasPending() {
             return queue.length > 0 || timeout !== null || flushPromise !== null;
         }
@@ -352,7 +360,8 @@
         async function flushFor(sessionId) {
             let succeeded = true;
             while (hasPendingFor(sessionId)) {
-                succeeded = await flush();
+                const result = await flushDetailed();
+                if (result.sessionOutcomes.get(sessionId) === false) succeeded = false;
             }
             return succeeded;
         }

--- a/web/static/js/event-planner.js
+++ b/web/static/js/event-planner.js
@@ -17,7 +17,7 @@
     const SAVE_EVENT_ENDPOINT = '/api/v1/events';
 
     function createRouteSessionOrchestrator({ document, htmx, moves, reportError, refreshEtas }) {
-        let saveInFlight = false;
+        const savesInFlight = new Set();
 
         function getActiveSessionId() {
             const container = document.querySelector('.routes-container');
@@ -47,8 +47,15 @@
             return true;
         }
 
-        function hasQueuedMoves() {
-            return moves.hasPending();
+        function getSaveFormSessionId(form) {
+            return form.elements.namedItem('session_id')?.value || null;
+        }
+
+        function hasQueuedMoves(form) {
+            const sessionId = getSaveFormSessionId(form);
+            return Boolean(sessionId)
+                && getActiveSessionId() === sessionId
+                && moves.hasPending(sessionId);
         }
 
         function snapshotSaveForm(form) {
@@ -88,20 +95,27 @@
         }
 
         async function submitSaveWithQueuedMoves(form) {
-            if (saveInFlight) return true;
-            if (!moves.hasPending()) return false;
+            const requestedSessionId = getSaveFormSessionId(form);
+            if (!requestedSessionId || getActiveSessionId() !== requestedSessionId) return false;
+            if (savesInFlight.has(requestedSessionId)) return true;
+            if (!moves.hasPending(requestedSessionId)) return false;
 
             const values = snapshotSaveForm(form);
-            saveInFlight = true;
+            savesInFlight.add(requestedSessionId);
             let flushed = false;
             let liveForm = null;
             try {
                 flushed = await moves.flush();
             } finally {
-                liveForm = findLiveSaveForm();
-                if (liveForm) restoreSaveForm(liveForm, values);
+                if (getActiveSessionId() === requestedSessionId) {
+                    const candidate = findLiveSaveForm();
+                    if (candidate && getSaveFormSessionId(candidate) === requestedSessionId) {
+                        liveForm = candidate;
+                        restoreSaveForm(liveForm, values);
+                    }
+                }
                 // requestSubmit re-enters the capture listener, so unlock first.
-                saveInFlight = false;
+                savesInFlight.delete(requestedSessionId);
             }
 
             if (flushed && liveForm && canSubmitSaveForm(liveForm)) {
@@ -252,6 +266,7 @@
         const queue = [];
         let timeout = null;
         let flushPromise = null;
+        let activeSessionId = null;
 
         function scheduleFlush() {
             if (timeout !== null) cancel(timeout);
@@ -295,12 +310,15 @@
                 const moves = takeBatch();
                 if (moves.length === 0) return false;
 
+                activeSessionId = moves[0].session_id;
                 let succeeded;
                 try {
                     succeeded = await sendBatch(toPayload(moves));
                 } catch (error) {
                     queue.unshift(...moves);
                     throw error;
+                } finally {
+                    activeSessionId = null;
                 }
                 if (!succeeded) return false;
             }
@@ -327,7 +345,11 @@
             return queue.length > 0 || timeout !== null || flushPromise !== null;
         }
 
-        return { enqueue, flush, hasPending };
+        function hasPendingFor(sessionId) {
+            return activeSessionId === sessionId || queue.some(move => move.session_id === sessionId);
+        }
+
+        return { enqueue, flush, hasPending, hasPendingFor };
     }
 
     function bootBrowser() {
@@ -459,8 +481,8 @@
             document,
             htmx,
             moves: {
-                hasPending: function() {
-                    return participantMoveBatcher.hasPending();
+                hasPending: function(sessionId) {
+                    return participantMoveBatcher.hasPendingFor(sessionId);
                 },
                 flush: function() {
                     return participantMoveBatcher.flush();
@@ -523,7 +545,7 @@
 
         document.addEventListener('submit', async function(evt) {
             const form = evt.target;
-            if (!isSaveEventForm(form) || !routeSessionOrchestrator.hasQueuedMoves()) {
+            if (!isSaveEventForm(form) || !routeSessionOrchestrator.hasQueuedMoves(form)) {
                 return;
             }
 

--- a/web/static/js/event-planner.js
+++ b/web/static/js/event-planner.js
@@ -14,6 +14,47 @@
         writeDraft();
     }
 
+    function createRouteSessionOrchestrator({ getActiveSessionId, results, moves, saveForm }) {
+        let saveInFlight = false;
+
+        function applyEditResult({ requestedSessionId, ok, html }) {
+            if (!ok) {
+                results.reportError(html);
+                return false;
+            }
+            if (getActiveSessionId() !== requestedSessionId) {
+                return true;
+            }
+
+            results.render(html);
+            return true;
+        }
+
+        async function submitSaveWithQueuedMoves(form) {
+            if (saveInFlight) return true;
+            if (!moves.hasPending()) return false;
+
+            saveInFlight = true;
+            const values = saveForm.snapshot(form);
+            let flushed = false;
+            let liveForm = null;
+            try {
+                flushed = await moves.flush();
+            } finally {
+                liveForm = saveForm.findLive();
+                if (liveForm) saveForm.restore(liveForm, values);
+                saveInFlight = false;
+            }
+
+            if (flushed && liveForm && saveForm.canSubmit(liveForm)) {
+                saveForm.submit(liveForm);
+            }
+            return true;
+        }
+
+        return { applyEditResult, submitSaveWithQueuedMoves };
+    }
+
     const DROPOFF_ETA_SLACK_SECS = 2 * 60;
 
     function formatClockTime(value) {
@@ -355,10 +396,65 @@
             return container ? container.dataset.sessionId : null;
         }
 
+        let participantMoveBatcher;
+        const routeSessionOrchestrator = createRouteSessionOrchestrator({
+            getActiveSessionId: getSessionId,
+            results: {
+                render: function(html) {
+                    const routeResults = document.getElementById('results-section');
+                    if (!routeResults) return;
+
+                    routeResults.innerHTML = html;
+                    htmx.process(routeResults);
+                    populateStopEtas();
+                },
+                reportError: showRouteError,
+            },
+            moves: {
+                hasPending: function() {
+                    return participantMoveBatcher.hasPending();
+                },
+                flush: function() {
+                    return participantMoveBatcher.flush();
+                },
+            },
+            saveForm: {
+                snapshot: function(form) {
+                    return {
+                        event_date: form.elements.namedItem('event_date')?.value || '',
+                        notes: form.elements.namedItem('notes')?.value || '',
+                    };
+                },
+                findLive: function() {
+                    const sessionInput = document.querySelector('#results-section form input[name="session_id"]');
+                    return sessionInput ? sessionInput.closest('form') : null;
+                },
+                canSubmit: function(form) {
+                    const submitButton = form.querySelector('button[type="submit"]');
+                    return form.getAttribute('hx-post') === '/api/v1/events' && !submitButton?.disabled;
+                },
+                restore: function(form, values) {
+                    const eventDate = form.elements.namedItem('event_date');
+                    const notes = form.elements.namedItem('notes');
+                    if (eventDate) eventDate.value = values.event_date;
+                    if (notes) notes.value = values.notes;
+                },
+                submit: function(form) {
+                    if (typeof form.requestSubmit === 'function') {
+                        form.requestSubmit();
+                        return;
+                    }
+
+                    const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+                    if (form.dispatchEvent(submitEvent)) form.submit();
+                },
+            },
+        });
+
         /**
          * Moves a participant from one route to another
          */
-        const participantMoveBatcher = createParticipantMoveBatcher({
+        participantMoveBatcher = createParticipantMoveBatcher({
             sendBatch: async function(payload) {
                 try {
                     const response = await fetch('/api/v1/routes/edit/move-participant', {
@@ -371,17 +467,11 @@
                     });
 
                     const html = await response.text();
-                    if (!response.ok) {
-                        showRouteError(html);
-                        return false;
-                    }
-
-                    const routeResults = document.getElementById('results-section');
-                    if (routeResults && getSessionId() === payload.session_id) {
-                        routeResults.innerHTML = html;
-                        populateStopEtas();
-                    }
-                    return true;
+                    return routeSessionOrchestrator.applyEditResult({
+                        requestedSessionId: payload.session_id,
+                        ok: response.ok,
+                        html,
+                    });
                 } catch (err) {
                     console.error('Failed to move participant:', err);
                     showRouteError('Failed to move participant: ' + err.message);
@@ -408,42 +498,19 @@
             });
         }
 
-        function hasQueuedParticipantMoves() {
-            return participantMoveBatcher.hasPending();
-        }
-
-        async function flushQueuedParticipantMoves() {
-            return participantMoveBatcher.flush();
-        }
-
         function isSaveEventForm(form) {
             return form instanceof HTMLFormElement && form.getAttribute('hx-post') === '/api/v1/events';
         }
 
         document.addEventListener('submit', async function(evt) {
             const form = evt.target;
-            if (!isSaveEventForm(form) || !hasQueuedParticipantMoves() || form.dataset.pendingMoveFlush === 'true') {
+            if (!isSaveEventForm(form) || !participantMoveBatcher.hasPending()) {
                 return;
             }
 
             evt.preventDefault();
             evt.stopImmediatePropagation();
-            form.dataset.pendingMoveFlush = 'true';
-
-            const flushed = await flushQueuedParticipantMoves();
-            delete form.dataset.pendingMoveFlush;
-            if (!flushed) {
-                return;
-            }
-
-            if (typeof form.requestSubmit === 'function') {
-                form.requestSubmit(evt.submitter || undefined);
-            } else {
-                const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
-                if (form.dispatchEvent(submitEvent)) {
-                    form.submit();
-                }
-            }
+            await routeSessionOrchestrator.submitSaveWithQueuedMoves(form);
         }, true);
 
         /**
@@ -479,15 +546,11 @@
                 });
 
                 const html = await response.text();
-                const routeResults = document.getElementById('results-section');
-                if (routeResults) {
-                    if (!response.ok) {
-                        showRouteError(html);
-                    } else {
-                        routeResults.innerHTML = html;
-                        populateStopEtas();
-                    }
-                }
+                routeSessionOrchestrator.applyEditResult({
+                    requestedSessionId: sessionId,
+                    ok: response.ok,
+                    html,
+                });
             } catch (err) {
                 console.error('Failed to swap drivers:', err);
                 showRouteError('Failed to swap drivers: ' + err.message);
@@ -513,15 +576,11 @@
                 });
 
                 const html = await response.text();
-                const routeResults = document.getElementById('results-section');
-                if (routeResults) {
-                    if (!response.ok) {
-                        showRouteError(html);
-                    } else {
-                        routeResults.innerHTML = html;
-                        populateStopEtas();
-                    }
-                }
+                routeSessionOrchestrator.applyEditResult({
+                    requestedSessionId: sessionId,
+                    ok: response.ok,
+                    html,
+                });
             } catch (err) {
                 console.error('Failed to reset routes:', err);
                 showRouteError('Failed to reset routes: ' + err.message);
@@ -552,15 +611,11 @@
                 });
 
                 const html = await response.text();
-                const routeResults = document.getElementById('results-section');
-                if (routeResults) {
-                    if (!response.ok) {
-                        showRouteError(html);
-                    } else {
-                        routeResults.innerHTML = html;
-                        populateStopEtas();
-                    }
-                }
+                routeSessionOrchestrator.applyEditResult({
+                    requestedSessionId: sessionId,
+                    ok: response.ok,
+                    html,
+                });
             } catch (err) {
                 console.error('Failed to add driver:', err);
                 showRouteError('Failed to add driver: ' + err.message);
@@ -1489,6 +1544,7 @@
 
     return {
         createParticipantMoveBatcher,
+        createRouteSessionOrchestrator,
         formatRouteText,
         generateMapsUrl,
         getStopEta,

--- a/web/static/js/event-planner.js
+++ b/web/static/js/event-planner.js
@@ -105,7 +105,7 @@
             let flushed = false;
             let liveForm = null;
             try {
-                flushed = await moves.flush();
+                flushed = await moves.flush(requestedSessionId);
             } finally {
                 if (getActiveSessionId() === requestedSessionId) {
                     const candidate = findLiveSaveForm();
@@ -349,7 +349,15 @@
             return activeSessionId === sessionId || queue.some(move => move.session_id === sessionId);
         }
 
-        return { enqueue, flush, hasPending, hasPendingFor };
+        async function flushFor(sessionId) {
+            let succeeded = true;
+            while (hasPendingFor(sessionId)) {
+                succeeded = await flush();
+            }
+            return succeeded;
+        }
+
+        return { enqueue, flush, flushFor, hasPending, hasPendingFor };
     }
 
     function bootBrowser() {
@@ -484,8 +492,8 @@
                 hasPending: function(sessionId) {
                     return participantMoveBatcher.hasPendingFor(sessionId);
                 },
-                flush: function() {
-                    return participantMoveBatcher.flush();
+                flush: function(sessionId) {
+                    return participantMoveBatcher.flushFor(sessionId);
                 },
             },
             reportError: showRouteError,

--- a/web/static/js/event-planner.js
+++ b/web/static/js/event-planner.js
@@ -14,45 +14,103 @@
         writeDraft();
     }
 
-    function createRouteSessionOrchestrator({ getActiveSessionId, results, moves, saveForm }) {
+    const SAVE_EVENT_ENDPOINT = '/api/v1/events';
+
+    function createRouteSessionOrchestrator({ document, htmx, moves, reportError, refreshEtas }) {
         let saveInFlight = false;
+
+        function getActiveSessionId() {
+            const container = document.querySelector('.routes-container');
+            return container ? container.dataset.sessionId : null;
+        }
+
+        function renderResults(html) {
+            const resultsSection = document.getElementById('results-section');
+            if (!resultsSection) return;
+
+            resultsSection.innerHTML = html;
+            htmx.process(resultsSection);
+            refreshEtas();
+        }
 
         function applyEditResult({ requestedSessionId, ok, html }) {
             if (!ok) {
-                results.reportError(html);
+                reportError(html);
                 return false;
             }
             if (getActiveSessionId() !== requestedSessionId) {
+                // The request succeeded, but its HTML no longer owns the view.
                 return true;
             }
 
-            results.render(html);
+            renderResults(html);
             return true;
+        }
+
+        function hasQueuedMoves() {
+            return moves.hasPending();
+        }
+
+        function snapshotSaveForm(form) {
+            return {
+                event_date: form.elements.namedItem('event_date')?.value || '',
+                notes: form.elements.namedItem('notes')?.value || '',
+            };
+        }
+
+        function findLiveSaveForm() {
+            const sessionInput = document.querySelector('#results-section form input[name="session_id"]');
+            return sessionInput ? sessionInput.closest('form') : null;
+        }
+
+        function restoreSaveForm(form, values) {
+            const eventDate = form.elements.namedItem('event_date');
+            const notes = form.elements.namedItem('notes');
+            if (eventDate) eventDate.value = values.event_date;
+            if (notes) notes.value = values.notes;
+        }
+
+        function canSubmitSaveForm(form) {
+            const submitButton = form.querySelector('button[type="submit"]');
+            return form.getAttribute('hx-post') === SAVE_EVENT_ENDPOINT
+                && Boolean(submitButton)
+                && !submitButton.disabled;
+        }
+
+        function submitSaveForm(form) {
+            if (typeof form.requestSubmit === 'function') {
+                form.requestSubmit();
+                return;
+            }
+
+            const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+            if (form.dispatchEvent(submitEvent)) form.submit();
         }
 
         async function submitSaveWithQueuedMoves(form) {
             if (saveInFlight) return true;
             if (!moves.hasPending()) return false;
 
+            const values = snapshotSaveForm(form);
             saveInFlight = true;
-            const values = saveForm.snapshot(form);
             let flushed = false;
             let liveForm = null;
             try {
                 flushed = await moves.flush();
             } finally {
-                liveForm = saveForm.findLive();
-                if (liveForm) saveForm.restore(liveForm, values);
+                liveForm = findLiveSaveForm();
+                if (liveForm) restoreSaveForm(liveForm, values);
+                // requestSubmit re-enters the capture listener, so unlock first.
                 saveInFlight = false;
             }
 
-            if (flushed && liveForm && saveForm.canSubmit(liveForm)) {
-                saveForm.submit(liveForm);
+            if (flushed && liveForm && canSubmitSaveForm(liveForm)) {
+                submitSaveForm(liveForm);
             }
             return true;
         }
 
-        return { applyEditResult, submitSaveWithQueuedMoves };
+        return { applyEditResult, hasQueuedMoves, submitSaveWithQueuedMoves };
     }
 
     const DROPOFF_ETA_SLACK_SECS = 2 * 60;
@@ -398,18 +456,8 @@
 
         let participantMoveBatcher;
         const routeSessionOrchestrator = createRouteSessionOrchestrator({
-            getActiveSessionId: getSessionId,
-            results: {
-                render: function(html) {
-                    const routeResults = document.getElementById('results-section');
-                    if (!routeResults) return;
-
-                    routeResults.innerHTML = html;
-                    htmx.process(routeResults);
-                    populateStopEtas();
-                },
-                reportError: showRouteError,
-            },
+            document,
+            htmx,
             moves: {
                 hasPending: function() {
                     return participantMoveBatcher.hasPending();
@@ -418,37 +466,8 @@
                     return participantMoveBatcher.flush();
                 },
             },
-            saveForm: {
-                snapshot: function(form) {
-                    return {
-                        event_date: form.elements.namedItem('event_date')?.value || '',
-                        notes: form.elements.namedItem('notes')?.value || '',
-                    };
-                },
-                findLive: function() {
-                    const sessionInput = document.querySelector('#results-section form input[name="session_id"]');
-                    return sessionInput ? sessionInput.closest('form') : null;
-                },
-                canSubmit: function(form) {
-                    const submitButton = form.querySelector('button[type="submit"]');
-                    return form.getAttribute('hx-post') === '/api/v1/events' && !submitButton?.disabled;
-                },
-                restore: function(form, values) {
-                    const eventDate = form.elements.namedItem('event_date');
-                    const notes = form.elements.namedItem('notes');
-                    if (eventDate) eventDate.value = values.event_date;
-                    if (notes) notes.value = values.notes;
-                },
-                submit: function(form) {
-                    if (typeof form.requestSubmit === 'function') {
-                        form.requestSubmit();
-                        return;
-                    }
-
-                    const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
-                    if (form.dispatchEvent(submitEvent)) form.submit();
-                },
-            },
+            reportError: showRouteError,
+            refreshEtas: populateStopEtas,
         });
 
         /**
@@ -499,12 +518,12 @@
         }
 
         function isSaveEventForm(form) {
-            return form instanceof HTMLFormElement && form.getAttribute('hx-post') === '/api/v1/events';
+            return form instanceof HTMLFormElement && form.getAttribute('hx-post') === SAVE_EVENT_ENDPOINT;
         }
 
         document.addEventListener('submit', async function(evt) {
             const form = evt.target;
-            if (!isSaveEventForm(form) || !participantMoveBatcher.hasPending()) {
+            if (!isSaveEventForm(form) || !routeSessionOrchestrator.hasQueuedMoves()) {
                 return;
             }
 

--- a/web/static/js/event-planner.test.js
+++ b/web/static/js/event-planner.test.js
@@ -12,163 +12,191 @@ const {
     saveDraft,
 } = require('./event-planner.js');
 
-test('route edit responses render only while their requested session is active', () => {
-    let activeSessionId = 'session-a';
+function createSaveForm({
+    eventDate = '',
+    notes = '',
+    sessionId = 'session-a',
+    saveEnabled = true,
+    submitButton = true,
+} = {}) {
+    const fields = {
+        event_date: { value: eventDate },
+        notes: { value: notes },
+        session_id: { value: sessionId },
+    };
+    const form = {
+        submitCount: 0,
+        elements: { namedItem: name => fields[name] || null },
+        getAttribute: name => name === 'hx-post' && saveEnabled ? '/api/v1/events' : null,
+        querySelector: selector => selector === 'button[type="submit"]' && submitButton
+            ? { disabled: !saveEnabled }
+            : null,
+        requestSubmit() { this.submitCount += 1; },
+        value(name) { return fields[name]?.value; },
+    };
+    return form;
+}
+
+function createRouteSessionHarness({
+    activeSessionId = 'session-a',
+    getLiveForm = () => null,
+    hasPending = () => true,
+    flush = async () => true,
+} = {}) {
     const rendered = [];
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => activeSessionId,
-        results: {
-            render: html => rendered.push(html),
-            reportError: () => {},
+    const processed = [];
+    const errors = [];
+    let etaRefreshes = 0;
+    let currentSessionId = activeSessionId;
+    const resultsSection = {
+        set innerHTML(html) { rendered.push(html); },
+    };
+    const document = {
+        querySelector(selector) {
+            if (selector === '.routes-container') {
+                return currentSessionId ? { dataset: { sessionId: currentSessionId } } : null;
+            }
+            if (selector === '#results-section form input[name="session_id"]') {
+                const form = getLiveForm();
+                return form ? { closest: () => form } : null;
+            }
+            return null;
         },
+        getElementById: id => id === 'results-section' ? resultsSection : null,
+    };
+    const orchestrator = createRouteSessionOrchestrator({
+        document,
+        htmx: { process: element => processed.push(element) },
+        moves: { hasPending, flush },
+        reportError: html => errors.push(html),
+        refreshEtas: () => { etaRefreshes += 1; },
     });
 
-    orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: true, html: 'current routes' });
-    activeSessionId = 'session-b';
-    orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: true, html: 'stale routes' });
+    return {
+        errors,
+        get etaRefreshes() { return etaRefreshes; },
+        orchestrator,
+        processed,
+        rendered,
+        resultsSection,
+        setActiveSessionId: value => { currentSessionId = value; },
+    };
+}
 
-    assert.deepEqual(rendered, ['current routes']);
+test('route edit responses render only while their requested session is active', () => {
+    const harness = createRouteSessionHarness();
+
+    const currentResult = harness.orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: true, html: 'current routes' });
+    harness.setActiveSessionId('session-b');
+    const staleResult = harness.orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: true, html: 'stale routes' });
+
+    assert.deepEqual({ currentResult, staleResult, rendered: harness.rendered, processed: harness.processed, etaRefreshes: harness.etaRefreshes }, {
+        currentResult: true,
+        staleResult: true,
+        rendered: ['current routes'],
+        processed: [harness.resultsSection],
+        etaRefreshes: 1,
+    });
 });
 
 test('route edit errors are reported even after the requested session becomes stale', () => {
-    const errors = [];
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => 'session-b',
-        results: {
-            render: () => {},
-            reportError: html => errors.push(html),
-        },
+    const harness = createRouteSessionHarness({ activeSessionId: 'session-b' });
+
+    const succeeded = harness.orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: false, html: 'move failed' });
+
+    assert.deepEqual({ succeeded, errors: harness.errors }, {
+        succeeded: false,
+        errors: ['move failed'],
     });
-
-    orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: false, html: 'move failed' });
-
-    assert.deepEqual(errors, ['move failed']);
 });
 
 test('saving with queued moves restores typed fields and submits the replacement form', async () => {
-    const originalForm = { event_date: '2026-08-23', notes: 'Bring snacks', session_id: 'session-a' };
+    const originalForm = createSaveForm({ eventDate: '2026-08-23', notes: 'Bring snacks' });
     let liveForm = originalForm;
-    const submitted = [];
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => 'session-a',
-        results: { render: () => {}, reportError: () => {} },
-        moves: {
-            hasPending: () => true,
-            flush: async () => {
-                liveForm = { event_date: '', notes: '', session_id: 'session-a-fresh' };
-                return true;
-            },
-        },
-        saveForm: {
-            snapshot: form => ({ event_date: form.event_date, notes: form.notes }),
-            findLive: () => liveForm,
-            canSubmit: () => true,
-            restore: (form, values) => Object.assign(form, values),
-            submit: form => submitted.push(form),
+    const harness = createRouteSessionHarness({
+        getLiveForm: () => liveForm,
+        flush: async () => {
+            liveForm = createSaveForm({ sessionId: 'session-a-fresh' });
+            return true;
         },
     });
 
-    const handled = await orchestrator.submitSaveWithQueuedMoves(originalForm);
+    const handled = await harness.orchestrator.submitSaveWithQueuedMoves(originalForm);
 
-    assert.deepEqual({ handled, liveForm, submitted }, {
+    assert.deepEqual({
+        handled,
+        eventDate: liveForm.value('event_date'),
+        notes: liveForm.value('notes'),
+        sessionId: liveForm.value('session_id'),
+        originalSubmits: originalForm.submitCount,
+        liveSubmits: liveForm.submitCount,
+    }, {
         handled: true,
-        liveForm: { event_date: '2026-08-23', notes: 'Bring snacks', session_id: 'session-a-fresh' },
-        submitted: [liveForm],
+        eventDate: '2026-08-23',
+        notes: 'Bring snacks',
+        sessionId: 'session-a-fresh',
+        originalSubmits: 0,
+        liveSubmits: 1,
     });
 });
 
 test('saving after a move restores fields without submitting an unsaveable replacement form', async () => {
-    const originalForm = { event_date: '2026-08-23', notes: 'Bring snacks' };
-    const liveForm = { event_date: '', notes: '' };
-    let submitted = false;
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => 'session-a',
-        results: { render: () => {}, reportError: () => {} },
-        moves: { hasPending: () => true, flush: async () => true },
-        saveForm: {
-            snapshot: form => ({ ...form }),
-            findLive: () => liveForm,
-            canSubmit: () => false,
-            restore: (form, values) => Object.assign(form, values),
-            submit: () => { submitted = true; },
-        },
+    const originalForm = createSaveForm({ eventDate: '2026-08-23', notes: 'Bring snacks' });
+    const liveForm = createSaveForm({ saveEnabled: false });
+    const harness = createRouteSessionHarness({
+        getLiveForm: () => liveForm,
     });
 
-    await orchestrator.submitSaveWithQueuedMoves(originalForm);
+    await harness.orchestrator.submitSaveWithQueuedMoves(originalForm);
 
-    assert.deepEqual({ liveForm, submitted }, {
-        liveForm: { event_date: '2026-08-23', notes: 'Bring snacks' },
-        submitted: false,
+    assert.deepEqual({ eventDate: liveForm.value('event_date'), notes: liveForm.value('notes'), submits: liveForm.submitCount }, {
+        eventDate: '2026-08-23',
+        notes: 'Bring snacks',
+        submits: 0,
     });
 });
 
-test('saving after an error replacement tolerates the live form being absent', async () => {
-    let submitted = false;
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => 'session-a',
-        results: { render: () => {}, reportError: () => {} },
-        moves: { hasPending: () => true, flush: async () => false },
-        saveForm: {
-            snapshot: () => ({ event_date: '2026-08-23', notes: '' }),
-            findLive: () => null,
-            canSubmit: () => true,
-            restore: () => {},
-            submit: () => { submitted = true; },
-        },
-    });
+test('saving after a successful replacement tolerates the live form being absent', async () => {
+    const originalForm = createSaveForm({ eventDate: '2026-08-23' });
+    const harness = createRouteSessionHarness({ getLiveForm: () => null });
 
-    const handled = await orchestrator.submitSaveWithQueuedMoves({});
+    const handled = await harness.orchestrator.submitSaveWithQueuedMoves(originalForm);
 
-    assert.deepEqual({ handled, submitted }, { handled: true, submitted: false });
+    assert.equal(handled, true);
 });
 
 test('saving after a partial move flush restores fields but does not submit', async () => {
-    const liveForm = { event_date: '', notes: '' };
-    let submitted = false;
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => 'session-a',
-        results: { render: () => {}, reportError: () => {} },
-        moves: { hasPending: () => true, flush: async () => false },
-        saveForm: {
-            snapshot: () => ({ event_date: '2026-08-23', notes: 'Bring snacks' }),
-            findLive: () => liveForm,
-            canSubmit: () => true,
-            restore: (form, values) => Object.assign(form, values),
-            submit: () => { submitted = true; },
-        },
+    const originalForm = createSaveForm({ eventDate: '2026-08-23', notes: 'Bring snacks' });
+    const liveForm = createSaveForm();
+    const harness = createRouteSessionHarness({
+        getLiveForm: () => liveForm,
+        flush: async () => false,
     });
 
-    await orchestrator.submitSaveWithQueuedMoves({});
+    await harness.orchestrator.submitSaveWithQueuedMoves(originalForm);
 
-    assert.deepEqual({ liveForm, submitted }, {
-        liveForm: { event_date: '2026-08-23', notes: 'Bring snacks' },
-        submitted: false,
+    assert.deepEqual({ eventDate: liveForm.value('event_date'), notes: liveForm.value('notes'), submits: liveForm.submitCount }, {
+        eventDate: '2026-08-23',
+        notes: 'Bring snacks',
+        submits: 0,
     });
 });
 
 test('a second save attempt during the same move flush does not submit twice', async () => {
     let finishFlush;
     const flush = new Promise(resolve => { finishFlush = resolve; });
-    let submissions = 0;
-    const orchestrator = createRouteSessionOrchestrator({
-        getActiveSessionId: () => 'session-a',
-        results: { render: () => {}, reportError: () => {} },
-        moves: { hasPending: () => true, flush: () => flush },
-        saveForm: {
-            snapshot: () => ({ event_date: '2026-08-23', notes: '' }),
-            findLive: () => ({}),
-            canSubmit: () => true,
-            restore: () => {},
-            submit: () => { submissions += 1; },
-        },
+    const form = createSaveForm({ eventDate: '2026-08-23' });
+    const harness = createRouteSessionHarness({
+        getLiveForm: () => form,
+        flush: () => flush,
     });
 
-    const firstSave = orchestrator.submitSaveWithQueuedMoves({});
-    const secondSave = orchestrator.submitSaveWithQueuedMoves({});
+    const firstSave = harness.orchestrator.submitSaveWithQueuedMoves(form);
+    const secondSave = harness.orchestrator.submitSaveWithQueuedMoves(form);
     finishFlush(true);
     await Promise.all([firstSave, secondSave]);
 
-    assert.equal(submissions, 1);
+    assert.equal(form.submitCount, 1);
 });
 
 test('saving a draft aborts an in-flight restore before clearing the active session', () => {

--- a/web/static/js/event-planner.test.js
+++ b/web/static/js/event-planner.test.js
@@ -352,3 +352,23 @@ test('participant moves flush sequentially in same-session batches with the exis
         { session_id: 'session-b', participant_id: 3, from_route_index: 0, to_route_index: 2, insert_at_position: -1 },
     ]);
 });
+
+test('flushing a session preserves an earlier failure across later successful batches', async () => {
+    let calls = 0;
+    const batcher = createParticipantMoveBatcher({
+        batchLimit: 1,
+        schedule: () => 1,
+        cancel: () => {},
+        sendBatch: async () => {
+            calls += 1;
+            return calls !== 1;
+        },
+    });
+    batcher.enqueue({ session_id: 'session-a', participant_id: 1 });
+    batcher.enqueue({ session_id: 'session-a', participant_id: 2 });
+    batcher.enqueue({ session_id: 'session-a', participant_id: 3 });
+
+    assert.equal(await batcher.flushFor('session-a'), false);
+    assert.equal(calls, 3);
+    assert.equal(batcher.hasPendingFor('session-a'), false);
+});

--- a/web/static/js/event-planner.test.js
+++ b/web/static/js/event-planner.test.js
@@ -116,7 +116,7 @@ test('saving with queued moves restores typed fields and submits the replacement
     const harness = createRouteSessionHarness({
         getLiveForm: () => liveForm,
         flush: async () => {
-            liveForm = createSaveForm({ sessionId: 'session-a-fresh' });
+            liveForm = createSaveForm({ sessionId: 'session-a' });
             return true;
         },
     });
@@ -134,7 +134,7 @@ test('saving with queued moves restores typed fields and submits the replacement
         handled: true,
         eventDate: '2026-08-23',
         notes: 'Bring snacks',
-        sessionId: 'session-a-fresh',
+        sessionId: 'session-a',
         originalSubmits: 0,
         liveSubmits: 1,
     });
@@ -197,6 +197,38 @@ test('a second save attempt during the same move flush does not submit twice', a
     await Promise.all([firstSave, secondSave]);
 
     assert.equal(form.submitCount, 1);
+});
+
+test('a queued save never restores or submits a replacement session form', async () => {
+    let finishFlush;
+    const flush = new Promise(resolve => { finishFlush = resolve; });
+    const sessionAForm = createSaveForm({ eventDate: '2026-08-23', notes: 'Session A', sessionId: 'session-a' });
+    const sessionBForm = createSaveForm({ eventDate: '2026-08-24', notes: 'Session B', sessionId: 'session-b' });
+    let liveForm = sessionAForm;
+    const harness = createRouteSessionHarness({
+        getLiveForm: () => liveForm,
+        hasPending: () => true,
+        flush: () => flush,
+    });
+
+    const sessionASave = harness.orchestrator.submitSaveWithQueuedMoves(sessionAForm);
+    harness.setActiveSessionId('session-b');
+    liveForm = sessionBForm;
+    const sessionBSave = harness.orchestrator.submitSaveWithQueuedMoves(sessionBForm);
+    finishFlush(true);
+    await Promise.all([sessionASave, sessionBSave]);
+
+    assert.deepEqual({
+        eventDate: sessionBForm.value('event_date'),
+        notes: sessionBForm.value('notes'),
+        sessionASubmits: sessionAForm.submitCount,
+        sessionBSubmits: sessionBForm.submitCount,
+    }, {
+        eventDate: '2026-08-24',
+        notes: 'Session B',
+        sessionASubmits: 0,
+        sessionBSubmits: 1,
+    });
 });
 
 test('saving a draft aborts an in-flight restore before clearing the active session', () => {
@@ -286,7 +318,12 @@ test('participant moves flush sequentially in same-session batches with the exis
     batcher.enqueue({ session_id: 'session-a', participant_id: 2, from_route_index: 1, to_route_index: 0, insert_at_position: -1 });
     batcher.enqueue({ session_id: 'session-b', participant_id: 3, from_route_index: 0, to_route_index: 2, insert_at_position: -1 });
 
+    assert.equal(batcher.hasPendingFor('session-a'), true);
+    assert.equal(batcher.hasPendingFor('session-b'), true);
+    assert.equal(batcher.hasPendingFor('session-c'), false);
     assert.equal(await batcher.flush(), true);
+    assert.equal(batcher.hasPendingFor('session-a'), false);
+    assert.equal(batcher.hasPendingFor('session-b'), false);
     assert.deepEqual(sent, [
         {
             session_id: 'session-a',

--- a/web/static/js/event-planner.test.js
+++ b/web/static/js/event-planner.test.js
@@ -5,11 +5,171 @@ const assert = require('node:assert/strict');
 
 const {
     createParticipantMoveBatcher,
+    createRouteSessionOrchestrator,
     formatRouteText,
     generateMapsUrl,
     getStopEta,
     saveDraft,
 } = require('./event-planner.js');
+
+test('route edit responses render only while their requested session is active', () => {
+    let activeSessionId = 'session-a';
+    const rendered = [];
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => activeSessionId,
+        results: {
+            render: html => rendered.push(html),
+            reportError: () => {},
+        },
+    });
+
+    orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: true, html: 'current routes' });
+    activeSessionId = 'session-b';
+    orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: true, html: 'stale routes' });
+
+    assert.deepEqual(rendered, ['current routes']);
+});
+
+test('route edit errors are reported even after the requested session becomes stale', () => {
+    const errors = [];
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => 'session-b',
+        results: {
+            render: () => {},
+            reportError: html => errors.push(html),
+        },
+    });
+
+    orchestrator.applyEditResult({ requestedSessionId: 'session-a', ok: false, html: 'move failed' });
+
+    assert.deepEqual(errors, ['move failed']);
+});
+
+test('saving with queued moves restores typed fields and submits the replacement form', async () => {
+    const originalForm = { event_date: '2026-08-23', notes: 'Bring snacks', session_id: 'session-a' };
+    let liveForm = originalForm;
+    const submitted = [];
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => 'session-a',
+        results: { render: () => {}, reportError: () => {} },
+        moves: {
+            hasPending: () => true,
+            flush: async () => {
+                liveForm = { event_date: '', notes: '', session_id: 'session-a-fresh' };
+                return true;
+            },
+        },
+        saveForm: {
+            snapshot: form => ({ event_date: form.event_date, notes: form.notes }),
+            findLive: () => liveForm,
+            canSubmit: () => true,
+            restore: (form, values) => Object.assign(form, values),
+            submit: form => submitted.push(form),
+        },
+    });
+
+    const handled = await orchestrator.submitSaveWithQueuedMoves(originalForm);
+
+    assert.deepEqual({ handled, liveForm, submitted }, {
+        handled: true,
+        liveForm: { event_date: '2026-08-23', notes: 'Bring snacks', session_id: 'session-a-fresh' },
+        submitted: [liveForm],
+    });
+});
+
+test('saving after a move restores fields without submitting an unsaveable replacement form', async () => {
+    const originalForm = { event_date: '2026-08-23', notes: 'Bring snacks' };
+    const liveForm = { event_date: '', notes: '' };
+    let submitted = false;
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => 'session-a',
+        results: { render: () => {}, reportError: () => {} },
+        moves: { hasPending: () => true, flush: async () => true },
+        saveForm: {
+            snapshot: form => ({ ...form }),
+            findLive: () => liveForm,
+            canSubmit: () => false,
+            restore: (form, values) => Object.assign(form, values),
+            submit: () => { submitted = true; },
+        },
+    });
+
+    await orchestrator.submitSaveWithQueuedMoves(originalForm);
+
+    assert.deepEqual({ liveForm, submitted }, {
+        liveForm: { event_date: '2026-08-23', notes: 'Bring snacks' },
+        submitted: false,
+    });
+});
+
+test('saving after an error replacement tolerates the live form being absent', async () => {
+    let submitted = false;
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => 'session-a',
+        results: { render: () => {}, reportError: () => {} },
+        moves: { hasPending: () => true, flush: async () => false },
+        saveForm: {
+            snapshot: () => ({ event_date: '2026-08-23', notes: '' }),
+            findLive: () => null,
+            canSubmit: () => true,
+            restore: () => {},
+            submit: () => { submitted = true; },
+        },
+    });
+
+    const handled = await orchestrator.submitSaveWithQueuedMoves({});
+
+    assert.deepEqual({ handled, submitted }, { handled: true, submitted: false });
+});
+
+test('saving after a partial move flush restores fields but does not submit', async () => {
+    const liveForm = { event_date: '', notes: '' };
+    let submitted = false;
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => 'session-a',
+        results: { render: () => {}, reportError: () => {} },
+        moves: { hasPending: () => true, flush: async () => false },
+        saveForm: {
+            snapshot: () => ({ event_date: '2026-08-23', notes: 'Bring snacks' }),
+            findLive: () => liveForm,
+            canSubmit: () => true,
+            restore: (form, values) => Object.assign(form, values),
+            submit: () => { submitted = true; },
+        },
+    });
+
+    await orchestrator.submitSaveWithQueuedMoves({});
+
+    assert.deepEqual({ liveForm, submitted }, {
+        liveForm: { event_date: '2026-08-23', notes: 'Bring snacks' },
+        submitted: false,
+    });
+});
+
+test('a second save attempt during the same move flush does not submit twice', async () => {
+    let finishFlush;
+    const flush = new Promise(resolve => { finishFlush = resolve; });
+    let submissions = 0;
+    const orchestrator = createRouteSessionOrchestrator({
+        getActiveSessionId: () => 'session-a',
+        results: { render: () => {}, reportError: () => {} },
+        moves: { hasPending: () => true, flush: () => flush },
+        saveForm: {
+            snapshot: () => ({ event_date: '2026-08-23', notes: '' }),
+            findLive: () => ({}),
+            canSubmit: () => true,
+            restore: () => {},
+            submit: () => { submissions += 1; },
+        },
+    });
+
+    const firstSave = orchestrator.submitSaveWithQueuedMoves({});
+    const secondSave = orchestrator.submitSaveWithQueuedMoves({});
+    finishFlush(true);
+    await Promise.all([firstSave, secondSave]);
+
+    assert.equal(submissions, 1);
+});
 
 test('saving a draft aborts an in-flight restore before clearing the active session', () => {
     const actions = [];

--- a/web/static/js/event-planner.test.js
+++ b/web/static/js/event-planner.test.js
@@ -199,31 +199,48 @@ test('a second save attempt during the same move flush does not submit twice', a
     assert.equal(form.submitCount, 1);
 });
 
-test('a queued save never restores or submits a replacement session form', async () => {
-    let finishFlush;
-    const flush = new Promise(resolve => { finishFlush = resolve; });
+test('a queued save waits for its own session when an earlier session fails', async () => {
+    let finishSessionA;
+    const sessionAGate = new Promise(resolve => { finishSessionA = resolve; });
+    const sent = [];
+    const batcher = createParticipantMoveBatcher({
+        schedule: () => 1,
+        cancel: () => {},
+        sendBatch: async payload => {
+            sent.push(payload.session_id);
+            if (payload.session_id === 'session-a') {
+                await sessionAGate;
+                return false;
+            }
+            return true;
+        },
+    });
     const sessionAForm = createSaveForm({ eventDate: '2026-08-23', notes: 'Session A', sessionId: 'session-a' });
     const sessionBForm = createSaveForm({ eventDate: '2026-08-24', notes: 'Session B', sessionId: 'session-b' });
     let liveForm = sessionAForm;
     const harness = createRouteSessionHarness({
         getLiveForm: () => liveForm,
-        hasPending: () => true,
-        flush: () => flush,
+        hasPending: sessionId => batcher.hasPendingFor(sessionId),
+        flush: sessionId => batcher.flushFor(sessionId),
     });
 
+    batcher.enqueue({ session_id: 'session-a', participant_id: 1 });
     const sessionASave = harness.orchestrator.submitSaveWithQueuedMoves(sessionAForm);
     harness.setActiveSessionId('session-b');
     liveForm = sessionBForm;
+    batcher.enqueue({ session_id: 'session-b', participant_id: 2 });
     const sessionBSave = harness.orchestrator.submitSaveWithQueuedMoves(sessionBForm);
-    finishFlush(true);
+    finishSessionA();
     await Promise.all([sessionASave, sessionBSave]);
 
     assert.deepEqual({
+        sent,
         eventDate: sessionBForm.value('event_date'),
         notes: sessionBForm.value('notes'),
         sessionASubmits: sessionAForm.submitCount,
         sessionBSubmits: sessionBForm.submitCount,
     }, {
+        sent: ['session-a', 'session-b'],
         eventDate: '2026-08-24',
         notes: 'Session B',
         sessionASubmits: 0,


### PR DESCRIPTION
### Problem

Saving an Event immediately after moving a participant could silently fail. Flushing the queued move replaced the route-results partial, detached the captured save form, and discarded the typed Event Date and Notes before the old form was resubmitted. Cross-session and multi-batch failures could also swallow a valid Save or incorrectly permit one after a dropped move.

### Changes

- Added a route-session orchestrator for guarded edit rendering and queued-move save handoff.
- Centralized participant-move, driver-swap, reset, and unused-driver result rendering with session validation, HTMX activation, and ETA refresh.
- Preserved Event Date and Notes across move-triggered partial replacements, then submitted only the live save-enabled replacement form.
- Made participant-move flush completion session-aware and retained failures across later same-session batches.
- Added Node coverage for stale responses, save restoration, refusal paths, re-entrant saves, and cross-session/multi-batch failure ordering.

### Decisions

- Kept the orchestration seam inside `event-planner.js` and preserved existing browser globals, inline handlers, templates, restore behavior, copy/preview behavior, and the zero-dependency Node test setup.
- Copied only the two user-editable save fields. Hidden session payload fields remain authoritative from the fresh server render.
- Error responses remain visible even when the requesting session is no longer current; only stale successful renders are discarded.
- A Save waits for every queued batch belonging to its initiating session. Failures from other sessions do not poison it, while any failure from its own session blocks submission.

### Testing

- `node --check web/static/js/event-planner.js`
- Direct Node test execution — 15/15 passed
- `make test` — passed, including `go test -race ./...`
- `git diff --check`
- GitHub CI — lint, test, Linux, macOS arm64, and Windows passed at `67e0c39`
- `make lint` could not complete locally because golangci-lint 2.12.2 was built with Go 1.26 while this machine's active toolchain is Go 1.27; it panicked before analysis. CI pins Go 1.25 and passed. No Go files changed.

<details>
<summary>Agent Context</summary>

This is an explicit no-ticket Rocket follow-up to deepen browser Event Plan orchestration.

The triggering race was concrete: the capturing submit listener prevented Event save while participant moves were queued, then awaited the move batch. A successful move response replaced `#results-section.innerHTML`, which contains the Event save form. The listener subsequently called `requestSubmit` on the detached original form. Besides losing typed values, direct `innerHTML` replacements did not call `htmx.process`, so even a newly resolved form would have been inert.

The new `createRouteSessionOrchestrator` owns two related policies over the same server-rendered route-results region:

1. `applyEditResult` reports errors, rejects successful responses for superseded sessions, and replaces current results while reprocessing HTMX bindings and refreshing ETAs.
2. `submitSaveWithQueuedMoves` snapshots only `event_date` and `notes`, serializes a save handoff per route session, flushes that session's queued moves, finds the live replacement form, restores those two fields, and submits only when the fresh form remains save-enabled and every requested-session batch succeeded.

`createParticipantMoveBatcher.flushFor(sessionId)` advances shared global batches until that session is terminal. Detailed internal outcomes allow it to ignore failures belonging only to other sessions while retaining any requested-session failure across later successful batches. The public `flush()` API remains boolean.

Normal refusal paths are intentional. A move can make routes over capacity, producing a replacement form without `hx-post` and with a disabled submit button. An error response may produce no replacement form. A multi-batch flush can render one batch and fail a later one. These cases restore typed fields when possible but do not submit or navigate.

Out of scope: replacing inline handlers, changing calculation-validation behavior, changing session restore/draft behavior, adding a package manager or DOM dependency, splitting another JS file, modifying templates or `ui.js`, and cleaning up embedded test assets.

</details>
