### PR TITLE
refactor(no-ticket): unify routing metrics

### DIFF
--- a/internal/routesession/store_test.go
+++ b/internal/routesession/store_test.go
@@ -7,6 +7,7 @@ import (
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
 	"ride-home-router/internal/routesession"
+	"ride-home-router/internal/routing"
 	"sync"
 	"testing"
 	"time"
@@ -114,6 +115,41 @@ func TestCreateReturnsIndependentFreshSnapshot(t *testing.T) {
 	}
 	if got.Routes[0].Driver.Name != "Driver" || got.ActivityLocation.Name != "HQ" {
 		t.Fatalf("snapshot aliases caller state: %#v", got)
+	}
+}
+
+func TestCreateSummaryMatchesCalculatedRoutingSummary(t *testing.T) {
+	calc := calculator{}
+	request := &routing.RoutingRequest{
+		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		Participants: []models.Participant{
+			{ID: 10, Name: "Rider", Lat: 1, Lng: 1},
+		},
+		Drivers: []models.Driver{
+			{ID: 1, Name: "Driver", Lat: 2, Lng: 0, VehicleCapacity: 1},
+		},
+		Mode: routing.RouteModeDropoff,
+	}
+	result, err := routing.NewBalancedRouter(calc).CalculateRoutes(context.Background(), request)
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+	if result.Summary.MaxDetourSecs <= 0 {
+		t.Fatalf("calculated max detour = %.1f, want nonzero fixture", result.Summary.MaxDetourSecs)
+	}
+
+	store := routesession.NewStore(calc)
+	t.Cleanup(store.Close)
+	snapshot := store.Create(routesession.CreateInput{
+		Routes:          result.Routes,
+		SelectedDrivers: request.Drivers,
+		Mode:            result.Mode,
+	})
+
+	if snapshot.Summary.MaxDetourSecs != result.Summary.MaxDetourSecs ||
+		snapshot.Summary.SumDetourSecs != result.Summary.SumDetourSecs ||
+		snapshot.Summary.AverageDetourSecs != result.Summary.AverageDetourSecs {
+		t.Fatalf("session detour summary = %+v, want calculation summary %+v", snapshot.Summary, result.Summary)
 	}
 }
 

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -95,7 +95,7 @@ func (r *BalancedRouter) CalculateRoutes(ctx context.Context, req *RoutingReques
 
 	// Phase 2: Improve route order in the context of the complete solution.
 	phase2Start := time.Now()
-	if err := r.optimizeRouteOrders(ctx, rc, routes, driverIDs); err != nil {
+	if err := rc.optimizeRouteOrders(ctx, routes, driverIDs); err != nil {
 		return nil, err
 	}
 	log.Printf("[TIMING] Phase 2 (route ordering): %v", time.Since(phase2Start))
@@ -407,7 +407,7 @@ func scoreSolution(routeMetrics map[int64]routeObjectiveMetrics, driverIDs []int
 	return result
 }
 
-func (r *BalancedRouter) optimizeRouteOrders(ctx context.Context, rc routeContext, routes map[int64]*balancedRoute, driverIDs []int64) error {
+func (rc routeContext) optimizeRouteOrders(ctx context.Context, routes map[int64]*balancedRoute, driverIDs []int64) error {
 	routeMetrics := make(map[int64]routeObjectiveMetrics, len(driverIDs))
 	candidateStops := make(map[int64][]*models.Participant, len(driverIDs))
 	for _, driverID := range driverIDs {
@@ -421,7 +421,7 @@ func (r *BalancedRouter) optimizeRouteOrders(ctx context.Context, rc routeContex
 		candidateStops[driverID] = stops
 	}
 
-	optimizedStops, _, _, err := r.optimizeStopsForSolution(ctx, rc, routes, routeMetrics, candidateStops, driverIDs)
+	optimizedStops, _, _, err := rc.optimizeStopsForSolution(ctx, routes, routeMetrics, candidateStops, driverIDs)
 	if err != nil {
 		return err
 	}
@@ -433,9 +433,8 @@ func (r *BalancedRouter) optimizeRouteOrders(ctx context.Context, rc routeContex
 
 // optimizeStopsForSolution reorders only the supplied routes, but evaluates
 // every reversal against the complete solution including unchanged peer routes.
-func (r *BalancedRouter) optimizeStopsForSolution(
+func (rc routeContext) optimizeStopsForSolution(
 	ctx context.Context,
-	rc routeContext,
 	routes map[int64]*balancedRoute,
 	baseMetrics map[int64]routeObjectiveMetrics,
 	changedStops map[int64][]*models.Participant,
@@ -542,9 +541,8 @@ func (r *BalancedRouter) optimizeAssignments(ctx context.Context, rc routeContex
 			}
 			candidateEvaluations++
 
-			optimizedStops, _, candidateScore, err := r.optimizeStopsForSolution(
+			optimizedStops, _, candidateScore, err := rc.optimizeStopsForSolution(
 				ctx,
-				rc,
 				routes,
 				routeMetrics,
 				map[int64][]*models.Participant{
@@ -647,7 +645,7 @@ func (r *BalancedRouter) optimizeAssignments(ctx context.Context, rc routeContex
 		// untouched peer route by changing which route sets the global maximum.
 		// Re-establish a full-solution ordering fixed point before evaluating the
 		// next assignment neighborhood.
-		if err := r.optimizeRouteOrders(ctx, rc, routes, driverIDs); err != nil {
+		if err := rc.optimizeRouteOrders(ctx, routes, driverIDs); err != nil {
 			return iteration, err
 		}
 		for _, driverID := range driverIDs {
@@ -674,6 +672,8 @@ func (r *BalancedRouter) buildResult(ctx context.Context, rc routeContext, route
 	calculatedRoutes := make([]models.CalculatedRoute, 0)
 	totalDropoff := 0.0
 	totalDist := 0.0
+	maxDetour := 0.0
+	sumDetour := 0.0
 	driversUsed := 0
 
 	driverIDs := make([]int64, 0, len(routes))
@@ -700,30 +700,27 @@ func (r *BalancedRouter) buildResult(ctx context.Context, rc routeContext, route
 		}
 		for i, p := range route.stops {
 			routeStops[i] = models.RouteStop{
-				Order:                    i,
-				Participant:              p,
-				DistanceFromPrevMeters:   metrics.Stops[i].DistanceFromPrevMeters,
-				CumulativeDistanceMeters: metrics.Stops[i].CumulativeDistanceMeters,
-				DurationFromPrevSecs:     metrics.Stops[i].DurationFromPrevSecs,
-				CumulativeDurationSecs:   metrics.Stops[i].CumulativeDurationSecs,
+				Participant: p,
 			}
 		}
 
 		totalDropoff += metrics.TotalStopDistanceMeters
 		totalDist += metrics.TotalDistanceMeters
+		if metrics.DetourSecs > maxDetour {
+			maxDetour = metrics.DetourSecs
+		}
+		sumDetour += metrics.DetourSecs
 
-		calculatedRoutes = append(calculatedRoutes, models.CalculatedRoute{
-			Driver:                     route.driver,
-			Stops:                      routeStops,
-			TotalDropoffDistanceMeters: metrics.TotalStopDistanceMeters,
-			DistanceToDriverHomeMeters: metrics.FinalLegDistanceMeters,
-			TotalDistanceMeters:        metrics.TotalDistanceMeters,
-			EffectiveCapacity:          route.driver.VehicleCapacity,
-			BaselineDurationSecs:       metrics.BaselineDurationSecs,
-			RouteDurationSecs:          metrics.RouteDurationSecs,
-			DetourSecs:                 metrics.DetourSecs,
-			Mode:                       rc.mode,
-		})
+		calculatedRoute := models.CalculatedRoute{
+			Driver: route.driver,
+			Stops:  routeStops,
+		}
+		rc.applyMetrics(&calculatedRoute, metrics)
+		calculatedRoutes = append(calculatedRoutes, calculatedRoute)
+	}
+	averageDetour := 0.0
+	if driversUsed > 0 {
+		averageDetour = sumDetour / float64(driversUsed)
 	}
 
 	return &models.RoutingResult{
@@ -733,6 +730,9 @@ func (r *BalancedRouter) buildResult(ctx context.Context, rc routeContext, route
 			TotalDriversUsed:           driversUsed,
 			TotalDropoffDistanceMeters: totalDropoff,
 			TotalDistanceMeters:        totalDist,
+			MaxDetourSecs:              maxDetour,
+			SumDetourSecs:              sumDetour,
+			AverageDetourSecs:          averageDetour,
 			UnassignedParticipants:     []int64{},
 		},
 		Mode: rc.mode,

--- a/internal/routing/balanced_router.go
+++ b/internal/routing/balanced_router.go
@@ -699,16 +699,12 @@ func (r *BalancedRouter) buildResult(ctx context.Context, rc routeContext, route
 			return nil, err
 		}
 		for i, p := range route.stops {
-			routeStops[i] = models.RouteStop{
-				Participant: p,
-			}
+			routeStops[i].Participant = p
 		}
 
 		totalDropoff += metrics.TotalStopDistanceMeters
 		totalDist += metrics.TotalDistanceMeters
-		if metrics.DetourSecs > maxDetour {
-			maxDetour = metrics.DetourSecs
-		}
+		maxDetour = max(maxDetour, metrics.DetourSecs)
 		sumDetour += metrics.DetourSecs
 
 		calculatedRoute := models.CalculatedRoute{

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -563,17 +563,33 @@ func TestOptimizeAssignments_ReordersUntouchedPeerAfterGlobalMaximumChanges(t *t
 }
 
 func TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective(t *testing.T) {
-	router := NewBalancedRouter(stableDistanceCalculator{})
+	activity := models.Coordinates{Lat: 0, Lng: 0}
+	first := models.Coordinates{Lat: 1, Lng: 0}
+	second := models.Coordinates{Lat: 2, Lng: 0}
+	nearbyHome := models.Coordinates{Lat: 3, Lng: 0}
+	oppositeHome := models.Coordinates{Lat: -100, Lng: 0}
+	distances := newOverrideDistanceAdapter(1000)
+	distances.setDuration(activity, first, 1)
+	distances.setDuration(activity, second, 2)
+	distances.setDuration(first, second, 1)
+	distances.setDuration(second, first, 1)
+	distances.setDuration(first, nearbyHome, 1)
+	distances.setDuration(second, nearbyHome, 2)
+	distances.setDuration(activity, nearbyHome, 2)
+	distances.setDuration(first, oppositeHome, 101)
+	distances.setDuration(second, oppositeHome, 102)
+	distances.setDuration(activity, oppositeHome, 100)
+	router := NewBalancedRouter(distances)
 
 	result, err := router.CalculateRoutes(context.Background(), &RoutingRequest{
-		InstituteCoords: models.Coordinates{Lat: 0, Lng: 0},
+		InstituteCoords: activity,
 		Participants: []models.Participant{
-			{ID: 1, Name: "First", Lat: 1, Lng: 0},
-			{ID: 2, Name: "Second", Lat: 2, Lng: 0},
+			{ID: 1, Name: "First", Lat: first.Lat, Lng: first.Lng},
+			{ID: 2, Name: "Second", Lat: second.Lat, Lng: second.Lng},
 		},
 		Drivers: []models.Driver{
-			{ID: 1, Name: "Nearby Driver", Lat: 2, Lng: 0, VehicleCapacity: 2},
-			{ID: 2, Name: "Opposite Driver", Lat: -100, Lng: 0, VehicleCapacity: 2},
+			{ID: 1, Name: "Nearby Driver", Lat: nearbyHome.Lat, Lng: nearbyHome.Lng, VehicleCapacity: 2},
+			{ID: 2, Name: "Opposite Driver", Lat: oppositeHome.Lat, Lng: oppositeHome.Lng, VehicleCapacity: 2},
 		},
 		Mode: RouteModeDropoff,
 	})
@@ -590,8 +606,11 @@ func TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective
 	if len(result.Routes[0].Stops) != 2 {
 		t.Fatalf("nearby driver stops = %d, want 2", len(result.Routes[0].Stops))
 	}
-	if result.Summary.MaxDetourSecs != 0 || result.Summary.SumDetourSecs != 0 || result.Summary.AverageDetourSecs != 0 {
-		t.Fatalf("unused driver affected detour summary: %+v", result.Summary)
+	if result.Summary.SumDetourSecs <= 0 {
+		t.Fatalf("sum detour = %.1f, want a nonzero fixture", result.Summary.SumDetourSecs)
+	}
+	if result.Summary.MaxDetourSecs != result.Summary.SumDetourSecs || result.Summary.AverageDetourSecs != result.Summary.SumDetourSecs {
+		t.Fatalf("unused driver affected detour summary divisor: %+v", result.Summary)
 	}
 }
 

--- a/internal/routing/balanced_router_test.go
+++ b/internal/routing/balanced_router_test.go
@@ -458,8 +458,12 @@ func TestBalancedRouter_OrdersRoutesAgainstTheFullSolutionObjective(t *testing.T
 
 	var firstRoute *models.CalculatedRoute
 	latestDropoff := 0.0
+	maxDetour := 0.0
+	sumDetour := 0.0
 	for i := range result.Routes {
 		route := &result.Routes[i]
+		maxDetour = max(maxDetour, route.DetourSecs)
+		sumDetour += route.DetourSecs
 		for _, stop := range route.Stops {
 			latestDropoff = max(latestDropoff, stop.CumulativeDurationSecs)
 		}
@@ -478,6 +482,21 @@ func TestBalancedRouter_OrdersRoutesAgainstTheFullSolutionObjective(t *testing.T
 	}
 	if latestDropoff != 12 {
 		t.Fatalf("latest dropoff = %.0f, want peer-route maximum 12", latestDropoff)
+	}
+	if maxDetour != 3 || sumDetour != 3 {
+		t.Fatalf("route detours: max=%.1f sum=%.1f, want max=3 sum=3", maxDetour, sumDetour)
+	}
+	if result.Summary.MaxDetourSecs != 3 {
+		t.Fatalf("summary max detour = %.1f, want 3", result.Summary.MaxDetourSecs)
+	}
+	if result.Summary.SumDetourSecs != 3 {
+		t.Fatalf("summary sum detour = %.1f, want 3", result.Summary.SumDetourSecs)
+	}
+	if result.Summary.AverageDetourSecs != 1.5 {
+		t.Fatalf("summary average detour = %.1f, want 1.5", result.Summary.AverageDetourSecs)
+	}
+	if result.Summary.MaxDetourSecs != maxDetour || result.Summary.SumDetourSecs != sumDetour {
+		t.Fatalf("summary detours %+v do not match returned routes", result.Summary)
 	}
 }
 
@@ -528,7 +547,7 @@ func TestOptimizeAssignments_ReordersUntouchedPeerAfterGlobalMaximumChanges(t *t
 	driverIDs := []int64{driver1.ID, driver2.ID, driver3.ID}
 	rc := newRouteContext(distances, activity, RouteModeDropoff)
 
-	if err := router.optimizeRouteOrders(ctx, rc, routes, driverIDs); err != nil {
+	if err := rc.optimizeRouteOrders(ctx, routes, driverIDs); err != nil {
 		t.Fatalf("optimizeRouteOrders() error = %v", err)
 	}
 	if routes[driver3.ID].stops[0].ID != c1.ID {
@@ -570,6 +589,9 @@ func TestBalancedRouter_CanLeaveASelectedDriverUnusedForAHigherPriorityObjective
 	}
 	if len(result.Routes[0].Stops) != 2 {
 		t.Fatalf("nearby driver stops = %d, want 2", len(result.Routes[0].Stops))
+	}
+	if result.Summary.MaxDetourSecs != 0 || result.Summary.SumDetourSecs != 0 || result.Summary.AverageDetourSecs != 0 {
+		t.Fatalf("unused driver affected detour summary: %+v", result.Summary)
 	}
 }
 

--- a/internal/routing/route_metrics.go
+++ b/internal/routing/route_metrics.go
@@ -168,22 +168,9 @@ func (rc routeContext) groupInsertionDeltaRiderScoreFrom(ctx context.Context, dr
 	return after - before, nil
 }
 
-func PopulateRouteMetrics(ctx context.Context, distanceCalc distance.DistanceCalculator, instituteCoords models.Coordinates, mode RouteMode, route *models.CalculatedRoute) error {
-	if route == nil {
-		return fmt.Errorf("route is required")
-	}
-
-	rc := newRouteContext(distanceCalc, instituteCoords, mode)
-	participants := make([]*models.Participant, len(route.Stops))
-	for i := range route.Stops {
-		participants[i] = route.Stops[i].Participant
-	}
-
-	metrics, err := rc.evaluateParticipants(ctx, route.Driver, participants)
-	if err != nil {
-		return err
-	}
-
+// applyMetrics updates route display fields from metrics evaluated for the
+// participants in route.Stops, in the same order.
+func (rc routeContext) applyMetrics(route *models.CalculatedRoute, metrics *routeMetrics) {
 	for i := range route.Stops {
 		route.Stops[i].Order = i
 		route.Stops[i].DistanceFromPrevMeters = metrics.Stops[i].DistanceFromPrevMeters
@@ -202,6 +189,25 @@ func PopulateRouteMetrics(ctx context.Context, distanceCalc distance.DistanceCal
 	if route.EffectiveCapacity == 0 && route.Driver != nil {
 		route.EffectiveCapacity = route.Driver.VehicleCapacity
 	}
+}
+
+func PopulateRouteMetrics(ctx context.Context, distanceCalc distance.DistanceCalculator, instituteCoords models.Coordinates, mode RouteMode, route *models.CalculatedRoute) error {
+	if route == nil {
+		return fmt.Errorf("route is required")
+	}
+
+	rc := newRouteContext(distanceCalc, instituteCoords, mode)
+	participants := make([]*models.Participant, len(route.Stops))
+	for i := range route.Stops {
+		participants[i] = route.Stops[i].Participant
+	}
+
+	metrics, err := rc.evaluateParticipants(ctx, route.Driver, participants)
+	if err != nil {
+		return err
+	}
+
+	rc.applyMetrics(route, metrics)
 
 	return nil
 }
@@ -229,8 +235,7 @@ func OptimizeRouteOrder(ctx context.Context, distanceCalc distance.DistanceCalcu
 			stops:  participants,
 		},
 	}
-	router := &BalancedRouter{distanceCalc: distanceCalc}
-	if err := router.optimizeRouteOrders(ctx, rc, routes, []int64{driverID}); err != nil {
+	if err := rc.optimizeRouteOrders(ctx, routes, []int64{driverID}); err != nil {
 		return err
 	}
 	optimized := routes[driverID].stops

--- a/internal/routing/route_metrics_test.go
+++ b/internal/routing/route_metrics_test.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"context"
 	"math"
+	"reflect"
 	"ride-home-router/internal/distance"
 	"ride-home-router/internal/models"
 	"sync"
@@ -181,6 +182,9 @@ func TestPopulateRouteMetrics_PickupIncludesActivityDestination(t *testing.T) {
 	if route.DetourSecs != 0 {
 		t.Fatalf("DetourSecs = %.0f, want 0", route.DetourSecs)
 	}
+	if route.EffectiveCapacity != 4 {
+		t.Fatalf("EffectiveCapacity = %d, want driver capacity 4", route.EffectiveCapacity)
+	}
 	if len(route.Stops) != 2 {
 		t.Fatalf("len(route.Stops) = %d, want 2", len(route.Stops))
 	}
@@ -195,9 +199,83 @@ func TestPopulateRouteMetrics_PickupIncludesActivityDestination(t *testing.T) {
 	}
 }
 
-func TestOptimizeRouteOrder_ReordersAndRefreshesMetrics(t *testing.T) {
+func TestPopulateRouteMetrics_PreservesOrgVehicleAssignment(t *testing.T) {
+	orgVehicleID := int64(30)
 	route := &models.CalculatedRoute{
-		Driver: &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0},
+		Driver:            &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0, VehicleCapacity: 2},
+		OrgVehicleID:      orgVehicleID,
+		OrgVehicleName:    "Van",
+		EffectiveCapacity: 5,
+		Stops: []models.RouteStop{
+			{Participant: &models.Participant{ID: 1, Name: "Passenger", Lat: 8, Lng: 0}},
+		},
+	}
+
+	if err := PopulateRouteMetrics(context.Background(), stableDistanceCalculator{}, models.Coordinates{}, RouteModeDropoff, route); err != nil {
+		t.Fatalf("PopulateRouteMetrics() error = %v", err)
+	}
+
+	if route.OrgVehicleID != orgVehicleID {
+		t.Fatalf("OrgVehicleID = %v, want %d", route.OrgVehicleID, orgVehicleID)
+	}
+	if route.OrgVehicleName != "Van" {
+		t.Fatalf("OrgVehicleName = %q, want Van", route.OrgVehicleName)
+	}
+	if route.EffectiveCapacity != 5 {
+		t.Fatalf("EffectiveCapacity = %d, want assigned vehicle capacity 5", route.EffectiveCapacity)
+	}
+}
+
+func TestCalculateRoutes_MetricsMatchPopulateRouteMetrics(t *testing.T) {
+	ctx := context.Background()
+	calc := stableDistanceCalculator{}
+	activity := models.Coordinates{Lat: 0, Lng: 0}
+	router := NewBalancedRouter(calc)
+	result, err := router.CalculateRoutes(ctx, &RoutingRequest{
+		InstituteCoords: activity,
+		Participants: []models.Participant{
+			{ID: 1, Name: "Near", Lat: 2, Lng: 0},
+			{ID: 2, Name: "Far", Lat: 7, Lng: 0},
+		},
+		Drivers: []models.Driver{
+			{ID: 7, Name: "Driver", Lat: 10, Lng: 0, VehicleCapacity: 2},
+		},
+		Mode: "",
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
+	}
+	if len(result.Routes) != 1 {
+		t.Fatalf("len(result.Routes) = %d, want 1", len(result.Routes))
+	}
+	if result.Mode != RouteModeDropoff || result.Routes[0].Mode != RouteModeDropoff {
+		t.Fatalf("default modes: result=%q route=%q, want dropoff", result.Mode, result.Routes[0].Mode)
+	}
+	for i, stop := range result.Routes[0].Stops {
+		if stop.Order != i {
+			t.Fatalf("stop %d order = %d, want dense zero-based order", i, stop.Order)
+		}
+	}
+
+	want := result.Routes[0]
+	recomputed := want
+	recomputed.Stops = append([]models.RouteStop(nil), want.Stops...)
+	if err := PopulateRouteMetrics(ctx, calc, activity, "", &recomputed); err != nil {
+		t.Fatalf("PopulateRouteMetrics() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(recomputed, want) {
+		t.Fatalf("recomputed route = %#v, want CalculateRoutes result %#v", recomputed, want)
+	}
+}
+
+func TestOptimizeRouteOrder_ReordersAndRefreshesMetrics(t *testing.T) {
+	orgVehicleID := int64(30)
+	route := &models.CalculatedRoute{
+		Driver:            &models.Driver{ID: 1, Name: "Driver", Lat: 10, Lng: 0, VehicleCapacity: 2},
+		OrgVehicleID:      orgVehicleID,
+		OrgVehicleName:    "Van",
+		EffectiveCapacity: 5,
 		Stops: []models.RouteStop{
 			{Participant: &models.Participant{ID: 2, Name: "Origin Detour", Lat: 1, Lng: 100}},
 			{Participant: &models.Participant{ID: 1, Name: "Destination Side", Lat: 9, Lng: 0}},
@@ -217,39 +295,46 @@ func TestOptimizeRouteOrder_ReordersAndRefreshesMetrics(t *testing.T) {
 	if route.TotalDistanceMeters == 0 || route.RouteDurationSecs == 0 {
 		t.Fatalf("route metrics were not refreshed: total=%.0f duration=%.0f", route.TotalDistanceMeters, route.RouteDurationSecs)
 	}
+	if route.OrgVehicleID != orgVehicleID || route.OrgVehicleName != "Van" {
+		t.Fatalf("organization vehicle assignment changed: id=%v name=%q", route.OrgVehicleID, route.OrgVehicleName)
+	}
+	if route.EffectiveCapacity != 5 {
+		t.Fatalf("EffectiveCapacity = %d, want assigned vehicle capacity 5", route.EffectiveCapacity)
+	}
 }
 
-func TestOptimizeRouteOrder_MatchesSolverOrdering(t *testing.T) {
+func TestOptimizeRouteOrder_PreservesSingleRouteSolverResult(t *testing.T) {
 	ctx := context.Background()
 	calc := stableDistanceCalculator{}
 	activity := models.Coordinates{Lat: 0, Lng: 0}
-	driver := &models.Driver{ID: 7, Name: "Driver", Lat: 10, Lng: 0}
-	participants := []*models.Participant{
-		{ID: 1, Name: "Far", Lat: 2, Lng: 8},
-		{ID: 2, Name: "Near Home", Lat: 9, Lng: 0},
-		{ID: 3, Name: "Near Activity", Lat: 1, Lng: 0},
+	result, err := NewBalancedRouter(calc).CalculateRoutes(ctx, &RoutingRequest{
+		InstituteCoords: activity,
+		Participants: []models.Participant{
+			{ID: 1, Name: "Far", Lat: 2, Lng: 8},
+			{ID: 2, Name: "Near Home", Lat: 9, Lng: 0},
+			{ID: 3, Name: "Near Activity", Lat: 1, Lng: 0},
+		},
+		Drivers: []models.Driver{
+			{ID: 7, Name: "Driver", Lat: 10, Lng: 0, VehicleCapacity: 3},
+		},
+		Mode: RouteModeDropoff,
+	})
+	if err != nil {
+		t.Fatalf("CalculateRoutes() error = %v", err)
 	}
-	route := &models.CalculatedRoute{Driver: driver, Stops: make([]models.RouteStop, len(participants))}
-	for i, participant := range participants {
-		route.Stops[i].Participant = participant
+	if len(result.Routes) != 1 {
+		t.Fatalf("len(result.Routes) = %d, want 1", len(result.Routes))
 	}
 
-	if err := OptimizeRouteOrder(ctx, calc, activity, RouteModeDropoff, route); err != nil {
+	want := result.Routes[0]
+	optimized := want
+	optimized.Stops = append([]models.RouteStop(nil), want.Stops...)
+	if err := OptimizeRouteOrder(ctx, calc, activity, RouteModeDropoff, &optimized); err != nil {
 		t.Fatalf("OptimizeRouteOrder() error = %v", err)
 	}
 
-	internalRoutes := map[int64]*balancedRoute{
-		driver.ID: {driver: driver, stops: append([]*models.Participant(nil), participants...)},
-	}
-	router := &BalancedRouter{distanceCalc: calc}
-	if err := router.optimizeRouteOrders(ctx, newRouteContext(calc, activity, RouteModeDropoff), internalRoutes, []int64{driver.ID}); err != nil {
-		t.Fatalf("optimizeRouteOrders() error = %v", err)
-	}
-
-	for i, stop := range route.Stops {
-		if got, want := stop.Participant.ID, internalRoutes[driver.ID].stops[i].ID; got != want {
-			t.Fatalf("stop %d participant = %d, want solver order %d", i, got, want)
-		}
+	if !reflect.DeepEqual(optimized, want) {
+		t.Fatalf("optimized route = %#v, want solver result %#v", optimized, want)
 	}
 }
 


### PR DESCRIPTION
### Problem

Routing objective evaluation and displayed route metrics shared traversal
logic but diverged at two seams: route ordering lived on a BalancedRouter
receiver it did not use, and CalculateRoutes duplicated the route/stop field
mapping used by PopulateRouteMetrics. CalculateRoutes also returned zero max,
sum, and average detour values in its JSON summary despite nonzero route
detours.

### Changes

- Moved route-order search onto the existing routeContext value receiver.
- Removed the fabricated BalancedRouter from OptimizeRouteOrder.
- Added one shared routeContext metric materializer for calculated and edited
  routes.
- Populated calculate-response detour summary aggregates from emitted routes.
- Added regression coverage for metric parity, assigned-vehicle preservation,
  default mode/order, optimization idempotence, unused drivers, and
  route-session summary agreement.

### Decisions

- Kept public APIs, routeContext, balancedRoute, and objective/scoring types.
- Kept solution-level assignment and summary orchestration on BalancedRouter.
- Matched route-session detour semantics exactly, including the zero-floored
  maximum and used-driver average divisor.
- Preserved existing organization-vehicle identity and nonzero effective
  capacity during route edits.

### Testing

- `/home/ar/.local/share/mise/installs/go/1.27.0/bin/go test ./...`
- `/home/ar/.local/share/mise/installs/go/1.27.0/bin/go test -race ./internal/routing ./internal/routesession`
- `/home/ar/.local/share/mise/installs/go/1.27.0/bin/go vet ./...`
- `node --test web/static/js/*.test.js`
- `git diff --check`

`make lint` cannot complete in the current environment. The installed
golangci-lint 2.12.2 was built with Go 1.26 and panics while loading this Go
1.27 module.

<details>
<summary>Agent Context</summary>

The change intentionally deepens the existing routeContext seam rather than
introducing another abstraction. `evaluateRouteObjective` already projected
participant-first objective values from `evaluateParticipants`; the order
search methods used only that context plus their arguments, so their former
BalancedRouter receiver was false coupling. The shared `applyMetrics` method
is unexported and has exactly two consumers: fresh solver result construction
and public metric recalculation for edited routes.

The calculate JSON summary bug was reproduced with two independently specified
routes whose detours are 3 and 0 seconds. Before the fix, returned route data
had those values while all three detour summary fields were zero. The fixed
summary is max 3, sum 3, average 1.5. HTML route results were not broken because
they already rebuild their summary through the route-session store.

Important preserved invariants include pickup/dropoff semantics, default
dropoff mode, participant-first lexicographic priorities, household adjacency,
deterministic first-found ties, search caps/epsilon, empty-route filtering,
in-place mutation, and routeContext value-receiver concurrency. Existing
organization-vehicle ID/name and a nonzero effective capacity are preserved
during both PopulateRouteMetrics and OptimizeRouteOrder.

</details>
