### PR TITLE
refactor(no-ticket): deepen route plan lifecycle

### DIFF
--- a/internal/eventsnapshot/snapshot.go
+++ b/internal/eventsnapshot/snapshot.go
@@ -1,0 +1,104 @@
+// Package eventsnapshot converts live routing results into immutable event history snapshots.
+package eventsnapshot
+
+import (
+	"errors"
+	"ride-home-router/internal/models"
+)
+
+var (
+	// ErrRoutesRequired indicates that no route contains any stops.
+	ErrRoutesRequired = errors.New("routes are required")
+	// ErrDriverRequired indicates that a route has no assigned driver.
+	ErrDriverRequired = errors.New("each route must include a driver")
+	// ErrParticipantRequired indicates that a route stop has no participant.
+	ErrParticipantRequired = errors.New("each route stop must include a participant")
+	// ErrMixedModes indicates that the saved routes do not share one mode.
+	ErrMixedModes = errors.New("all routes must use the same mode")
+)
+
+// Snapshot contains the immutable routes and summary persisted for an event.
+type Snapshot struct {
+	Mode    models.RouteMode
+	Routes  []models.EventRoute
+	Summary models.EventSummary
+}
+
+// Build validates a live routing result and converts it to an event snapshot.
+func Build(result models.RoutingResult) (Snapshot, error) {
+	mode, err := models.ParseRouteMode(string(result.Mode))
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snapshot := Snapshot{Mode: mode, Routes: make([]models.EventRoute, 0, len(result.Routes))}
+	for _, route := range result.Routes {
+		if route.Driver == nil {
+			return Snapshot{}, ErrDriverRequired
+		}
+		if len(route.Stops) == 0 {
+			continue
+		}
+		routeMode := route.Mode
+		if routeMode == "" {
+			routeMode = mode
+		}
+		routeMode, err = models.ParseRouteMode(string(routeMode))
+		if err != nil {
+			return Snapshot{}, err
+		}
+		if routeMode != mode {
+			return Snapshot{}, ErrMixedModes
+		}
+		for _, stop := range route.Stops {
+			if stop.Participant == nil {
+				return Snapshot{}, ErrParticipantRequired
+			}
+		}
+		eventRoute := models.EventRoute{
+			RouteOrder:                 len(snapshot.Routes),
+			DriverID:                   route.Driver.ID,
+			DriverName:                 route.Driver.Name,
+			DriverAddress:              route.Driver.Address,
+			EffectiveCapacity:          route.EffectiveCapacity,
+			OrgVehicleID:               route.OrgVehicleID,
+			OrgVehicleName:             route.OrgVehicleName,
+			TotalDropoffDistanceMeters: route.TotalDropoffDistanceMeters,
+			DistanceToDriverHomeMeters: route.DistanceToDriverHomeMeters,
+			TotalDistanceMeters:        route.TotalDistanceMeters,
+			BaselineDurationSecs:       route.BaselineDurationSecs,
+			RouteDurationSecs:          route.RouteDurationSecs,
+			DetourSecs:                 route.DetourSecs,
+			Mode:                       routeMode,
+			SnapshotVersion:            2,
+			MetricsComplete:            true,
+			Stops:                      make([]models.EventRouteStop, 0, len(route.Stops)),
+		}
+		if eventRoute.EffectiveCapacity == 0 {
+			eventRoute.EffectiveCapacity = route.Driver.VehicleCapacity
+		}
+		for stopIndex, stop := range route.Stops {
+			eventRoute.Stops = append(eventRoute.Stops, models.EventRouteStop{
+				Order:                    stopIndex,
+				ParticipantID:            stop.Participant.ID,
+				ParticipantName:          stop.Participant.Name,
+				ParticipantAddress:       stop.Participant.Address,
+				DistanceFromPrevMeters:   stop.DistanceFromPrevMeters,
+				CumulativeDistanceMeters: stop.CumulativeDistanceMeters,
+				DurationFromPrevSecs:     stop.DurationFromPrevSecs,
+				CumulativeDurationSecs:   stop.CumulativeDurationSecs,
+			})
+			snapshot.Summary.TotalParticipants++
+		}
+		snapshot.Summary.TotalDrivers++
+		snapshot.Summary.TotalDistanceMeters += route.TotalDistanceMeters
+		if route.OrgVehicleID > 0 {
+			snapshot.Summary.OrgVehiclesUsed++
+		}
+		snapshot.Routes = append(snapshot.Routes, eventRoute)
+	}
+	if len(snapshot.Routes) == 0 {
+		return Snapshot{}, ErrRoutesRequired
+	}
+	snapshot.Summary.Mode = mode
+	return snapshot, nil
+}

--- a/internal/eventsnapshot/snapshot.go
+++ b/internal/eventsnapshot/snapshot.go
@@ -49,11 +49,6 @@ func Build(result models.RoutingResult) (Snapshot, error) {
 		if routeMode != mode {
 			return Snapshot{}, ErrMixedModes
 		}
-		for _, stop := range route.Stops {
-			if stop.Participant == nil {
-				return Snapshot{}, ErrParticipantRequired
-			}
-		}
 		eventRoute := models.EventRoute{
 			RouteOrder:                 len(snapshot.Routes),
 			DriverID:                   route.Driver.ID,
@@ -77,6 +72,9 @@ func Build(result models.RoutingResult) (Snapshot, error) {
 			eventRoute.EffectiveCapacity = route.Driver.VehicleCapacity
 		}
 		for stopIndex, stop := range route.Stops {
+			if stop.Participant == nil {
+				return Snapshot{}, ErrParticipantRequired
+			}
 			eventRoute.Stops = append(eventRoute.Stops, models.EventRouteStop{
 				Order:                    stopIndex,
 				ParticipantID:            stop.Participant.ID,

--- a/internal/eventsnapshot/snapshot_test.go
+++ b/internal/eventsnapshot/snapshot_test.go
@@ -8,6 +8,23 @@ import (
 	"testing"
 )
 
+func TestValidationSentinelText(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{eventsnapshot.ErrRoutesRequired, "routes are required"},
+		{eventsnapshot.ErrDriverRequired, "each route must include a driver"},
+		{eventsnapshot.ErrParticipantRequired, "each route stop must include a participant"},
+		{eventsnapshot.ErrMixedModes, "all routes must use the same mode"},
+	}
+	for _, test := range tests {
+		if got := test.err.Error(); got != test.want {
+			t.Errorf("sentinel text = %q, want %q", got, test.want)
+		}
+	}
+}
+
 func TestBuildRequiresAtLeastOneNonEmptyRoute(t *testing.T) {
 	result := models.RoutingResult{
 		Mode: models.RouteModeDropoff,

--- a/internal/eventsnapshot/snapshot_test.go
+++ b/internal/eventsnapshot/snapshot_test.go
@@ -1,0 +1,208 @@
+package eventsnapshot_test
+
+import (
+	"errors"
+	"reflect"
+	"ride-home-router/internal/eventsnapshot"
+	"ride-home-router/internal/models"
+	"testing"
+)
+
+func TestBuildRequiresAtLeastOneNonEmptyRoute(t *testing.T) {
+	result := models.RoutingResult{
+		Mode: models.RouteModeDropoff,
+		Routes: []models.CalculatedRoute{{
+			Driver: &models.Driver{ID: 1, VehicleCapacity: 2},
+			Mode:   models.RouteModeDropoff,
+		}},
+	}
+
+	_, err := eventsnapshot.Build(result)
+
+	if !errors.Is(err, eventsnapshot.ErrRoutesRequired) {
+		t.Fatalf("Build error = %v, want ErrRoutesRequired", err)
+	}
+}
+
+func TestBuildRequiresDriverBeforeSkippingEmptyRoute(t *testing.T) {
+	result := models.RoutingResult{
+		Mode:   models.RouteModeDropoff,
+		Routes: []models.CalculatedRoute{{Mode: models.RouteModeDropoff}},
+	}
+
+	_, err := eventsnapshot.Build(result)
+
+	if !errors.Is(err, eventsnapshot.ErrDriverRequired) {
+		t.Fatalf("Build error = %v, want ErrDriverRequired", err)
+	}
+}
+
+func TestBuildRequiresParticipantForEveryStop(t *testing.T) {
+	result := models.RoutingResult{
+		Mode: models.RouteModeDropoff,
+		Routes: []models.CalculatedRoute{{
+			Driver: &models.Driver{ID: 1, VehicleCapacity: 2},
+			Stops:  []models.RouteStop{{}},
+			Mode:   models.RouteModeDropoff,
+		}},
+	}
+
+	_, err := eventsnapshot.Build(result)
+
+	if !errors.Is(err, eventsnapshot.ErrParticipantRequired) {
+		t.Fatalf("Build error = %v, want ErrParticipantRequired", err)
+	}
+}
+
+func TestBuildNormalizesBlankModesToDropoff(t *testing.T) {
+	result := models.RoutingResult{
+		Routes: []models.CalculatedRoute{{
+			Driver: &models.Driver{ID: 1, VehicleCapacity: 2},
+			Stops:  []models.RouteStop{{Participant: &models.Participant{ID: 10}}},
+		}},
+	}
+
+	snapshot, err := eventsnapshot.Build(result)
+	if err != nil {
+		t.Fatalf("Build error = %v", err)
+	}
+	if snapshot.Mode != models.RouteModeDropoff {
+		t.Fatalf("snapshot mode = %q, want dropoff", snapshot.Mode)
+	}
+	if len(snapshot.Routes) != 1 || snapshot.Routes[0].Mode != models.RouteModeDropoff {
+		t.Fatalf("snapshot routes = %#v, want one dropoff route", snapshot.Routes)
+	}
+}
+
+func TestBuildRejectsMixedModes(t *testing.T) {
+	result := models.RoutingResult{
+		Mode: models.RouteModeDropoff,
+		Routes: []models.CalculatedRoute{{
+			Driver: &models.Driver{ID: 1, VehicleCapacity: 2},
+			Stops:  []models.RouteStop{{Participant: &models.Participant{ID: 10}}},
+			Mode:   models.RouteModePickup,
+		}},
+	}
+
+	_, err := eventsnapshot.Build(result)
+
+	if !errors.Is(err, eventsnapshot.ErrMixedModes) {
+		t.Fatalf("Build error = %v, want ErrMixedModes", err)
+	}
+}
+
+func TestBuildCreatesCompleteEventSnapshot(t *testing.T) {
+	result := models.RoutingResult{
+		Mode: models.RouteModePickup,
+		Routes: []models.CalculatedRoute{
+			{
+				Driver: &models.Driver{ID: 99, Name: "Unused", VehicleCapacity: 1},
+				Mode:   models.RouteMode("ignored-invalid-mode"),
+			},
+			{
+				Driver:                     &models.Driver{ID: 1, Name: "Driver One", Address: "1 Driver Way", VehicleCapacity: 3},
+				OrgVehicleID:               7,
+				OrgVehicleName:             "Shared Van",
+				TotalDropoffDistanceMeters: 1000,
+				DistanceToDriverHomeMeters: 250,
+				TotalDistanceMeters:        1250,
+				BaselineDurationSecs:       600,
+				RouteDurationSecs:          900,
+				DetourSecs:                 300,
+				Stops: []models.RouteStop{
+					{
+						Participant:              &models.Participant{ID: 10, Name: "Alice", Address: "10 Rider Road"},
+						DistanceFromPrevMeters:   400,
+						CumulativeDistanceMeters: 400,
+						DurationFromPrevSecs:     240,
+						CumulativeDurationSecs:   240,
+					},
+					{
+						Participant:              &models.Participant{ID: 11, Name: "Bob", Address: "11 Rider Road"},
+						DistanceFromPrevMeters:   600,
+						CumulativeDistanceMeters: 1000,
+						DurationFromPrevSecs:     360,
+						CumulativeDurationSecs:   600,
+					},
+				},
+			},
+			{
+				Driver:                     &models.Driver{ID: 2, Name: "Driver Two", Address: "2 Driver Way", VehicleCapacity: 4},
+				EffectiveCapacity:          5,
+				OrgVehicleID:               7,
+				OrgVehicleName:             "Shared Van",
+				TotalDropoffDistanceMeters: 900,
+				DistanceToDriverHomeMeters: 350,
+				TotalDistanceMeters:        1250,
+				BaselineDurationSecs:       700,
+				RouteDurationSecs:          1000,
+				DetourSecs:                 300,
+				Mode:                       models.RouteModePickup,
+				Stops: []models.RouteStop{{
+					Participant:              &models.Participant{ID: 12, Name: "Casey", Address: "12 Rider Road"},
+					DistanceFromPrevMeters:   900,
+					CumulativeDistanceMeters: 900,
+					DurationFromPrevSecs:     540,
+					CumulativeDurationSecs:   540,
+				}},
+			},
+		},
+	}
+	want := eventsnapshot.Snapshot{
+		Mode: models.RouteModePickup,
+		Routes: []models.EventRoute{
+			{
+				RouteOrder: 0, DriverID: 1, DriverName: "Driver One", DriverAddress: "1 Driver Way",
+				EffectiveCapacity: 3, OrgVehicleID: 7, OrgVehicleName: "Shared Van",
+				TotalDropoffDistanceMeters: 1000, DistanceToDriverHomeMeters: 250, TotalDistanceMeters: 1250,
+				BaselineDurationSecs: 600, RouteDurationSecs: 900, DetourSecs: 300,
+				Mode: models.RouteModePickup, SnapshotVersion: 2, MetricsComplete: true,
+				Stops: []models.EventRouteStop{
+					{Order: 0, ParticipantID: 10, ParticipantName: "Alice", ParticipantAddress: "10 Rider Road", DistanceFromPrevMeters: 400, CumulativeDistanceMeters: 400, DurationFromPrevSecs: 240, CumulativeDurationSecs: 240},
+					{Order: 1, ParticipantID: 11, ParticipantName: "Bob", ParticipantAddress: "11 Rider Road", DistanceFromPrevMeters: 600, CumulativeDistanceMeters: 1000, DurationFromPrevSecs: 360, CumulativeDurationSecs: 600},
+				},
+			},
+			{
+				RouteOrder: 1, DriverID: 2, DriverName: "Driver Two", DriverAddress: "2 Driver Way",
+				EffectiveCapacity: 5, OrgVehicleID: 7, OrgVehicleName: "Shared Van",
+				TotalDropoffDistanceMeters: 900, DistanceToDriverHomeMeters: 350, TotalDistanceMeters: 1250,
+				BaselineDurationSecs: 700, RouteDurationSecs: 1000, DetourSecs: 300,
+				Mode: models.RouteModePickup, SnapshotVersion: 2, MetricsComplete: true,
+				Stops: []models.EventRouteStop{{Order: 0, ParticipantID: 12, ParticipantName: "Casey", ParticipantAddress: "12 Rider Road", DistanceFromPrevMeters: 900, CumulativeDistanceMeters: 900, DurationFromPrevSecs: 540, CumulativeDurationSecs: 540}},
+			},
+		},
+		Summary: models.EventSummary{TotalParticipants: 3, TotalDrivers: 2, TotalDistanceMeters: 2500, OrgVehiclesUsed: 2, Mode: models.RouteModePickup},
+	}
+
+	got, err := eventsnapshot.Build(result)
+	if err != nil {
+		t.Fatalf("Build error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Build = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildPreservesInvalidModeIdentity(t *testing.T) {
+	_, err := eventsnapshot.Build(models.RoutingResult{Mode: models.RouteMode("invalid")})
+	if !errors.Is(err, models.ErrInvalidRouteMode) {
+		t.Fatalf("Build error = %v, want ErrInvalidRouteMode", err)
+	}
+}
+
+func TestBuildValidatesRouteModeBeforeParticipants(t *testing.T) {
+	result := models.RoutingResult{
+		Mode: models.RouteModeDropoff,
+		Routes: []models.CalculatedRoute{{
+			Driver: &models.Driver{ID: 1, VehicleCapacity: 2},
+			Stops:  []models.RouteStop{{}},
+			Mode:   models.RouteMode("invalid"),
+		}},
+	}
+
+	_, err := eventsnapshot.Build(result)
+
+	if !errors.Is(err, models.ErrInvalidRouteMode) {
+		t.Fatalf("Build error = %v, want ErrInvalidRouteMode", err)
+	}
+}

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -281,7 +281,11 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		if h.handleEventValidationError(w, sessionErr) {
 			return
 		}
-		if errors.Is(sessionErr, routesession.ErrNotFound) {
+		if errors.Is(sessionErr, routesession.ErrAlreadyCommitted) {
+			log.Printf("[HTTP] POST /api/v1/events: session_already_committed session_id=%s", req.SessionID)
+			h.handleNotFound(w, messageSessionNotFound)
+			return
+		} else if errors.Is(sessionErr, routesession.ErrNotFound) {
 			if req.Routes == nil && formRoutesJSON != "" {
 				routes, ok := h.parsePostedRoutesJSON(w, formRoutesJSON)
 				if !ok {

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"ride-home-router/internal/eventsnapshot"
 	"ride-home-router/internal/httpx"
 	"ride-home-router/internal/models"
 	"ride-home-router/internal/routesession"
@@ -52,6 +53,14 @@ type CreateEventRequest struct {
 	Notes     string                `json:"notes"`
 	Routes    *models.RoutingResult `json:"routes"`
 	SessionID string                `json:"session_id"`
+}
+
+type eventValidationError struct {
+	message string
+}
+
+func (e eventValidationError) Error() string {
+	return e.message
 }
 
 // EventDetailResponse represents the detailed event response.
@@ -222,8 +231,44 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		h.handleValidationError(w, messageEventDateRequired)
 		return
 	}
+
+	var createdEvent *models.Event
+	var savedRouteCount int
+	persist := func(ctx context.Context, result models.RoutingResult) error {
+		eventDate, err := time.Parse("2006-01-02", req.EventDate)
+		if err != nil {
+			log.Printf("[HTTP] POST /api/v1/events: invalid_date=%s err=%v", req.EventDate, err)
+			return eventValidationError{message: messageInvalidEventDateFormat}
+		}
+
+		snapshot, err := eventsnapshot.Build(result)
+		if err != nil {
+			log.Printf("[HTTP] POST /api/v1/events: invalid_routes err=%v", err)
+			message := err.Error()
+			if errors.Is(err, models.ErrInvalidRouteMode) {
+				message = messageInvalidRouteMode
+			}
+			return eventValidationError{message: message}
+		}
+
+		event := &models.Event{EventDate: eventDate, Notes: req.Notes, Mode: snapshot.Mode}
+		created, err := h.DB.Events().Create(ctx, event, snapshot.Routes, &snapshot.Summary)
+		if err != nil {
+			log.Printf("[ERROR] Failed to create event: date=%s routes=%d err=%v", req.EventDate, len(snapshot.Routes), err)
+			return err
+		}
+		createdEvent = created
+		savedRouteCount = len(snapshot.Routes)
+		return nil
+	}
+
 	if req.SessionID != "" {
-		routes, sessionErr := h.RouteSession.SaveSnapshot(req.SessionID)
+		sessionErr := h.RouteSession.Commit(r.Context(), req.SessionID, persist)
+		var validationErr eventValidationError
+		if errors.As(sessionErr, &validationErr) {
+			h.handleValidationError(w, validationErr.message)
+			return
+		}
 		if errors.Is(sessionErr, routesession.ErrNotFound) {
 			if req.Routes == nil && formRoutesJSON != "" {
 				routes, ok := h.parsePostedRoutesJSON(w, formRoutesJSON)
@@ -238,6 +283,15 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			log.Printf("[HTTP] POST /api/v1/events: session_not_found using posted routes fallback session_id=%s", req.SessionID)
+			if err := persist(r.Context(), *req.Routes); err != nil {
+				var fallbackValidationErr eventValidationError
+				if errors.As(err, &fallbackValidationErr) {
+					h.handleValidationError(w, fallbackValidationErr.message)
+				} else {
+					h.handleInternalError(w, err)
+				}
+				return
+			}
 		} else if errors.Is(sessionErr, routesession.ErrUnbalanced) {
 			log.Printf("[HTTP] POST /api/v1/events: blocked save for out-of-balance session_id=%s", req.SessionID)
 			h.handleValidationError(w, messageRoutesMustBeBalancedBeforeSaving)
@@ -245,47 +299,22 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		} else if sessionErr != nil {
 			h.handleInternalError(w, sessionErr)
 			return
-		} else {
-			req.Routes = &routes
 		}
 	} else if req.Routes == nil {
 		log.Printf("[HTTP] POST /api/v1/events: missing routes")
 		h.handleValidationError(w, messageRoutesRequired)
 		return
-	}
-
-	eventDate, err := time.Parse("2006-01-02", req.EventDate)
-	if err != nil {
-		log.Printf("[HTTP] POST /api/v1/events: invalid_date=%s err=%v", req.EventDate, err)
-		h.handleValidationError(w, messageInvalidEventDateFormat)
+	} else if err := persist(r.Context(), *req.Routes); err != nil {
+		var validationErr eventValidationError
+		if errors.As(err, &validationErr) {
+			h.handleValidationError(w, validationErr.message)
+		} else {
+			h.handleInternalError(w, err)
+		}
 		return
 	}
 
-	mode, routes, summary, err := buildEventSnapshots(req.Routes)
-	if err != nil {
-		log.Printf("[HTTP] POST /api/v1/events: invalid_routes err=%v", err)
-		h.handleValidationError(w, err.Error())
-		return
-	}
-
-	event := &models.Event{
-		EventDate: eventDate,
-		Notes:     req.Notes,
-		Mode:      mode,
-	}
-
-	event, err = h.DB.Events().Create(r.Context(), event, routes, summary)
-	if err != nil {
-		log.Printf("[ERROR] Failed to create event: date=%s routes=%d err=%v", req.EventDate, len(routes), err)
-		h.handleInternalError(w, err)
-		return
-	}
-
-	if req.SessionID != "" {
-		h.RouteSession.Delete(req.SessionID)
-	}
-
-	log.Printf("[HTTP] Created event: id=%d date=%s routes=%d", event.ID, event.EventDate.Format("2006-01-02"), len(routes))
+	log.Printf("[HTTP] Created event: id=%d date=%s routes=%d", createdEvent.ID, createdEvent.EventDate.Format("2006-01-02"), savedRouteCount)
 
 	if h.isHTMX(r) {
 		w.Header().Set(httpx.HeaderContentType, httpx.MediaTypeHTML)
@@ -294,7 +323,7 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeJSON(w, http.StatusCreated, event)
+	h.writeJSON(w, http.StatusCreated, createdEvent)
 }
 
 func (h *Handler) parsePostedRoutesJSON(w http.ResponseWriter, routesJSON string) (*models.RoutingResult, bool) {
@@ -397,103 +426,6 @@ func (h *Handler) buildEventListView(ctx context.Context, limit, offset int) (*E
 		NextOffset:     displayedCount,
 		PageSize:       defaultEventListPageSize,
 		UseMiles:       settings.UseMiles,
-	}, nil
-}
-
-func buildEventSnapshots(result *models.RoutingResult) (models.RouteMode, []models.EventRoute, *models.EventSummary, error) {
-	if result == nil {
-		return "", nil, nil, fmt.Errorf("routes are required")
-	}
-
-	mode, err := normalizeRouteMode(string(result.Mode))
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	routes := make([]models.EventRoute, 0, len(result.Routes))
-	totalParticipants := 0
-	totalDrivers := 0
-	totalDistance := 0.0
-	orgVehiclesUsed := 0
-
-	for _, route := range result.Routes {
-		if route.Driver == nil {
-			return "", nil, nil, fmt.Errorf("each route must include a driver")
-		}
-		if len(route.Stops) == 0 {
-			continue
-		}
-
-		routeMode := route.Mode
-		if routeMode == "" {
-			routeMode = mode
-		}
-		routeMode, err = normalizeRouteMode(string(routeMode))
-		if err != nil {
-			return "", nil, nil, err
-		}
-		if routeMode != mode {
-			return "", nil, nil, fmt.Errorf("all routes must use the same mode")
-		}
-
-		snapshot := models.EventRoute{
-			RouteOrder:                 len(routes),
-			DriverID:                   route.Driver.ID,
-			DriverName:                 route.Driver.Name,
-			DriverAddress:              route.Driver.Address,
-			EffectiveCapacity:          route.EffectiveCapacity,
-			OrgVehicleID:               route.OrgVehicleID,
-			OrgVehicleName:             route.OrgVehicleName,
-			TotalDropoffDistanceMeters: route.TotalDropoffDistanceMeters,
-			DistanceToDriverHomeMeters: route.DistanceToDriverHomeMeters,
-			TotalDistanceMeters:        route.TotalDistanceMeters,
-			BaselineDurationSecs:       route.BaselineDurationSecs,
-			RouteDurationSecs:          route.RouteDurationSecs,
-			DetourSecs:                 route.DetourSecs,
-			Mode:                       routeMode,
-			SnapshotVersion:            2,
-			MetricsComplete:            true,
-			Stops:                      make([]models.EventRouteStop, 0, len(route.Stops)),
-		}
-		if snapshot.EffectiveCapacity == 0 {
-			snapshot.EffectiveCapacity = route.Driver.VehicleCapacity
-		}
-
-		for stopIndex, stop := range route.Stops {
-			if stop.Participant == nil {
-				return "", nil, nil, fmt.Errorf("each route stop must include a participant")
-			}
-			snapshot.Stops = append(snapshot.Stops, models.EventRouteStop{
-				Order:                    stopIndex,
-				ParticipantID:            stop.Participant.ID,
-				ParticipantName:          stop.Participant.Name,
-				ParticipantAddress:       stop.Participant.Address,
-				DistanceFromPrevMeters:   stop.DistanceFromPrevMeters,
-				CumulativeDistanceMeters: stop.CumulativeDistanceMeters,
-				DurationFromPrevSecs:     stop.DurationFromPrevSecs,
-				CumulativeDurationSecs:   stop.CumulativeDurationSecs,
-			})
-			totalParticipants++
-		}
-
-		totalDrivers++
-		totalDistance += route.TotalDistanceMeters
-		if route.OrgVehicleID > 0 {
-			orgVehiclesUsed++
-		}
-		routes = append(routes, snapshot)
-	}
-
-	if len(routes) == 0 {
-		return "", nil, nil, fmt.Errorf("routes are required")
-	}
-
-	return mode, routes, &models.EventSummary{
-		TotalParticipants:   totalParticipants,
-		TotalDrivers:        totalDrivers,
-		TotalDistanceMeters: totalDistance,
-		OrgVehiclesUsed:     orgVehiclesUsed,
-		Mode:                mode,
 	}, nil
 }
 

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -57,10 +57,24 @@ type CreateEventRequest struct {
 
 type eventValidationError struct {
 	message string
+	cause   error
 }
 
 func (e eventValidationError) Error() string {
 	return e.message
+}
+
+func (e eventValidationError) Unwrap() error {
+	return e.cause
+}
+
+func (h *Handler) handleEventValidationError(w http.ResponseWriter, err error) bool {
+	var validationErr eventValidationError
+	if !errors.As(err, &validationErr) {
+		return false
+	}
+	h.handleValidationError(w, validationErr.message)
+	return true
 }
 
 // EventDetailResponse represents the detailed event response.
@@ -238,7 +252,7 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		eventDate, err := time.Parse("2006-01-02", req.EventDate)
 		if err != nil {
 			log.Printf("[HTTP] POST /api/v1/events: invalid_date=%s err=%v", req.EventDate, err)
-			return eventValidationError{message: messageInvalidEventDateFormat}
+			return eventValidationError{message: messageInvalidEventDateFormat, cause: err}
 		}
 
 		snapshot, err := eventsnapshot.Build(result)
@@ -248,7 +262,7 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 			if errors.Is(err, models.ErrInvalidRouteMode) {
 				message = messageInvalidRouteMode
 			}
-			return eventValidationError{message: message}
+			return eventValidationError{message: message, cause: err}
 		}
 
 		event := &models.Event{EventDate: eventDate, Notes: req.Notes, Mode: snapshot.Mode}
@@ -264,9 +278,7 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 
 	if req.SessionID != "" {
 		sessionErr := h.RouteSession.Commit(r.Context(), req.SessionID, persist)
-		var validationErr eventValidationError
-		if errors.As(sessionErr, &validationErr) {
-			h.handleValidationError(w, validationErr.message)
+		if h.handleEventValidationError(w, sessionErr) {
 			return
 		}
 		if errors.Is(sessionErr, routesession.ErrNotFound) {
@@ -284,10 +296,7 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 			}
 			log.Printf("[HTTP] POST /api/v1/events: session_not_found using posted routes fallback session_id=%s", req.SessionID)
 			if err := persist(r.Context(), *req.Routes); err != nil {
-				var fallbackValidationErr eventValidationError
-				if errors.As(err, &fallbackValidationErr) {
-					h.handleValidationError(w, fallbackValidationErr.message)
-				} else {
+				if !h.handleEventValidationError(w, err) {
 					h.handleInternalError(w, err)
 				}
 				return
@@ -305,10 +314,7 @@ func (h *Handler) HandleCreateEvent(w http.ResponseWriter, r *http.Request) {
 		h.handleValidationError(w, messageRoutesRequired)
 		return
 	} else if err := persist(r.Context(), *req.Routes); err != nil {
-		var validationErr eventValidationError
-		if errors.As(err, &validationErr) {
-			h.handleValidationError(w, validationErr.message)
-		} else {
+		if !h.handleEventValidationError(w, err) {
 			h.handleInternalError(w, err)
 		}
 		return

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"html/template"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"ride-home-router/internal/database"
 	"ride-home-router/internal/models"
 	"ride-home-router/internal/routesession"
 	"ride-home-router/internal/sqlite"
@@ -36,6 +38,24 @@ PAGE|{{.DisplayedCount}}/{{.Total}}{{range .Events}}<div class="event-item">{{.I
 {{if .UseLegacyAssignments}}Legacy Detail{{range .Assignments}}|{{.DriverName}}{{range .Stops}}|{{.ParticipantName}}|{{printf "%.0f" .DistanceFromPrevMeters}}{{end}}{{end}}{{else}}Native Detail{{range .Routes}}|{{.DriverName}}|Final Leg {{printf "%.0f" .DistanceToDriverHomeMeters}}|Detour {{printf "%.0f" .DetourSecs}}{{end}}{{end}}
 {{end}}
 `
+
+type failingEventRepository struct {
+	database.EventRepository
+	err error
+}
+
+func (r failingEventRepository) Create(context.Context, *models.Event, []models.EventRoute, *models.EventSummary) (*models.Event, error) {
+	return nil, r.err
+}
+
+type eventRepositoryDataStore struct {
+	database.DataStore
+	events database.EventRepository
+}
+
+func (s eventRepositoryDataStore) Events() database.EventRepository {
+	return s.events
+}
 
 func TestHandleCreateEvent_MissingRoutesReturnsBadRequest(t *testing.T) {
 	handler, _ := newTestEventHandler(t, false)
@@ -107,6 +127,71 @@ func TestHandleCreateEvent_SessionSaveWithoutRoutesJSON(t *testing.T) {
 	}
 }
 
+func TestHandleCreateEvent_PersistenceFailureRetainsSession(t *testing.T) {
+	handler, store := newTestEventHandler(t, false)
+	session := handler.RouteSession.Create(routesession.CreateInput{
+		Routes: []models.CalculatedRoute{{
+			Driver:            &models.Driver{ID: 1, Name: "Driver 1", VehicleCapacity: 2},
+			EffectiveCapacity: 2,
+			Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+			Mode:              models.RouteModeDropoff,
+		}},
+		Mode: models.RouteModeDropoff,
+	})
+	wantErr := errors.New("event persistence failed")
+	handler.DB = eventRepositoryDataStore{
+		DataStore: store,
+		events: failingEventRepository{
+			EventRepository: store.Events(),
+			err:             wantErr,
+		},
+	}
+
+	form := "event_date=2026-03-14&session_id=" + session.ID
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	if _, ok := handler.RouteSession.Snapshot(session.ID); !ok {
+		t.Fatal("session was removed after event persistence failed")
+	}
+}
+
+func TestHandleCreateEvent_AllEmptyRoutesReturnsLowercaseMessage(t *testing.T) {
+	handler, _ := newTestEventHandler(t, false)
+	session := handler.RouteSession.Create(routesession.CreateInput{
+		Routes: []models.CalculatedRoute{{
+			Driver:            &models.Driver{ID: 1, Name: "Driver 1", VehicleCapacity: 2},
+			EffectiveCapacity: 2,
+			Mode:              models.RouteModeDropoff,
+		}},
+		Mode: models.RouteModeDropoff,
+	})
+
+	form := "event_date=2026-03-14&session_id=" + session.ID
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	var response ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error.Message != "routes are required" {
+		t.Fatalf("message = %q, want %q", response.Error.Message, "routes are required")
+	}
+}
+
 func TestHandleCreateEvent_ExpiredSessionReturnsNotFound(t *testing.T) {
 	handler, _ := newTestEventHandler(t, false)
 
@@ -171,6 +256,38 @@ func TestHandleCreateEvent_ExpiredSessionFallsBackToPostedRoutesJSON(t *testing.
 	}
 	if routes[0].DriverName != "Fallback Driver" {
 		t.Fatalf("saved driver = %q, want fallback posted route driver", routes[0].DriverName)
+	}
+}
+
+func TestHandleCreateEvent_InvalidFallbackModeReturnsFriendlyMessage(t *testing.T) {
+	handler, _ := newTestEventHandler(t, false)
+	routingPayload := models.RoutingResult{
+		Mode: models.RouteMode("invalid"),
+		Routes: []models.CalculatedRoute{{
+			Driver: &models.Driver{ID: 7, Name: "Fallback Driver", VehicleCapacity: 2},
+			Stops:  []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+		}},
+	}
+	payloadBytes, err := json.Marshal(routingPayload)
+	if err != nil {
+		t.Fatalf("marshal routing payload: %v", err)
+	}
+	form := "event_date=2026-03-14&session_id=expired-session-id&routes_json=" + url.QueryEscape(string(payloadBytes))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.HandleCreateEvent(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	var response ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Error.Message != messageInvalidRouteMode {
+		t.Fatalf("message = %q, want %q", response.Error.Message, messageInvalidRouteMode)
 	}
 }
 
@@ -602,52 +719,6 @@ func TestHandleDeleteEvent_HTMXRerendersEventList(t *testing.T) {
 	}
 	if !strings.Contains(body, "keep me") {
 		t.Fatalf("expected remaining event to be rendered, got %q", body)
-	}
-}
-
-func TestBuildEventSnapshots_RejectsMixedRouteModes(t *testing.T) {
-	result := &models.RoutingResult{
-		Mode: models.RouteModeDropoff,
-		Routes: []models.CalculatedRoute{
-			{
-				Driver: &models.Driver{ID: 1, Name: "Driver One", VehicleCapacity: 4},
-				Mode:   models.RouteModeDropoff,
-				Stops: []models.RouteStop{
-					{Participant: &models.Participant{ID: 1, Name: "Passenger One"}},
-				},
-			},
-			{
-				Driver: &models.Driver{ID: 2, Name: "Driver Two", VehicleCapacity: 4},
-				Mode:   models.RouteModePickup,
-				Stops: []models.RouteStop{
-					{Participant: &models.Participant{ID: 2, Name: "Passenger Two"}},
-				},
-			},
-		},
-	}
-
-	_, _, _, err := buildEventSnapshots(result)
-	if err == nil || err.Error() != "all routes must use the same mode" {
-		t.Fatalf("expected mixed-mode validation error, got %v", err)
-	}
-}
-
-func TestBuildEventSnapshots_RejectsInvalidMode(t *testing.T) {
-	result := &models.RoutingResult{
-		Mode: "sideways",
-		Routes: []models.CalculatedRoute{
-			{
-				Driver: &models.Driver{ID: 1, Name: "Driver One", VehicleCapacity: 4},
-				Stops: []models.RouteStop{
-					{Participant: &models.Participant{ID: 1, Name: "Passenger One"}},
-				},
-			},
-		},
-	}
-
-	_, _, _, err := buildEventSnapshots(result)
-	if err == nil || err.Error() != messageInvalidRouteMode {
-		t.Fatalf("expected invalid mode error %q, got %v", messageInvalidRouteMode, err)
 	}
 }
 

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -20,6 +20,7 @@ import (
 	"ride-home-router/web"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -51,6 +52,19 @@ func (r failingEventRepository) Create(context.Context, *models.Event, []models.
 type eventRepositoryDataStore struct {
 	database.DataStore
 	events database.EventRepository
+}
+
+type blockingEventRepository struct {
+	database.EventRepository
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingEventRepository) Create(ctx context.Context, event *models.Event, routes []models.EventRoute, summary *models.EventSummary) (*models.Event, error) {
+	r.once.Do(func() { close(r.started) })
+	<-r.release
+	return r.EventRepository.Create(ctx, event, routes, summary)
 }
 
 func (s eventRepositoryDataStore) Events() database.EventRepository {
@@ -127,6 +141,59 @@ func TestHandleCreateEvent_SessionSaveWithoutRoutesJSON(t *testing.T) {
 	}
 	if _, ok := handler.RouteSession.Snapshot(session.ID); ok {
 		t.Fatal("session remains available after successful event persistence")
+	}
+}
+
+func TestHandleCreateEvent_ConcurrentRetryWithFallbackDoesNotCreateDuplicate(t *testing.T) {
+	handler, store := newTestEventHandler(t, false)
+	result := models.RoutingResult{
+		Mode: models.RouteModeDropoff,
+		Routes: []models.CalculatedRoute{{
+			Driver:            &models.Driver{ID: 1, Name: "Driver 1", VehicleCapacity: 2},
+			EffectiveCapacity: 2,
+			Stops:             []models.RouteStop{{Participant: &models.Participant{ID: 10, Name: "Alice"}}},
+			Mode:              models.RouteModeDropoff,
+		}},
+	}
+	session := handler.RouteSession.Create(routesession.CreateInput{Routes: result.Routes, Mode: result.Mode})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	blockingRepo := &blockingEventRepository{EventRepository: store.Events(), started: started, release: release}
+	handler.DB = eventRepositoryDataStore{DataStore: store, events: blockingRepo}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal routing payload: %v", err)
+	}
+	form := "event_date=2026-03-14&session_id=" + session.ID + "&routes_json=" + url.QueryEscape(string(payload))
+
+	save := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/events", strings.NewReader(form))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+		handler.HandleCreateEvent(rr, req)
+		return rr
+	}
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { firstDone <- save() }()
+	<-started
+	secondDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { secondDone <- save() }()
+	close(release)
+
+	first := <-firstDone
+	second := <-secondDone
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d, want 201; body=%s", first.Code, first.Body.String())
+	}
+	if second.Code != http.StatusNotFound {
+		t.Fatalf("retry status = %d, want 404; body=%s", second.Code, second.Body.String())
+	}
+	events, _, err := store.Events().List(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("saved events = %d, want 1", len(events))
 	}
 }
 

--- a/internal/handlers/events_test.go
+++ b/internal/handlers/events_test.go
@@ -125,6 +125,9 @@ func TestHandleCreateEvent_SessionSaveWithoutRoutesJSON(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 saved event, got %d", len(events))
 	}
+	if _, ok := handler.RouteSession.Snapshot(session.ID); ok {
+		t.Fatal("session remains available after successful event persistence")
+	}
 }
 
 func TestHandleCreateEvent_PersistenceFailureRetainsSession(t *testing.T) {

--- a/internal/handlers/route_edit.go
+++ b/internal/handlers/route_edit.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log"
 	"net/http"
-	"ride-home-router/internal/models"
 	"ride-home-router/internal/routesession"
 )
 
@@ -18,17 +17,12 @@ type participantMove struct {
 	InsertAtPosition int   `json:"insert_at_position"`
 }
 
-func buildRoutingPayload(routes []models.CalculatedRoute, summary models.RoutingSummary, mode models.RouteMode) models.RoutingResult {
-	return models.RoutingResult{Routes: routes, Summary: summary, Mode: mode}
-}
-
 func buildRouteResultsView(snapshot routesession.Snapshot) RouteResultsView {
 	return RouteResultsView{
 		Routes: snapshot.Routes, OverCapacity: snapshot.OverCapacity, IsOutOfBalance: snapshot.IsOutOfBalance,
 		Summary: snapshot.Summary, UseMiles: snapshot.UseMiles, ActivityLocation: snapshot.ActivityLocation,
 		RouteTime: snapshot.RouteTime, SessionID: snapshot.ID, IsEditing: snapshot.IsEditing,
 		UnusedDrivers: snapshot.UnusedDrivers, Mode: string(snapshot.Mode),
-		RoutingPayload: buildRoutingPayload(snapshot.Routes, snapshot.Summary, snapshot.Mode),
 	}
 }
 

--- a/internal/handlers/route_edit_test.go
+++ b/internal/handlers/route_edit_test.go
@@ -130,6 +130,12 @@ func TestHandleGetRouteSessionReturnsHTMXFragment(t *testing.T) {
 	if w.Code != http.StatusOK || !bytes.Contains(w.Body.Bytes(), []byte(`data-session-id="`+created.ID+`"`)) {
 		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
 	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`name="session_id" value="`+created.ID+`"`)) {
+		t.Fatalf("body does not contain the session save field: %q", w.Body.String())
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte(`name="routes_json"`)) {
+		t.Fatalf("body contains unreachable routes_json fallback field: %q", w.Body.String())
+	}
 }
 
 func TestHandleMoveParticipantPreservesBatchRequestValidation(t *testing.T) {

--- a/internal/handlers/view_models.go
+++ b/internal/handlers/view_models.go
@@ -163,7 +163,6 @@ type RouteResultsView struct {
 	IsEditing        bool
 	UnusedDrivers    []models.Driver
 	Mode             string
-	RoutingPayload   models.RoutingResult
 }
 
 type RoutingErrorDetails struct {

--- a/internal/routesession/store.go
+++ b/internal/routesession/store.go
@@ -258,9 +258,14 @@ func (s *Store) Commit(ctx context.Context, id string, persist func(context.Cont
 	if err != nil {
 		return err
 	}
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			state.mu.Unlock()
+		}
+	}()
 	_, unbalanced := capacityState(state.currentRoutes)
 	if unbalanced {
-		state.mu.Unlock()
 		return ErrUnbalanced
 	}
 	payload := models.RoutingResult{
@@ -269,11 +274,11 @@ func (s *Store) Commit(ctx context.Context, id string, persist func(context.Cont
 		Mode:    state.mode,
 	}
 	if err := persist(ctx, payload); err != nil {
-		state.mu.Unlock()
 		return err
 	}
 	state.deleted = true
 	state.mu.Unlock()
+	unlocked = true
 	s.remove(id, state)
 	log.Printf("[SESSION] Deleted route session: id=%s", id)
 	return nil

--- a/internal/routesession/store.go
+++ b/internal/routesession/store.go
@@ -249,17 +249,34 @@ func (s *Store) AddDriver(ctx context.Context, id string, driverID int64) (Snaps
 	return snapshotOf(state), nil
 }
 
-func (s *Store) SaveSnapshot(id string) (models.RoutingResult, error) {
+// Commit persists a balanced session and removes it after persistence succeeds.
+// The persist callback receives the persistence context and runs while the target
+// session is locked. It must not call any Store method. Calls waiting on the same
+// session cannot be canceled.
+func (s *Store) Commit(ctx context.Context, id string, persist func(context.Context, models.RoutingResult) error) error {
 	state, err := s.lockSession(id)
 	if err != nil {
-		return models.RoutingResult{}, err
+		return err
 	}
-	defer state.mu.Unlock()
 	_, unbalanced := capacityState(state.currentRoutes)
 	if unbalanced {
-		return models.RoutingResult{}, ErrUnbalanced
+		state.mu.Unlock()
+		return ErrUnbalanced
 	}
-	return models.RoutingResult{Routes: copyRoutes(state.currentRoutes), Summary: calculateSummary(state.currentRoutes), Mode: state.mode}, nil
+	payload := models.RoutingResult{
+		Routes:  copyRoutes(state.currentRoutes),
+		Summary: calculateSummary(state.currentRoutes),
+		Mode:    state.mode,
+	}
+	if err := persist(ctx, payload); err != nil {
+		state.mu.Unlock()
+		return err
+	}
+	state.deleted = true
+	state.mu.Unlock()
+	s.remove(id, state)
+	log.Printf("[SESSION] Deleted route session: id=%s", id)
+	return nil
 }
 
 func (s *Store) Delete(id string) {

--- a/internal/routesession/store.go
+++ b/internal/routesession/store.go
@@ -20,6 +20,7 @@ const (
 
 var (
 	ErrNotFound               = errors.New("route session not found")
+	ErrAlreadyCommitted       = errors.New("route session already committed")
 	ErrInvalidRouteIndex      = errors.New("invalid route index")
 	ErrParticipantNotFound    = errors.New("participant not found")
 	ErrParticipantNotInSource = errors.New("participant not found in source route")
@@ -84,6 +85,7 @@ type session struct {
 type Store struct {
 	distanceCalc    distance.DistanceCalculator
 	sessions        map[string]*session
+	committed       map[string]time.Time
 	mu              sync.Mutex
 	ttl             time.Duration
 	cleanupInterval time.Duration
@@ -99,7 +101,7 @@ func NewStore(distanceCalc distance.DistanceCalculator) *Store {
 
 func newStore(distanceCalc distance.DistanceCalculator, ttl, cleanupInterval time.Duration, now func() time.Time) *Store {
 	store := &Store{
-		distanceCalc: distanceCalc, sessions: make(map[string]*session), ttl: ttl,
+		distanceCalc: distanceCalc, sessions: make(map[string]*session), committed: make(map[string]time.Time), ttl: ttl,
 		cleanupInterval: cleanupInterval, now: now,
 		stopCleanup: make(chan struct{}), cleanupDone: make(chan struct{}),
 	}
@@ -256,11 +258,15 @@ func (s *Store) AddDriver(ctx context.Context, id string, driverID int64) (Snaps
 func (s *Store) Commit(ctx context.Context, id string, persist func(context.Context, models.RoutingResult) error) error {
 	state, err := s.lockSession(id)
 	if err != nil {
+		if errors.Is(err, ErrNotFound) && s.wasCommitted(id) {
+			return ErrAlreadyCommitted
+		}
 		return err
 	}
 	unlocked := false
 	defer func() {
 		if !unlocked {
+			state.lastAccessedAt = s.now()
 			state.mu.Unlock()
 		}
 	}()
@@ -277,9 +283,14 @@ func (s *Store) Commit(ctx context.Context, id string, persist func(context.Cont
 		return err
 	}
 	state.deleted = true
+	s.mu.Lock()
+	s.committed[id] = s.now()
+	if s.sessions[id] == state {
+		delete(s.sessions, id)
+	}
+	s.mu.Unlock()
 	state.mu.Unlock()
 	unlocked = true
-	s.remove(id, state)
 	log.Printf("[SESSION] Deleted route session: id=%s", id)
 	return nil
 }
@@ -330,6 +341,17 @@ func (s *Store) remove(id string, state *session) {
 	s.mu.Unlock()
 }
 
+func (s *Store) wasCommitted(id string) bool {
+	s.mu.Lock()
+	committedAt, ok := s.committed[id]
+	if ok && s.now().Sub(committedAt) > s.ttl {
+		delete(s.committed, id)
+		ok = false
+	}
+	s.mu.Unlock()
+	return ok
+}
+
 func (s *Store) cleanupLoop() {
 	defer close(s.cleanupDone)
 	ticker := time.NewTicker(s.cleanupInterval)
@@ -353,6 +375,11 @@ func (s *Store) deleteExpired(now time.Time) {
 	states := make([]candidate, 0, len(s.sessions))
 	for id, state := range s.sessions {
 		states = append(states, candidate{id: id, state: state})
+	}
+	for id, committedAt := range s.committed {
+		if now.Sub(committedAt) > s.ttl {
+			delete(s.committed, id)
+		}
 	}
 	s.mu.Unlock()
 	for _, candidate := range states {

--- a/internal/routesession/store_internal_test.go
+++ b/internal/routesession/store_internal_test.go
@@ -1,6 +1,9 @@
 package routesession
 
 import (
+	"context"
+	"errors"
+	"ride-home-router/internal/models"
 	"testing"
 	"time"
 )
@@ -50,5 +53,44 @@ func TestDeleteExpiredSkipsBusySession(t *testing.T) {
 	}
 	if _, ok := store.Snapshot(other.ID); !ok {
 		t.Fatal("cleanup of a busy session blocked or removed an unrelated session")
+	}
+}
+
+func TestFailedCommitRefreshesSessionTTL(t *testing.T) {
+	now := time.Unix(100, 0)
+	store := newStore(nil, time.Minute, time.Hour, func() time.Time { return now })
+	t.Cleanup(store.Close)
+	created := store.Create(CreateInput{})
+	wantErr := errors.New("persistence failed")
+
+	err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error {
+		now = now.Add(2 * time.Minute)
+		return wantErr
+	})
+	if err != wantErr {
+		t.Fatalf("Commit error = %v, want callback error", err)
+	}
+	if _, ok := store.Snapshot(created.ID); !ok {
+		t.Fatal("session expired immediately after failed persistence")
+	}
+}
+
+func TestCommittedMarkerExpiresWithSessionTTL(t *testing.T) {
+	now := time.Unix(100, 0)
+	store := newStore(nil, time.Minute, time.Hour, func() time.Time { return now })
+	t.Cleanup(store.Close)
+	created := store.Create(CreateInput{})
+
+	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error { return nil }); err != nil {
+		t.Fatalf("Commit error = %v", err)
+	}
+	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error { return nil }); !errors.Is(err, ErrAlreadyCommitted) {
+		t.Fatalf("second Commit error = %v, want ErrAlreadyCommitted", err)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	store.deleteExpired(now)
+	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error { return nil }); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Commit after marker expiry error = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/routesession/store_test.go
+++ b/internal/routesession/store_test.go
@@ -388,7 +388,7 @@ func TestCommitFailureReturnsCallbackErrorAndRetainsIndependentSession(t *testin
 		return wantErr
 	})
 
-	if !errors.Is(err, wantErr) {
+	if err != wantErr {
 		t.Fatalf("Commit error = %v, want callback error", err)
 	}
 	got, ok := store.Snapshot(created.ID)
@@ -417,8 +417,8 @@ func TestCommitSuccessDeletesSessionExactlyOnce(t *testing.T) {
 	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error {
 		t.Fatal("second Commit invoked persistence")
 		return nil
-	}); !errors.Is(err, routesession.ErrNotFound) {
-		t.Fatalf("second Commit error = %v, want ErrNotFound", err)
+	}); !errors.Is(err, routesession.ErrAlreadyCommitted) {
+		t.Fatalf("second Commit error = %v, want ErrAlreadyCommitted", err)
 	}
 }
 

--- a/internal/routesession/store_test.go
+++ b/internal/routesession/store_test.go
@@ -544,6 +544,36 @@ func TestCommitDoesNotBlockOtherSessions(t *testing.T) {
 	}
 }
 
+func TestCommitUnlocksSessionWhenPersistencePanics(t *testing.T) {
+	store := routesession.NewStore(calculator{})
+	t.Cleanup(store.Close)
+	created := store.Create(testInput())
+	panicDone := make(chan any, 1)
+	go func() {
+		defer func() { panicDone <- recover() }()
+		_ = store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error {
+			panic("persistence panic")
+		})
+	}()
+	if recovered := <-panicDone; recovered != "persistence panic" {
+		t.Fatalf("recovered panic = %v, want persistence panic", recovered)
+	}
+
+	snapshotDone := make(chan bool, 1)
+	go func() {
+		_, ok := store.Snapshot(created.ID)
+		snapshotDone <- ok
+	}()
+	select {
+	case ok := <-snapshotDone:
+		if !ok {
+			t.Fatal("session disappeared after persistence panic")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session remained locked after persistence panic")
+	}
+}
+
 func TestStoreSupportsConcurrentSnapshotsAndResets(t *testing.T) {
 	store := routesession.NewStore(calculator{})
 	t.Cleanup(store.Close)

--- a/internal/routesession/store_test.go
+++ b/internal/routesession/store_test.go
@@ -355,26 +355,192 @@ func TestSwapResetAndAddDriverOperateThroughSnapshots(t *testing.T) {
 	}
 }
 
-func TestSaveSnapshotRejectsUnbalancedAndReturnsIndependentPayload(t *testing.T) {
+func TestCommitRejectsUnbalancedWithoutPersistence(t *testing.T) {
 	store := routesession.NewStore(calculator{})
 	t.Cleanup(store.Close)
 	routes := testRoutes()
 	routes[0].EffectiveCapacity = 0
 	routes[0].Driver.VehicleCapacity = 0
 	created := store.Create(routesession.CreateInput{Routes: routes, ActivityLocation: &models.ActivityLocation{}, RouteTime: "18:30", Mode: models.RouteModeDropoff})
-	if _, err := store.SaveSnapshot(created.ID); !errors.Is(err, routesession.ErrUnbalanced) {
-		t.Fatalf("SaveSnapshot error = %v, want ErrUnbalanced", err)
+	called := false
+
+	err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error {
+		called = true
+		return nil
+	})
+
+	if !errors.Is(err, routesession.ErrUnbalanced) {
+		t.Fatalf("Commit error = %v, want ErrUnbalanced", err)
+	}
+	if called {
+		t.Fatal("Commit invoked persistence for an unbalanced session")
+	}
+}
+
+func TestCommitFailureReturnsCallbackErrorAndRetainsIndependentSession(t *testing.T) {
+	store := routesession.NewStore(calculator{})
+	t.Cleanup(store.Close)
+	created := store.Create(testInput())
+	wantErr := errors.New("persistence failed")
+
+	err := store.Commit(context.Background(), created.ID, func(_ context.Context, payload models.RoutingResult) error {
+		payload.Routes[0].Driver.ID = 999
+		return wantErr
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Commit error = %v, want callback error", err)
+	}
+	got, ok := store.Snapshot(created.ID)
+	if !ok {
+		t.Fatal("session was removed after persistence failed")
+	}
+	if got.Routes[0].Driver.ID != 1 {
+		t.Fatalf("session driver ID = %d, want independent value 1", got.Routes[0].Driver.ID)
+	}
+	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error { return nil }); err != nil {
+		t.Fatalf("retry Commit error = %v", err)
+	}
+}
+
+func TestCommitSuccessDeletesSessionExactlyOnce(t *testing.T) {
+	store := routesession.NewStore(calculator{})
+	t.Cleanup(store.Close)
+	created := store.Create(testInput())
+
+	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error { return nil }); err != nil {
+		t.Fatalf("Commit error = %v", err)
+	}
+	if _, ok := store.Snapshot(created.ID); ok {
+		t.Fatal("session remains available after successful Commit")
+	}
+	if err := store.Commit(context.Background(), created.ID, func(context.Context, models.RoutingResult) error {
+		t.Fatal("second Commit invoked persistence")
+		return nil
+	}); !errors.Is(err, routesession.ErrNotFound) {
+		t.Fatalf("second Commit error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCommitWaitsForInFlightEditAndPersistsItsResult(t *testing.T) {
+	calc := newBlockingCalculator()
+	defer calc.unblock()
+	store := routesession.NewStore(calc)
+	t.Cleanup(store.Close)
+	created := store.Create(testInput())
+
+	editDone := make(chan error, 1)
+	go func() {
+		_, err := store.ApplyMoves(context.Background(), created.ID, []routesession.Move{{
+			ParticipantID: 10, ToRouteIndex: 1, InsertAtPosition: -1,
+		}}, routesession.ApplyMovesOptions{})
+		editDone <- err
+	}()
+	<-calc.started
+
+	commitDone := make(chan error, 1)
+	var persisted models.RoutingResult
+	go func() {
+		commitDone <- store.Commit(context.Background(), created.ID, func(_ context.Context, payload models.RoutingResult) error {
+			persisted = payload
+			return nil
+		})
+	}()
+	select {
+	case err := <-commitDone:
+		t.Fatalf("Commit returned before the in-flight edit: %v", err)
+	case <-time.After(50 * time.Millisecond):
 	}
 
-	balanced := store.Create(testInput())
-	payload, err := store.SaveSnapshot(balanced.ID)
-	if err != nil {
-		t.Fatalf("SaveSnapshot: %v", err)
+	calc.unblock()
+	if err := <-editDone; err != nil {
+		t.Fatalf("ApplyMoves error = %v", err)
 	}
-	payload.Routes[0].Driver.ID = 999
-	got, _ := store.Snapshot(balanced.ID)
-	if got.Routes[0].Driver.ID != 1 {
-		t.Fatal("saved payload aliases stored routes")
+	if err := <-commitDone; err != nil {
+		t.Fatalf("Commit error = %v", err)
+	}
+	if len(persisted.Routes[0].Stops) != 0 || len(persisted.Routes[1].Stops) != 1 {
+		t.Fatalf("persisted routes did not include completed edit: %#v", persisted.Routes)
+	}
+}
+
+func TestCommitRejectsEditThatArrivesDuringPersistence(t *testing.T) {
+	store := routesession.NewStore(calculator{})
+	t.Cleanup(store.Close)
+	created := store.Create(testInput())
+	persistStarted := make(chan struct{})
+	releasePersist := make(chan struct{})
+	commitDone := make(chan error, 1)
+	var persisted models.RoutingResult
+	go func() {
+		commitDone <- store.Commit(context.Background(), created.ID, func(_ context.Context, payload models.RoutingResult) error {
+			persisted = payload
+			close(persistStarted)
+			<-releasePersist
+			return nil
+		})
+	}()
+	<-persistStarted
+
+	editDone := make(chan error, 1)
+	go func() {
+		_, err := store.ApplyMoves(context.Background(), created.ID, []routesession.Move{{
+			ParticipantID: 10, ToRouteIndex: 1, InsertAtPosition: -1,
+		}}, routesession.ApplyMovesOptions{})
+		editDone <- err
+	}()
+	select {
+	case err := <-editDone:
+		t.Fatalf("ApplyMoves returned during persistence: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releasePersist)
+	if err := <-commitDone; err != nil {
+		t.Fatalf("Commit error = %v", err)
+	}
+	if err := <-editDone; !errors.Is(err, routesession.ErrNotFound) {
+		t.Fatalf("ApplyMoves error = %v, want ErrNotFound", err)
+	}
+	if len(persisted.Routes[0].Stops) != 1 || len(persisted.Routes[1].Stops) != 0 {
+		t.Fatalf("persisted payload includes blocked edit: %#v", persisted.Routes)
+	}
+}
+
+func TestCommitDoesNotBlockOtherSessions(t *testing.T) {
+	store := routesession.NewStore(calculator{})
+	t.Cleanup(store.Close)
+	committing := store.Create(testInput())
+	other := store.Create(testInput())
+	persistStarted := make(chan struct{})
+	releasePersist := make(chan struct{})
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- store.Commit(context.Background(), committing.ID, func(context.Context, models.RoutingResult) error {
+			close(persistStarted)
+			<-releasePersist
+			return nil
+		})
+	}()
+	<-persistStarted
+
+	otherDone := make(chan bool, 1)
+	go func() {
+		_, ok := store.Snapshot(other.ID)
+		otherDone <- ok
+	}()
+	select {
+	case ok := <-otherDone:
+		if !ok {
+			t.Fatal("other session disappeared during Commit")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Commit blocked access to another session")
+	}
+
+	close(releasePersist)
+	if err := <-commitDone; err != nil {
+		t.Fatalf("Commit error = %v", err)
 	}
 }
 

--- a/internal/templateutil/helpers.go
+++ b/internal/templateutil/helpers.go
@@ -27,13 +27,6 @@ func FuncMap() template.FuncMap {
 		"currentDate": func() string {
 			return time.Now().Format("2006-01-02")
 		},
-		"toJSON": func(v any) string {
-			b, err := json.Marshal(v)
-			if err != nil {
-				return "{}"
-			}
-			return string(b)
-		},
 		"toJSONRaw": func(v any) template.JS {
 			b, err := json.Marshal(v)
 			if err != nil {

--- a/web/templates/partials/route_results.html
+++ b/web/templates/partials/route_results.html
@@ -256,9 +256,6 @@
               hx-target="#save-result"
               hx-indicator="#save-loading">
             <input type="hidden" name="session_id" value="{{.SessionID}}">
-            {{if not .SessionID}}
-            <input type="hidden" name="routes_json" value="{{toJSON .RoutingPayload}}">
-            {{end}}
 
             <div class="form-group">
                 <label class="form-label">Event Date</label>


### PR DESCRIPTION
### Problem

Saving an editable route session crossed three separate seams in the event handler: copy the session, validate and convert live routes into historical snapshots, persist the Event, then delete the session. An edit could land after the copy and be silently discarded, while concurrent saves could persist duplicate Events. Snapshot-domain validation also lived in the HTTP package, and the route-results view carried an unreachable client payload fallback.

### Changes

- Added `internal/eventsnapshot.Build` to validate and convert live routing results into complete versioned Event snapshots.
- Replaced `routesession.Store.SaveSnapshot` with `Commit`, which serializes persistence against edits for the target session and removes it only after successful persistence.
- Rewired Event creation through the commit callback while preserving form, JSON, HTMX, status, message, fallback, and persistence behavior.
- Removed the unreachable rendered `routes_json` payload and its unused view-model/helper seam.
- Added module and handler coverage for snapshot invariants, save failure/retry behavior, duplicate commits, both edit/save race directions, cross-session independence, exact validation messages, and rendered form state.

### Decisions

- Kept route calculation and the existing `routesession` package intact; a broad Route Plan facade would only forward already-deep interfaces.
- Kept database ownership in the handler. `Commit` receives a callback and context, so `routesession` gains the atomicity guarantee without importing persistence packages.
- Preserved the posted-routes fallback contract for expired sessions and JSON callers, even though the normal browser no longer renders that payload.
- Kept Event history reads, legacy snapshot handling, session-expiry recovery UX, route-calculation summary divergence, and CORS/CSRF hardening out of scope.

### Testing

- `gofmt -l .`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run` with the repository's v2.12.2 linter under Go 1.26.6
- `node --test web/static/js/*.test.js`

<details>
<summary>Agent Context</summary>

The original architecture candidate proposed one Route Plan lifecycle abstraction spanning calculation, editing, and saving. Repository inspection showed that recent changes had already made `routeCalculation` and `routesession.Store` cohesive deep modules. The remaining justified seams were narrower:

1. `buildEventSnapshots` contained roughly 100 lines of validation and live-to-history conversion inside `handlers/events.go`.
2. `SaveSnapshot -> EventRepository.Create -> Delete` released the session lock before persistence. An edit could be acknowledged during that window and then discarded, and two save requests could both create Events.

The new `eventsnapshot.Build` seam owns only one-way conversion from `models.RoutingResult` to immutable `models.EventRoute` and `models.EventSummary` values. It preserves existing validation order and exact sentinel text, including:

- top-level mode validation before route validation;
- driver validation before skipping an empty route;
- route-mode validation before participant validation;
- no mode validation for skipped empty routes;
- dense saved route ordering;
- version 2 and complete-metrics flags;
- effective-capacity fallback to driver capacity;
- the existing non-deduplicated organization-vehicle summary count.

`routesession.Store.Commit` holds only the target session mutex through the persistence callback. A completed edit before Commit is included. An edit arriving during Commit waits, then receives `ErrNotFound` after a successful save rather than reporting success for discarded work. Other sessions remain independent. Callback errors are returned unchanged and retain the session for retry. The callback receives the request context but must not call Store methods while the target session lock is held; same-session lock acquisition is not context-cancellable.

The Event handler checks callback validation errors before store sentinels, preserves lazy parsing of the expired-session fallback, and still ignores forged or malformed client route payloads when a valid server session exists. The only intentional logging difference is removal of the old fallback-path log claiming that a nonexistent expired session was deleted.

The ambient Go 1.27 toolchain cannot currently load packages through golangci-lint 2.12.2. Lint was therefore run with the installed Go 1.26.6 toolchain and writable task-local caches; it completed with zero issues. All normal tests and race tests passed under the ambient toolchain.

</details>
